### PR TITLE
unit-test: add unit test for pkg/ingress/kube/annotations

### DIFF
--- a/pkg/ingress/kube/annotations/destination.go
+++ b/pkg/ingress/kube/annotations/destination.go
@@ -37,7 +37,7 @@ type DestinationConfig struct {
 
 type destination struct{}
 
-func (a destination) Parse(annotations Annotations, config *Ingress, globalContext *GlobalContext) error {
+func (a destination) Parse(annotations Annotations, config *Ingress, _ *GlobalContext) error {
 	if !needDestinationConfig(annotations) {
 		return nil
 	}
@@ -55,6 +55,9 @@ func (a destination) Parse(annotations Annotations, config *Ingress, globalConte
 		pairs := strings.Fields(line)
 		var weight int64 = 100
 		var addrIndex int
+		if len(pairs) == 0 {
+			continue
+		}
 		if strings.HasSuffix(pairs[0], "%") {
 			weight, err = strconv.ParseInt(strings.TrimSuffix(pairs[0], "%"), 10, 32)
 			if err != nil {

--- a/pkg/ingress/kube/annotations/destination_test.go
+++ b/pkg/ingress/kube/annotations/destination_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	networking "istio.io/api/networking/v1alpha3"
+)
+
+func TestDestinationParse(t *testing.T) {
+	parser := destination{}
+
+	testCases := []struct {
+		input  Annotations
+		expect *DestinationConfig
+	}{
+		{
+			input:  Annotations{},
+			expect: nil,
+		},
+		{
+			input: Annotations{
+				buildHigressAnnotationKey(destinationKey): "",
+			},
+			expect: nil,
+		},
+		{
+			input: Annotations{
+				buildHigressAnnotationKey(destinationKey): "100% my-svc.DEFAULT-GROUP.xxxx.nacos:8080 v1",
+			},
+			expect: &DestinationConfig{
+				McpDestination: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host:   "my-svc.DEFAULT-GROUP.xxxx.nacos",
+							Subset: "v1",
+							Port:   &networking.PortSelector{Number: 8080},
+						},
+						Weight: 100,
+					},
+				},
+				WeightSum: 100,
+			},
+		},
+		{
+			input: Annotations{
+				buildHigressAnnotationKey(destinationKey): "50% my-svc.DEFAULT-GROUP.xxxx.nacos:8080 v1\n\n" +
+					"50% my-svc.DEFAULT-GROUP.xxxx.nacos:8080 v2",
+			},
+			expect: &DestinationConfig{
+				McpDestination: []*networking.HTTPRouteDestination{
+					{
+						Destination: &networking.Destination{
+							Host:   "my-svc.DEFAULT-GROUP.xxxx.nacos",
+							Subset: "v1",
+							Port:   &networking.PortSelector{Number: 8080},
+						},
+						Weight: 50,
+					},
+					{
+						Destination: &networking.Destination{
+							Host:   "my-svc.DEFAULT-GROUP.xxxx.nacos",
+							Subset: "v2",
+							Port:   &networking.PortSelector{Number: 8080},
+						},
+						Weight: 50,
+					},
+				},
+				WeightSum: 100,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			config := &Ingress{}
+			_ = parser.Parse(testCase.input, config, nil)
+			if diff := cmp.Diff(config.Destination, testCase.expect); diff != "" {
+				t.Fatalf("TestDestinationParse() mismatch: (-want +got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/ingress/kube/annotations/redirect_test.go
+++ b/pkg/ingress/kube/annotations/redirect_test.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestRedirectParse(t *testing.T) {
+	parser := redirect{}
+
+	testCases := []struct {
+		name   string
+		input  Annotations
+		expect *RedirectConfig
+	}{
+		{
+			name:   "Don't contain any redirect keys",
+			input:  Annotations{},
+			expect: nil,
+		},
+		{
+			name: "By appRoot",
+			input: Annotations{
+				buildHigressAnnotationKey(appRoot):          "/root",
+				buildHigressAnnotationKey(sslRedirect):      "true",
+				buildHigressAnnotationKey(forceSSLRedirect): "true",
+			},
+			expect: &RedirectConfig{
+				AppRoot:       "/root",
+				httpsRedirect: true,
+				Code:          defaultPermanentRedirectCode,
+			},
+		},
+		{
+			name: "By temporalRedirect",
+			input: Annotations{
+				buildHigressAnnotationKey(temporalRedirect): "http://www.xxx.org",
+			},
+			expect: &RedirectConfig{
+				URL:  "http://www.xxx.org",
+				Code: defaultTemporalRedirectCode,
+			},
+		},
+		{
+			name: "By temporalRedirect with invalid url",
+			input: Annotations{
+				buildHigressAnnotationKey(temporalRedirect): "tcp://www.xxx.org",
+			},
+			expect: &RedirectConfig{
+				Code: defaultPermanentRedirectCode,
+			},
+		},
+		{
+			name: "By permanentRedirect",
+			input: Annotations{
+				buildHigressAnnotationKey(permanentRedirect): "http://www.xxx.org",
+			},
+			expect: &RedirectConfig{
+				URL:  "http://www.xxx.org",
+				Code: defaultPermanentRedirectCode,
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run("", func(t *testing.T) {
+			config := &Ingress{}
+			_ = parser.Parse(tt.input, config, nil)
+			if diff := cmp.Diff(tt.expect, config.Redirect, cmp.AllowUnexported(RedirectConfig{})); diff != "" {
+				t.Fatalf("TestRedirectParse() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/ingress/kube/annotations/upstreamtls_test.go
+++ b/pkg/ingress/kube/annotations/upstreamtls_test.go
@@ -1,0 +1,138 @@
+package annotations
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	networking "istio.io/api/networking/v1alpha3"
+)
+
+func TestUpstreamTLSParse(t *testing.T) {
+	parser := upstreamTLS{}
+
+	testCases := []struct {
+		input  Annotations
+		expect *UpstreamTLSConfig
+	}{
+		{
+			input:  Annotations{},
+			expect: nil,
+		},
+		{
+			input: Annotations{
+				buildNginxAnnotationKey(proxySSLSecret):     "",
+				buildNginxAnnotationKey(backendProtocol):    "HTTP2",
+				buildNginxAnnotationKey(proxySSLSecret):     "namespace/SSLSecret",
+				buildNginxAnnotationKey(proxySSLVerify):     "on",
+				buildNginxAnnotationKey(proxySSLName):       "SSLName",
+				buildNginxAnnotationKey(proxySSLServerName): "on",
+			},
+			expect: &UpstreamTLSConfig{
+				BackendProtocol: "HTTP2",
+				SSLVerify:       true,
+				SNI:             "SSLName",
+				SecretName:      "namespace/SSLSecret",
+			},
+		},
+		{
+			input: Annotations{
+				buildNginxAnnotationKey(proxySSLSecret):     "",
+				buildNginxAnnotationKey(backendProtocol):    "HTTP2",
+				buildNginxAnnotationKey(proxySSLSecret):     "", // if there is no ssl secret, it will be return directly
+				buildNginxAnnotationKey(proxySSLVerify):     "on",
+				buildNginxAnnotationKey(proxySSLName):       "SSLName",
+				buildNginxAnnotationKey(proxySSLServerName): "on",
+			},
+			expect: &UpstreamTLSConfig{
+				BackendProtocol: "HTTP2",
+				SSLVerify:       false,
+				SNI:             "",
+				SecretName:      "",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			config := &Ingress{}
+			_ = parser.Parse(testCase.input, config, nil)
+			if diff := cmp.Diff(testCase.expect, config.UpstreamTLS); diff != "" {
+				t.Fatalf("TestUpstreamTLSParse() mismatch: \n%s", diff)
+			}
+		})
+	}
+}
+
+func TestApplyTrafficPolicy(t *testing.T) {
+	parser := upstreamTLS{}
+
+	testCases := []struct {
+		input  *networking.TrafficPolicy_PortTrafficPolicy
+		config *Ingress
+		expect *networking.TrafficPolicy_PortTrafficPolicy
+	}{
+		{
+			input: &networking.TrafficPolicy_PortTrafficPolicy{},
+			config: &Ingress{
+				UpstreamTLS: &UpstreamTLSConfig{},
+			},
+			expect: &networking.TrafficPolicy_PortTrafficPolicy{},
+		},
+		{
+			input: &networking.TrafficPolicy_PortTrafficPolicy{},
+			config: &Ingress{
+				UpstreamTLS: &UpstreamTLSConfig{
+					BackendProtocol: "HTTP2",
+				},
+			},
+			expect: &networking.TrafficPolicy_PortTrafficPolicy{
+				ConnectionPool: &networking.ConnectionPoolSettings{
+					Http: &networking.ConnectionPoolSettings_HTTPSettings{
+						H2UpgradePolicy: networking.ConnectionPoolSettings_HTTPSettings_UPGRADE,
+					},
+				},
+			},
+		},
+		{
+			input: &networking.TrafficPolicy_PortTrafficPolicy{},
+			config: &Ingress{
+				UpstreamTLS: &UpstreamTLSConfig{
+					BackendProtocol: "HTTPS",
+					EnableSNI:       true,
+					SNI:             "SNI",
+				},
+			},
+			expect: &networking.TrafficPolicy_PortTrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode: networking.ClientTLSSettings_SIMPLE,
+					Sni:  "SNI",
+				},
+			},
+		},
+		{
+			input: &networking.TrafficPolicy_PortTrafficPolicy{},
+			config: &Ingress{
+				UpstreamTLS: &UpstreamTLSConfig{
+					SecretName: "namespace/secretName",
+					SSLVerify:  true,
+				},
+			},
+			expect: &networking.TrafficPolicy_PortTrafficPolicy{
+				Tls: &networking.ClientTLSSettings{
+					Mode:           networking.ClientTLSSettings_MUTUAL,
+					CredentialName: "kubernetes-ingress://Kubernetes/namespace/secretName",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			parser.ApplyTrafficPolicy(testCase.input, testCase.config)
+			if diff := cmp.Diff(testCase.expect, testCase.input); diff != "" {
+				t.Fatalf("TestApplyTrafficPolicy() mismatch (-want +got): \n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/ingress/kube/annotations/upstreamtls_test.go
+++ b/pkg/ingress/kube/annotations/upstreamtls_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package annotations
 
 import (

--- a/pkg/ingress/kube/annotations/util_test.go
+++ b/pkg/ingress/kube/annotations/util_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"istio.io/istio/pilot/pkg/model"
 )
 
@@ -50,4 +51,36 @@ func TestExtraSecret(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSplitBySeparator(t *testing.T) {
+	testCases := []struct {
+		input  string
+		sep    string
+		expect []string
+	}{
+		{
+			input:  "a b c d",
+			sep:    " ",
+			expect: []string{"a", "b", "c", "d"},
+		},
+		{
+			input:  ".1.2.3.4.",
+			sep:    ".",
+			expect: []string{"1", "2", "3", "4"},
+		},
+		{
+			input:  "1....2....3....4",
+			sep:    ".",
+			expect: []string{"1", "2", "3", "4"},
+		},
+	}
+
+	for _, tt := range testCases {
+		got := splitBySeparator(tt.input, tt.sep)
+		if diff := cmp.Diff(tt.expect, got); diff != "" {
+			t.Errorf("TestSplitBySeparator() mismatch (-want +got):\n%s", diff)
+		}
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: charlie <qianglin98@qq.com>

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

add unit test for pkg/ingress/kube/annotations

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #86 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

```
➜  annotations git:(ut/annotations) ✗ go test -coverprofile=count.out
2023-02-02T05:33:30.210033Z     error   ingress Fallback service foo/app within ingress test/ haven't ports
2023-02-02T05:33:30.414255Z     error   ingress Custom HTTP code 5ac within ingress test/ is invalid
2023-02-02T05:33:30.414880Z     error   ingress parse destination error invalid annotation value within ingress /
2023-02-02T05:33:30.415359Z     error   ingress CA secret bar/foo is invalid
PASS
coverage: 81.7% of statements

```

