### PR TITLE
Improve the UT coverage of cmd/higress.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,7 +74,7 @@ jobs:
         go-version: 1.19
     - uses: actions/checkout@v3
     - name: "Run E2E Tests"
-      run: make e2e-test
+      run: GOPROXY="https://proxy.golang.org,direct" make e2e-test
 
   publish:
     runs-on: ubuntu-latest

--- a/cmd/higress/main.go
+++ b/cmd/higress/main.go
@@ -34,6 +34,14 @@ var (
 	serverArgs     *bootstrap.ServerArgs
 	loggingOptions = log.DefaultOptions()
 
+	serverProvider = func(args *bootstrap.ServerArgs) (bootstrap.ServerInterface, error) {
+		return bootstrap.NewServer(serverArgs)
+	}
+
+	waitForMonitorSignal = func(stop chan struct{}) {
+		cmd.WaitSignal(stop)
+	}
+
 	rootCmd = &cobra.Command{
 		Use: "higress",
 	}
@@ -52,7 +60,7 @@ var (
 
 			stop := make(chan struct{})
 
-			server, err := bootstrap.NewServer(serverArgs)
+			server, err := serverProvider(serverArgs)
 			if err != nil {
 				return fmt.Errorf("fail to create higress server: %v", err)
 			}
@@ -61,7 +69,7 @@ var (
 				return fmt.Errorf("fail to start higress server: %v", err)
 			}
 
-			cmd.WaitSignal(stop)
+			waitForMonitorSignal(stop)
 
 			server.WaitUntilCompletion()
 			return nil

--- a/cmd/higress/main_test.go
+++ b/cmd/higress/main_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/alibaba/higress/pkg/bootstrap"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestServe(t *testing.T) {
+	runEBackup := serveCmd.RunE
+	argsBackup := os.Args
+	serverProviderBackup := serverProvider
+	executed := false
+
+	serverProvider = func(args *bootstrap.ServerArgs) (bootstrap.ServerInterface, error) {
+		return &delayedServer{Args: args, Delay: time.Second * 5}, nil
+	}
+
+	serveCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		executed = true
+		return runEBackup(cmd, args)
+	}
+	defer func() {
+		serverProvider = serverProviderBackup
+		os.Args = argsBackup
+		serveCmd.RunE = runEBackup
+	}()
+
+	a := assert.New(t)
+
+	delay := time.Second * 5
+
+	start := time.Now()
+	os.Args = []string{"/app/higress", "serve"}
+	waitForMonitorSignal = func(stop chan struct{}) {
+		time.Sleep(delay)
+		close(stop)
+	}
+	main()
+	end := time.Now()
+
+	cost := end.Sub(start)
+	a.GreaterOrEqual(cost, delay)
+
+	a.True(executed)
+}
+
+type delayedServer struct {
+	Args  *bootstrap.ServerArgs
+	Delay time.Duration
+	stop  <-chan struct{}
+}
+
+func (d *delayedServer) Start(stop <-chan struct{}) error {
+	d.stop = stop
+	return nil
+}
+
+func (d *delayedServer) WaitUntilCompletion() {
+	<-d.stop
+}

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/nacos-group/nacos-sdk-go v1.0.8
 	github.com/nacos-group/nacos-sdk-go/v2 v2.1.2
 	github.com/spf13/cobra v1.2.1
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	go.uber.org/atomic v1.9.0
 	google.golang.org/grpc v1.48.0
 	google.golang.org/protobuf v1.28.0
@@ -155,6 +155,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/toolkits/concurrent v0.0.0-20150624120057-a4371d70e3e3 // indirect
 	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
 	github.com/yl2chen/cidranger v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,7 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 h1:hzAQntlaYRkVSFEfj9OTWlVV1H155FMD8BTKktLv0QI=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
+github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20220520190051-1e77728a1eaa h1:B/lvg4tQ5hfFZd4V2hcSfFVfUvAK6GSFKxIIzwnkv8g=
@@ -1260,6 +1261,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -1270,6 +1273,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/bootstrap/server.go
+++ b/pkg/bootstrap/server.go
@@ -107,6 +107,11 @@ type ServerArgs struct {
 
 type readinessProbe func() (bool, error)
 
+type ServerInterface interface {
+	Start(stop <-chan struct{}) error
+	WaitUntilCompletion()
+}
+
 type Server struct {
 	*ServerArgs
 	environment      *model.Environment


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Improve the UT coverage of cmd/higress.


### Ⅱ. Does this pull request fix one issue?
fixes #84

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews
```
~/Projects/higress/cmd/higress ut/cmd/higress !1 ❯ go test -coverprofile=size_coverage.out                                                                                                                                 10s 17:04:57
2023-01-22T09:05:08.105099Z     info    FLAG: --clusterAliases="[]"
2023-01-22T09:05:08.105123Z     info    FLAG: --clusterID="Kubernetes"
2023-01-22T09:05:08.105125Z     info    FLAG: --clusterRegistriesNamespace=""
2023-01-22T09:05:08.105128Z     info    FLAG: --debug="true"
2023-01-22T09:05:08.105130Z     info    FLAG: --domain="cluster.local"
2023-01-22T09:05:08.105133Z     info    FLAG: --enableStatus="false"
2023-01-22T09:05:08.105135Z     info    FLAG: --gatewaySelectorKey="higress"
2023-01-22T09:05:08.105137Z     info    FLAG: --gatewaySelectorValue="higress-gateway"
2023-01-22T09:05:08.105139Z     info    FLAG: --grpcAddress=":15051"
2023-01-22T09:05:08.105141Z     info    FLAG: --help="false"
2023-01-22T09:05:08.105143Z     info    FLAG: --httpAddress=":8888"
2023-01-22T09:05:08.105147Z     info    FLAG: --ingressClass=""
2023-01-22T09:05:08.105149Z     info    FLAG: --keepStaleWhenEmpty="false"
2023-01-22T09:05:08.105153Z     info    FLAG: --keepaliveInterval="30s"
2023-01-22T09:05:08.105156Z     info    FLAG: --keepaliveMaxServerConnectionAge="2562047h47m16.854775807s"
2023-01-22T09:05:08.105159Z     info    FLAG: --keepaliveTimeout="10s"
2023-01-22T09:05:08.105162Z     info    FLAG: --kubeconfig=""
2023-01-22T09:05:08.105166Z     info    FLAG: --kubernetesApiBurst="160"
2023-01-22T09:05:08.105176Z     info    FLAG: --kubernetesApiQPS="80"
2023-01-22T09:05:08.105179Z     info    FLAG: --log_as_json="false"
2023-01-22T09:05:08.105184Z     info    FLAG: --log_caller=""
2023-01-22T09:05:08.105187Z     info    FLAG: --log_output_level="default:info"
2023-01-22T09:05:08.105191Z     info    FLAG: --log_rotate=""
2023-01-22T09:05:08.105194Z     info    FLAG: --log_rotate_max_age="30"
2023-01-22T09:05:08.105197Z     info    FLAG: --log_rotate_max_backups="1000"
2023-01-22T09:05:08.105200Z     info    FLAG: --log_rotate_max_size="104857600"
2023-01-22T09:05:08.105205Z     info    FLAG: --log_stacktrace_level="default:none"
2023-01-22T09:05:08.105211Z     info    FLAG: --log_target="[stdout]"
2023-01-22T09:05:08.105215Z     info    FLAG: --resync="1m0s"
2023-01-22T09:05:08.105220Z     info    FLAG: --vklog="0"
2023-01-22T09:05:08.105224Z     info    FLAG: --watchNamespace=""
2023-01-22T09:05:08.105228Z     info    Version unknown-unknown-unknown
PASS
coverage: 84.6% of statements
ok      github.com/alibaba/higress/cmd/higress  5.034s
```