### PR TITLE
feat: higress gateway support hostnetwork

### DIFF
--- a/helm/higress/templates/deployment.yaml
+++ b/helm/higress/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       securityContext:
       {{- if .Values.gateway.securityContext }}
         {{- toYaml .Values.gateway.securityContext | nindent 8 }}
-      {{- else if (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
+      {{- else if and (not .Values.gateway.hostNetwork) (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
         # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
         sysctls:
         - name: net.ipv4.ip_unprivileged_port_start
@@ -64,7 +64,7 @@ spec:
           securityContext:
           {{- if .Values.gateway.containerSecurityContext }}
             {{- toYaml .Values.gateway.containerSecurityContext | nindent 12 }}
-          {{- else if (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
+          {{- else if and (not .Values.gateway.hostNetwork) (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
             # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
             capabilities:
               drop:
@@ -181,6 +181,10 @@ spec:
             mountPath: /etc/istio/pod
           - name: proxy-socket
             mountPath: /etc/istio/proxy
+      {{- if .Values.gateway.hostNetwork }}
+      hostNetwork: {{ .Values.gateway.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       {{- with .Values.gateway.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -235,4 +239,3 @@ spec:
               containerName: higress-gateway
               divisor: 1m
               resource: limits.cpu
-        

--- a/helm/higress/values.yaml
+++ b/helm/higress/values.yaml
@@ -39,6 +39,8 @@ gateway:
   # Currently, two options are supported: "third-party-jwt" and "first-party-jwt".
   jwtPolicy: "third-party-jwt"
 
+  hostNetwork: false
+
   # Labels to apply to all resources
   labels: {}
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

`Higress Gateway` support hostNetwork.

Tested:
1. kind 1.25 (Linux Kernel 5.x)
2. kubeadm 1.23 (Linux Kernel 3.10)
3. kubeadm 1.20 (Linux Kernel 3.10)

`net.ipv4.ip_unprivileged_port_start` some cases start at 1024，`gateway` need bind port 80.

#### Bakgroud
Setting `hostNetwork` only, will cause
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/31346321/205501170-06197b90-3442-42d8-98ed-0327e77e7050.png">

#### Solution
1. securityContext: When use hostNetwork, remove sysctl configuration or setting provide by user.
2. containerSecurityContext: 
    a. In Linux Kernel 5.x, NonRoot or Root all operating normally.
    b. In Linux Kernel 3.10, can only be run with Root.
3. `dnsPolicy` setting ClusterFirstWithHostNet, because of gateway start need coredns resolve.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #39 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
```console
helm upgrade --install higress . -n higress-system --set gateway.hostNetwork=true <--set global.kind=true>
```

### Ⅴ. Special notes for reviews
A problem found in the test #97 
