### PR TITLE
Default set ingress class as higress and enable ingress status.

### DIFF
--- a/cmd/higress/main.go
+++ b/cmd/higress/main.go
@@ -28,6 +28,7 @@ import (
 	"istio.io/pkg/version"
 
 	"github.com/alibaba/higress/pkg/bootstrap"
+	innerconstants "github.com/alibaba/higress/pkg/config/constants"
 )
 
 var (
@@ -93,8 +94,8 @@ func init() {
 
 	serveCmd.PersistentFlags().StringVar(&serverArgs.GatewaySelectorKey, "gatewaySelectorKey", "higress", "gateway resource selector label key")
 	serveCmd.PersistentFlags().StringVar(&serverArgs.GatewaySelectorValue, "gatewaySelectorValue", "higress-gateway", "gateway resource selector label value")
-	serveCmd.PersistentFlags().BoolVar(&serverArgs.EnableStatus, "enableStatus", false, "enable the ingress status syncer which use to update the ip in ingress's status")
-	serveCmd.PersistentFlags().StringVar(&serverArgs.IngressClass, "ingressClass", "", "if not empty, only watch the ingresses have the specified class, otherwise watch all ingresses")
+	serveCmd.PersistentFlags().BoolVar(&serverArgs.EnableStatus, "enableStatus", true, "enable the ingress status syncer which use to update the ip in ingress's status")
+	serveCmd.PersistentFlags().StringVar(&serverArgs.IngressClass, "ingressClass", innerconstants.DefaultIngressClass, "if not empty, only watch the ingresses have the specified class, otherwise watch all ingresses")
 	serveCmd.PersistentFlags().StringVar(&serverArgs.WatchNamespace, "watchNamespace", "", "if not empty, only wath the ingresses in the specified namespace, otherwise watch in all namespacees")
 	serveCmd.PersistentFlags().BoolVar(&serverArgs.Debug, "debug", serverArgs.Debug, "if true, enables more debug http api")
 	serveCmd.PersistentFlags().StringVar(&serverArgs.HttpAddress, "httpAddress", serverArgs.HttpAddress, "the http address")

--- a/helm/higress/templates/controller-deployment.yaml
+++ b/helm/higress/templates/controller-deployment.yaml
@@ -169,10 +169,10 @@ spec:
           - "serve"
           - --gatewaySelectorKey=higress
           - --gatewaySelectorValue={{ .Release.Namespace }}-{{ include "gateway.name" . }}
+          {{- if not .Values.enableStatus }}
           - --enableStatus={{ .Values.enableStatus }}
-          {{- if .Values.ingressClass }}
-          - --ingressClass={{ .Values.ingressClass }}
           {{- end }}
+          - --ingressClass={{ .Values.ingressClass }}
           {{- if .Values.watchNamespace }}
           - --watchNamespace={{ .Values.watchNamespace }}
           {{- end }}

--- a/helm/higress/values.yaml
+++ b/helm/higress/values.yaml
@@ -318,9 +318,17 @@ global:
   # mechanisms (e.g., environmental variable CA_PROVIDER).
   caName: ""
 hub: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress
-ingressClass: ""
+
+# IngressClass filters which ingress resources the higress controller watches.
+# The default ingress class is higress.
+# There are some special cases for special ingress class.
+# 1. When the ingress class is set as nginx, the higress controller will watch ingress
+# resources with the nginx ingress class or without any ingress class.
+# 2. When the ingress class is set empty, the higress controller will watch all ingress
+# resources in the k8s cluster.
+ingressClass: "higress"
 watchNamespace: ""
-enableStatus: false
+enableStatus: true
 clusterName: ""
 # meshConfig defines runtime configuration of components, including Istiod and istio-agent behavior
 # See https://istio.io/docs/reference/config/istio.mesh.v1alpha1/ for all available options

--- a/pkg/bootstrap/server.go
+++ b/pkg/bootstrap/server.go
@@ -88,12 +88,20 @@ type RegistryOptions struct {
 }
 
 type ServerArgs struct {
-	Debug                bool
-	MeshId               string
-	RegionId             string
-	NativeIstio          bool
-	HttpAddress          string
-	GrpcAddress          string
+	Debug       bool
+	MeshId      string
+	RegionId    string
+	NativeIstio bool
+	HttpAddress string
+	GrpcAddress string
+
+	// IngressClass filters which ingress resources the higress controller watches.
+	// The default ingress class is higress.
+	// There are some special cases for special ingress class.
+	// 1. When the ingress class is set as nginx, the higress controller will watch ingress
+	// resources with the nginx ingress class or without any ingress class.
+	// 2. When the ingress class is set empty, the higress controller will watch all ingress
+	// resources in the k8s cluster.
 	IngressClass         string
 	EnableStatus         bool
 	WatchNamespace       string

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -1,0 +1,1 @@
+package constants

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package constants
 
 const DefaultIngressClass = "higress"

--- a/pkg/config/constants/constants.go
+++ b/pkg/config/constants/constants.go
@@ -1,1 +1,3 @@
 package constants
+
+const DefaultIngressClass = "higress"

--- a/test/ingress/conformance/tests/httproute-simple-same-namespace.yaml
+++ b/test/ingress/conformance/tests/httproute-simple-same-namespace.yaml
@@ -18,6 +18,7 @@ metadata:
   name: higress-conformance-infra-test
   namespace: higress-conformance-infra
 spec:
+  ingressClassName: higress
   rules:
   - http:
       paths:


### PR DESCRIPTION
As a new ingress controller,  we should have our own ingress class. 
For migration case, we also have settings for explicitly changing ingress class.

Associated issuse https://github.com/alibaba/higress/issues/145.