### PR TITLE
feat: add Makefile for building wasm-go easier

### DIFF
--- a/plugins/wasm-go/DockerfileBuilder
+++ b/plugins/wasm-go/DockerfileBuilder
@@ -1,0 +1,29 @@
+FROM ubuntu as builder
+
+ARG THIS_ARCH
+ARG PLUGIN_NAME
+
+RUN apt-get update \
+  && apt-get install -y wget build-essential\
+  && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://golang.google.cn/dl/go1.19.3.linux-$THIS_ARCH.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.3.linux-$THIS_ARCH.tar.gz
+ENV PATH=$PATH:/usr/local/go/bin
+
+RUN wget https://github.com/tinygo-org/tinygo/releases/download/v0.25.0/tinygo_0.25.0_$THIS_ARCH.deb
+RUN dpkg -i tinygo_0.25.0_$THIS_ARCH.deb
+ENV export PATH=$PATH:/usr/local/bin
+
+WORKDIR /workspace
+
+COPY . .
+
+WORKDIR /workspace/extensions/$PLUGIN_NAME
+
+RUN go mod tidy
+RUN tinygo build -o /main.wasm -scheduler=none -target=wasi ./main.go
+
+FROM scratch
+
+COPY --from=builder /main.wasm plugin.wasm

--- a/plugins/wasm-go/Makefile
+++ b/plugins/wasm-go/Makefile
@@ -1,0 +1,20 @@
+THIS_ARCH ?= amd64
+
+PLUGIN_NAME ?= hello-world
+REGISTRY ?=
+BUILD_TIME := $(shell date "+%Y%m%d-%H%M%S")
+COMMIT_ID := $(shell git rev-parse --short HEAD 2>/dev/null)
+IMG ?= ${REGISTRY}${PLUGIN_NAME}:${BUILD_TIME}-${COMMIT_ID}
+
+build:
+	DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=${PLUGIN_NAME} \
+	                               --build-arg THIS_ARCH=${THIS_ARCH} \
+	                               -t ${IMG} \
+	                               -f DockerfileBuilder \
+	                               --output extensions/${PLUGIN_NAME} .
+	@echo ""
+	@echo "image:            ${IMG}"
+	@echo "output wasm file: extensions/${PLUGIN_NAME}/plugin.wasm"
+
+build-push: build
+	docker push ${IMG}

--- a/plugins/wasm-go/README.md
+++ b/plugins/wasm-go/README.md
@@ -4,17 +4,73 @@
 
 此 SDK 用于开发 Higress 的 Wasm 插件
 
-## 编译环境要求
+## 使用 Docker 快速构建
 
-(需要支持 go 范型特性)
+使用以下命令可以快速构建 wasm-go 插件:
 
-Go 版本: >= 1.18
+```bash
+$ THIS_ARCH=arm64 PLUGIN_NAME=request-block make build
+```
+<details>
+<summary>输出结果</summary>
+<pre><code>
+DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=request-block \
+                               --build-arg THIS_ARCH=arm64 \
+                               -t request-block:20230211-184334-f402f86 \
+                               -f DockerfileBuilder \
+                               --output extensions/request-block .
+[+] Building 11.8s (17/17) FINISHED                                                                                                                                                                                                                                                  
+ => [internal] load .dockerignore                                                                                                                                                                                                                                               0.0s
+ => => transferring context: 2B                                                                                                                                                                                                                                                 0.0s
+ => [internal] load build definition from DockerfileBuilder                                                                                                                                                                                                                     0.0s
+ => => transferring dockerfile: 843B                                                                                                                                                                                                                                            0.0s
+ => [internal] load metadata for docker.io/library/ubuntu:latest                                                                                                                                                                                                                0.9s
+ => [builder  1/11] FROM docker.io/library/ubuntu@sha256:9a0bdde4188b896a372804be2384015e90e3f84906b750c1a53539b585fbbe7f                                                                                                                                                       0.0s
+ => [internal] load build context                                                                                                                                                                                                                                               0.0s
+ => => transferring context: 6.65kB                                                                                                                                                                                                                                             0.0s
+ => CACHED [builder  2/11] RUN apt-get update   && apt-get install -y wget build-essential  && rm -rf /var/lib/apt/lists/*                                                                                                                                                      0.0s
+ => CACHED [builder  3/11] RUN wget https://golang.google.cn/dl/go1.19.3.linux-arm64.tar.gz                                                                                                                                                                                     0.0s
+ => CACHED [builder  4/11] RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.19.3.linux-arm64.tar.gz                                                                                                                                                                       0.0s
+ => CACHED [builder  5/11] RUN wget https://github.com/tinygo-org/tinygo/releases/download/v0.25.0/tinygo_0.25.0_arm64.deb                                                                                                                                                      0.0s
+ => CACHED [builder  6/11] RUN dpkg -i tinygo_0.25.0_arm64.deb                                                                                                                                                                                                                  0.0s
+ => CACHED [builder  7/11] WORKDIR /workspace                                                                                                                                                                                                                                   0.0s
+ => [builder  8/11] COPY . .                                                                                                                                                                                                                                                    0.0s
+ => [builder  9/11] WORKDIR /workspace/extensions/request-block                                                                                                                                                                                                                 0.0s
+ => [builder 10/11] RUN go mod tidy                                                                                                                                                                                                                                             1.1s
+ => [builder 11/11] RUN tinygo build -o /main.wasm -scheduler=none -target=wasi ./main.go                                                                                                                                                                                       9.5s
+ => CACHED [stage-1 1/1] COPY --from=builder /main.wasm plugin.wasm                                                                                                                                                                                                             0.0s 
+ => exporting to client                                                                                                                                                                                                                                                         0.0s 
+ => => copying files 998.36kB                                                                                                                                                                                                                                                   0.0s 
 
-TinyGo 版本: >= 0.25.0
+image:            request-block:20230211-184334-f402f86
+output wasm file: extensions/request-block/plugin.wasm
+</code></pre>
+</details>
 
-## Quick Examples
+该命令最终构建出一个 wasm 文件和一个 Docker image。
+这个本地的 wasm 文件被输出到了指定的插件的目录下，可以直接用于调试。
+你也可以直接使用 `make build-push` 一并构建和推送 image.
 
-使用 [request-block](extensions/request-block) 作为例子
+### 参数说明
+
+| 参数名称          | 可选/必须 | 默认值                                      | 含义                                           |
+|---------------|-------|------------------------------------------|----------------------------------------------|
+| `THIS_ARCH`   | 可选的   | amd64                                    | 构建插件的机器的指令集架构，在非 amd64 架构的机器上构建时要手动指定。       |
+| `PLUGIN_NAME` | 可选的   | hello-world                              | 要构建的插件名称。                                    |
+| `REGISTRY`    | 可选的   | 空                                        | 生成的镜像的仓库地址，如 `example.registry.io/my-name/`. |
+| `IMG`         | 可选的   | 如不设置则根据仓库地址、插件名称、构建时间以及 git commit id 生成 | 生成的镜像名称。                                     |
+
+## 本地构建
+
+你也可以选择先在本地将 wasm 构建出来，再拷贝到 Docker 镜像中。这要求你要先在本地搭建构建环境。
+
+编译环境要求如下：
+
+- Go 版本: >= 1.18 (需要支持范型特性)
+
+- TinyGo 版本: >= 0.25.0
+
+下面是本地多步骤构建 [request-block](extensions/request-block) 的例子。
 
 ### step1. 编译 wasm
 
@@ -31,7 +87,9 @@ docker build -t <your_registry_hub>/request-block:1.0.0 .
 docker push <your_registry_hub>/request-block:1.0.0
 ```
 
-### step3. 创建 WasmPlugin 资源
+## 创建 WasmPlugin 资源使插件生效
+
+编写 WasmPlugin 资源如下：
 
 ```yaml
 apiVersion: extensions.higress.io/v1alpha1
@@ -46,10 +104,12 @@ spec:
   defaultConfig:
     block_urls:
     - "swagger.html"
-  url: oci://<your_registry_hub>/request-block:1.0.0
+  url: oci://<your_registry_hub>/request-block:1.0.0  # 之前构建和推送的 image 地址
 ```
 
-创建上述资源后，如果请求url携带 `swagger.html`, 则这个请求就会被拒绝，例如：
+使用 `kubectl apply -f <your-wasm-plugin-yaml>` 使资源生效。
+
+资源生效后，如果请求url携带 `swagger.html`, 则这个请求就会被拒绝，例如：
 
 ```bash
 curl <your_gateway_address>/api/user/swagger.html
@@ -108,5 +168,5 @@ spec:
   url: oci://<your_registry_hub>/request-block:1.0.0
 ```
 
-所有规则会按上面配置的顺序一次执行匹配，当有一个规则匹配时，就停止匹配，并选择匹配的配置执行插件逻辑
+所有规则会按上面配置的顺序一次执行匹配，当有一个规则匹配时，就停止匹配，并选择匹配的配置执行插件逻辑。
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

添加 Makefile 和 Dockerfile, 使得不用搭建本地环境及可构建 wasm-go 插件和镜像.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
本 PR 是针对 #152 的部分工作.


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
不涉及业务逻辑, 没有 Go 代码.

### Ⅳ. Describe how to verify it

在 wasm-go 目录下 `make build`, 测试输出的结果是否正确。可以到 amd64 和 arm64 等不同机器下试一试。

### Ⅴ. Special notes for reviews

