### PR TITLE
e2e: add canary header traffic split

### DIFF
--- a/test/ingress/conformance/tests/httproute-canary-header.go
+++ b/test/ingress/conformance/tests/httproute-canary-header.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/test/ingress/conformance/utils/http"
+	"github.com/alibaba/higress/test/ingress/conformance/utils/suite"
+)
+
+func init() {
+	HigressConformanceTests = append(HigressConformanceTests, HTTPRouteRewritePath)
+}
+
+var HTTPRouteCanaryHeader = suite.ConformanceTest{
+	ShortName:   "HTTPRouteCanaryHeader",
+	Description: "The Ingress in the higress-conformance-infra namespace uses the canary header traffic split",
+	Manifests:   []string{"tests/httproute-canary-header.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		testcases := []http.Assertion{
+			{
+				Meta: http.AssertionMeta{
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path:    "/echo",
+						Host:    "canary.higress.io",
+						Headers: map[string]string{"traffic-split-higress": "true"},
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			}, {
+				Meta: http.AssertionMeta{
+					TargetBackend:   "infra-backend-v2",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/echo",
+						Host: "canary.higress.io",
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+		}
+
+		t.Run("Canary HTTPRoute Traffic Split", func(t *testing.T) {
+			for _, testcase := range testcases {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcase)
+			}
+		})
+	},
+}

--- a/test/ingress/conformance/tests/httproute-canary-header.yaml
+++ b/test/ingress/conformance/tests/httproute-canary-header.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "traffic-split-higress"
+    nginx.ingress.kubernetes.io/canary-by-header-value: "true"
+  name: ingress-echo-canary-value
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: canary.higress.io
+      http:
+        paths:
+          - path: /echo
+            pathType: Exact
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-echo
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: canary.higress.io
+      http:
+        paths:
+          - path: /echo
+            pathType: Exact
+            backend:
+              service:
+                name: infra-backend-v2
+                port:
+                  number: 8080

--- a/test/ingress/e2e_test.go
+++ b/test/ingress/e2e_test.go
@@ -53,6 +53,7 @@ func TestHigressConformanceTests(t *testing.T) {
 		tests.HTTPRouteSimpleSameNamespace,
 		tests.HTTPRouteHostNameSameNamespace,
 		tests.HTTPRouteRewritePath,
+		tests.HTTPRouteCanaryHeader,
 	}
 
 	cSuite.Run(t, higressTests)


### PR DESCRIPTION
Signed-off-by: bitliu <bitliu@tencent.com>

Part of: #166 

