### PR TITLE
UT: Increase unit test coverage of pkg/bootstrap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace github.com/docker/docker => github.com/moby/moby v17.12.0-ce-rc1.0.20200
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 
 require (
+	github.com/agiledragon/gomonkey/v2 v2.2.0
 	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5
 	github.com/dubbogo/gost v1.13.1
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
+github.com/agiledragon/gomonkey/v2 v2.2.0 h1:QJWqpdEhGV/JJy70sZ/LDnhbSlMrqHAWHcNOjz1kyuI=
+github.com/agiledragon/gomonkey/v2 v2.2.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/ahmetb/gen-crd-api-reference-docs v0.3.0/go.mod h1:TdjdkYhlOifCQWPs1UdTma97kQQMozf5h26hTuG70u8=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/pkg/bootstrap/server.go
+++ b/pkg/bootstrap/server.go
@@ -223,7 +223,9 @@ func (s *Server) initConfigController() error {
 
 	// Defer starting the controller until after the service is created.
 	s.server.RunComponent(func(stop <-chan struct{}) error {
-		ingressConfig.InitializeCluster(ingressController, stop)
+		if err := ingressConfig.InitializeCluster(ingressController, stop); err != nil {
+			return err
+		}
 		go s.configController.Run(stop)
 		return nil
 	})
@@ -316,8 +318,7 @@ func (s *Server) initXdsServer() error {
 		s.xdsServer.Start(stop)
 		return nil
 	})
-	s.initGrpcServer()
-	return nil
+	return s.initGrpcServer()
 }
 
 func (s *Server) initGrpcServer() error {
@@ -377,10 +378,7 @@ func (s *Server) readyHandler(w http.ResponseWriter, _ *http.Request) {
 
 // cachesSynced checks whether caches have been synced.
 func (s *Server) cachesSynced() bool {
-	if !s.configController.HasSynced() {
-		return false
-	}
-	return true
+	return s.configController.HasSynced()
 }
 
 func (s *Server) waitForCacheSync(stop <-chan struct{}) bool {

--- a/pkg/bootstrap/server.go
+++ b/pkg/bootstrap/server.go
@@ -363,6 +363,7 @@ func (s *Server) initHttpServer() error {
 	return nil
 }
 
+// readyHandler checks whether the http server is ready
 func (s *Server) readyHandler(w http.ResponseWriter, _ *http.Request) {
 	for name, fn := range s.readinessProbes {
 		if ready, err := fn(); !ready {

--- a/pkg/bootstrap/server_test.go
+++ b/pkg/bootstrap/server_test.go
@@ -3,7 +3,6 @@ package bootstrap
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"istio.io/istio/pilot/pkg/features"
@@ -28,7 +27,7 @@ func TestStartWithNoError(t *testing.T) {
 		t.Errorf("failed to create server: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	if err = s.Start(ctx.Done()); err != nil {

--- a/pkg/bootstrap/server_test.go
+++ b/pkg/bootstrap/server_test.go
@@ -1,0 +1,51 @@
+package bootstrap
+
+import (
+	"context"
+	"github.com/agiledragon/gomonkey/v2"
+	"istio.io/istio/pilot/pkg/features"
+	"istio.io/istio/pkg/keepalive"
+	kubelib "istio.io/istio/pkg/kube"
+	"testing"
+	"time"
+)
+
+func TestStartWithNoError(t *testing.T) {
+	var (
+		s   *Server
+		err error
+	)
+
+	mockFn := func(s *Server) error {
+		s.kubeClient = kubelib.NewFakeClient()
+		return nil
+	}
+
+	gomonkey.ApplyFunc((*Server).initKubeClient, mockFn)
+
+	if s, err = NewServer(newServerArgs()); err != nil {
+		t.Errorf("failed to create server: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err = s.Start(ctx.Done()); err != nil {
+		t.Errorf("failed to start the server: %v", err)
+	}
+
+}
+
+func newServerArgs() *ServerArgs {
+	return &ServerArgs{
+		Debug:                true,
+		NativeIstio:          true,
+		HttpAddress:          ":8888",
+		GrpcAddress:          ":15051",
+		GrpcKeepAliveOptions: keepalive.DefaultOption(),
+		XdsOptions: XdsOptions{
+			DebounceAfter:     features.DebounceAfter,
+			DebounceMax:       features.DebounceMax,
+			EnableEDSDebounce: features.EnableEDSDebounce,
+		},
+	}
+}

--- a/pkg/bootstrap/server_test.go
+++ b/pkg/bootstrap/server_test.go
@@ -2,12 +2,13 @@ package bootstrap
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/agiledragon/gomonkey/v2"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/keepalive"
 	kubelib "istio.io/istio/pkg/kube"
-	"testing"
-	"time"
 )
 
 func TestStartWithNoError(t *testing.T) {
@@ -29,10 +30,10 @@ func TestStartWithNoError(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
 	if err = s.Start(ctx.Done()); err != nil {
 		t.Errorf("failed to start the server: %v", err)
 	}
-
 }
 
 func newServerArgs() *ServerArgs {

--- a/pkg/bootstrap/server_test.go
+++ b/pkg/bootstrap/server_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bootstrap
 
 import (
@@ -7,7 +21,8 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"istio.io/istio/pilot/pkg/features"
 	"istio.io/istio/pkg/keepalive"
-	kubelib "istio.io/istio/pkg/kube"
+
+	higresskube "github.com/alibaba/higress/pkg/kube"
 )
 
 func TestStartWithNoError(t *testing.T) {
@@ -17,7 +32,7 @@ func TestStartWithNoError(t *testing.T) {
 	)
 
 	mockFn := func(s *Server) error {
-		s.kubeClient = kubelib.NewFakeClient()
+		s.kubeClient = higresskube.NewFakeClient()
 		return nil
 	}
 

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -61,6 +61,7 @@ func NewFakeClient(objects ...runtime.Object) Client {
 	}
 	c.higress = higressfake.NewSimpleClientset()
 	c.higressInformer = higressinformer.NewSharedInformerFactoryWithOptions(c.higress, resyncInterval)
+	c.informerWatchesPending = atomic.NewInt32(0)
 
 	// https://github.com/kubernetes/kubernetes/issues/95372
 	// There is a race condition in the client fakes, where events that happen between the List and Watch


### PR DESCRIPTION
Signed-off-by: charlie <qianglin98@qq.com>

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
unit Test: Increase unit test coverage of pkg/bootstrap

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #83 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
```
➜  bootstrap git:(UT/bootstrap) go test -coverprofile=size_coverage.out
2022-12-07T05:57:50.295408Z     info    init xds server
2022-12-07T05:57:50.295636Z     info    ingress Skipping IngressClass, resource not supported for cluster 
2022-12-07T05:57:50.295660Z     info    ingress Disable status update for cluster 
2022-12-07T05:57:50.295704Z     info    initializing registry event handlers
2022-12-07T05:57:50.295711Z     info    ingress register resource networking.istio.io/v1alpha3/DestinationRule
2022-12-07T05:57:50.295718Z     info    ingress register resource networking.istio.io/v1alpha3/EnvoyFilter
2022-12-07T05:57:50.295721Z     info    ingress register resource networking.istio.io/v1alpha3/Gateway
2022-12-07T05:57:50.295724Z     info    ingress register resource networking.istio.io/v1alpha3/VirtualService
2022-12-07T05:57:50.295730Z     info    Starting ADS server
2022-12-07T05:57:50.296284Z     info    Waiting for caches to be synced
2022-12-07T05:57:50.296305Z     info    ingress Ingress config controller synced.
2022-12-07T05:57:50.296313Z     info    All controller caches have been synced up in 27.605µs
2022-12-07T05:57:50.296335Z     info    ads     All caches have been synced up in 1.768974ms, marking server ready
PASS
2022-12-07T05:57:50.296615Z     info    starting gRPC discovery service at [::]:15051
2022-12-07T05:57:50.296664Z     error   ingress Failed to sync ingress controller cache for cluster 
2022-12-07T05:57:50.296679Z     info    starting HTTP service at [::]:8888
2022-12-07T05:57:50.296674Z     error   ingress Failed to sync secret controller cache
coverage: 71.0% of statements
ok      github.com/alibaba/higress/pkg/bootstrap        1.094s
```


