### PR TITLE
feat: use echoserver to demonstrate ingress abilities

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -181,7 +181,7 @@ include tools/tools.mk
 include tools/lint.mk
 
 .PHONY: e2e-test
-e2e-test: $(tools/kind) create-cluster kube-load-image install-dev run-e2e-test delete-cluster
+e2e-test: $(tools/kind) delete-cluster create-cluster kube-load-image install-dev run-e2e-test delete-cluster
 
 create-cluster: $(tools/kind)
 	tools/hack/create-cluster.sh
@@ -205,7 +205,5 @@ run-e2e-test:
 	@echo -e "\n\033[36mWaiting higress-gateway to be ready...\033[0m\n"
 	kubectl wait --timeout=5m -n higress-system deployment/higress-gateway --for=condition=Available
 
-	@echo -e "\n\033[36mSend request to call foo service...\033[0m\n"
-	curl -i -v http://localhost/foo
-	@echo -e "\n\n\033[36mSend request to call bar service...\033[0m\n"
-	curl -i -v http://localhost/bar
+	@echo -e "\n\033[36mSend request to call backend...\033[0m\n"
+	curl -i -v http://localhost/hello-world

--- a/samples/hello-world/quickstart.yaml
+++ b/samples/hello-world/quickstart.yaml
@@ -30,7 +30,7 @@ spec:
         version: v1
     spec:
       containers:
-        - image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+        - image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/echoserver:v20221109-7ee2f3e
           imagePullPolicy: IfNotPresent
           name: backend
           ports:

--- a/samples/hello-world/quickstart.yaml
+++ b/samples/hello-world/quickstart.yaml
@@ -1,80 +1,62 @@
-kind: Pod
 apiVersion: v1
-metadata:
-  name: foo-app
-  labels:
-    app: foo
-spec:
-  containers:
-  - name: foo-app
-    image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/http-echo:0.2.3
-    args:
-    - "-text=foo"
----
 kind: Service
-apiVersion: v1
 metadata:
-  name: foo-service
-spec:
-  selector:
-    app: foo
-  ports:
-  # Default port used by the image
-  - port: 5678
----
-kind: Pod
-apiVersion: v1
-metadata:
-  name: bar-app
+  name: backend
   labels:
-    app: bar
+    app: backend
+    service: backend
 spec:
-  containers:
-  - name: bar-app
-    image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/http-echo:0.2.3
-    args:
-    - "-text=bar"
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: bar-service
-spec:
-  selector:
-    app: bar
   ports:
-  # Default port used by the image
-  - port: 5678
+    - name: http
+      port: 3000
+      targetPort: 3000
+  selector:
+    app: backend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: backend
+        version: v1
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-ingressconformance/echoserver:v20221109-7ee2f3e
+          imagePullPolicy: IfNotPresent
+          name: backend
+          ports:
+            - containerPort: 3000
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: foo
+  name: hello-world
 spec:
   rules:
   - http:
       paths:
       - pathType: Prefix
-        path: "/foo"
+        path: "/hello-world"
         backend:
           service:
-            name: foo-service
+            name: backend
             port:
-              number: 5678
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: bar
-spec:
-  rules:
-  - http:
-      paths:
-      - pathType: Prefix
-        path: "/bar"
-        backend:
-          service:
-            name: bar-service
-            port:
-              number: 5678
----
+              number: 3000


### PR DESCRIPTION
Signed-off-by: bitliu <bitliu@tencent.com>

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Use echoserver as the demonstrate ingress abilities. This is widely used in kubernetes-sigs/gateway-api and ingress upstream projects. And support mulit-arch and fix: https://github.com/alibaba/higress/issues/111.

Fixes: https://github.com/alibaba/higress/issues/111
