### PR TITLE
feat: 使用多阶段构建优化 wasm-go 构建流程

### DIFF
--- a/plugins/wasm-go/Dockerfile
+++ b/plugins/wasm-go/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER=docker.io/chenzhongrun/wasm-go-builder:go1.19-tinygo0.26.0
+ARG BUILDER=higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/wasm-go-builder:go1.19-tinygo0.26.0
 FROM $BUILDER as builder
 
 ARG PLUGIN_NAME=hello-world

--- a/plugins/wasm-go/Dockerfile
+++ b/plugins/wasm-go/Dockerfile
@@ -1,2 +1,17 @@
-FROM scratch
-COPY main.wasm plugin.wasm
+ARG BUILDER=docker.io/chenzhongrun/wasm-go-builder:go1.19-tinygo0.26.0
+FROM $BUILDER as builder
+
+ARG PLUGIN_NAME=hello-world
+
+WORKDIR /workspace
+
+COPY . .
+
+WORKDIR /workspace/extensions/$PLUGIN_NAME
+
+RUN go mod tidy
+RUN tinygo build -o /main.wasm -scheduler=none -target=wasi ./main.go
+
+FROM scratch as output
+
+COPY --from=builder /main.wasm plugin.wasm

--- a/plugins/wasm-go/DockerfileBuilder
+++ b/plugins/wasm-go/DockerfileBuilder
@@ -1,13 +1,58 @@
-ARG WASM_BUILDER=wasm-builder
+# The Dockerfile for wasm-go builder only support amd64 and arm64 yet.
+# If you want to build on another architecture, the following information may be helpful.
+#
+# - arch: amd64 \
+#   base image: docker.io/ubuntu
+#   go_url: https://golang.google.cn/dl/go1.20.1.linux-amd64.tar.gz"
+#   tinygo_url: https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_amd64.deb
+#
+# - arch: arm64
+#   base image: docker.io/ubuntu
+#   go_url: https://golang.google.cn/dl/go1.20.1.linux-arm64.tar.gz
+#   tinygo_url: https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_arm64.deb
+#
+# - arch: armel
+#   base image: build yourself
+#   go_url: install from source code
+#   tinygo_url: build yourself
+#
+# - arch: i386
+#   base image: build yourself
+#   go_url: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
+#   tinygo_url: build yourself
+#
+# - arch: mips64el
+#   base image: build your self
+#   go_url: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
+#   tinygo_url: build your self
+#
+# - arch: ppc64el
+#   base image: build your self
+#   go_url: https://dl.google.com/go/go1.20.1.linux-ppc64le.tar.gz
+#   tinygo_url: build your self
+#
+# - arch: s390x
+#   base image: docker.io/ubuntu
+#   go_url: https://dl.google.com/go/go1.20.1.linux-s390x.tar.gz
+#   tinygo_url: build your self
+#
+# - arch: armhf
+#   base image: build your self
+#   go_url: https://golang.google.cn/dl/go1.20.1.linux-armv6l.tar.gz
+#   tinygo_url: https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_armhf.deb
 
-FROM ubuntu as wasm-builder
+ARG BASE_IMAGE=docker.io/ubuntu
+FROM $BASE_IMAGE
 
 ARG GO_VERSION
 ARG TINYGO_VERSION
 
+LABEL go_version=$GO_VERSION tinygo_version=$TINYGO_VERSION
+
 RUN apt-get update \
   && apt-get install -y wget build-essential \
   && rm -rf /var/lib/apt/lists/*
+
 
 RUN arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
 	go_url=; \
@@ -17,14 +62,6 @@ RUN arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
     echo "arch:           '$arch'"; \
     echo "go go_version:  '$go_version'"; \
     echo "tinygo_version: '$tinygo_version'"; \
-    ## only support amd64, arm64 and armhf yet.
-    ## go_urls for other architectures:
-    ##  armel: install from source code
-    ##  i386: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
-    ##  mips64el: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
-    ##  ppc64el: https://dl.google.com/go/go1.20.1.linux-ppc64le.tar.gz
-    ##  s390x: https://dl.google.com/go/go1.20.1.linux-s390x.tar.gz
-    ## On these architectures you have to build the tinygo deb package yourself.
 	case "$arch" in \
 		'amd64') \
             go_url="https://golang.google.cn/dl/go$go_version.linux-amd64.tar.gz"; \
@@ -34,37 +71,14 @@ RUN arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
             go_url="https://golang.google.cn/dl/go$go_version.linux-arm64.tar.gz"; \
             tinygo_url="https://github.com/tinygo-org/tinygo/releases/download/v$tinygo_version/tinygo_${tinygo_version}_arm64.deb"; \
 			;; \
-		'armhf') \
-            go_url="https://golang.google.cn/dl/go$go_version.linux-armv6l.tar.gz"; \
-            tinygo_url="https://github.com/tinygo-org/tinygo/releases/download/v$tinygo_version/tinygo_${tinygo_version}_armhf.deb"; \
-			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' "; exit 1 ;; \
 	esac; \
     echo "go_url: '$go_url'"; \
     echo "tinygo_url: '$tinygo_url'"; \
     wget -O go.tgz "$go_url" --progress=dot:giga; \
     wget -O tinygo.deb "$tinygo_url" --progress=dot:giga; \
-    echo "Download complete"
+    echo "Download complete"; \
+    rm -rf /usr/local/go && tar -C /usr/local -xzf go.tgz && rm -rf go.tgz; \
+    dpkg -i tinygo.deb && rm -rf tinygo.deb
 
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go.tgz && rm -rf go.tgz
-RUN dpkg -i tinygo.deb && rm -rf tinygo.deb
 ENV PATH=$PATH:/usr/local/go/bin:/usr/local/bin
-
-ARG WASM_BUILDER=wasm-builder
-FROM $WASM_BUILDER as building
-
-ARG PLUGIN_NAME
-ARG plugin_name=${PLUGIN_NAME:-hello-world}
-
-WORKDIR /workspace
-
-COPY . .
-
-WORKDIR /workspace/extensions/$plugin_name
-
-RUN go mod tidy
-RUN tinygo build -o /main.wasm -scheduler=none -target=wasi ./main.go
-
-FROM scratch as output
-
-COPY --from=building /main.wasm plugin.wasm

--- a/plugins/wasm-go/DockerfileBuilder
+++ b/plugins/wasm-go/DockerfileBuilder
@@ -1,30 +1,60 @@
-FROM ubuntu as builder
+ARG WASM_BUILDER=wasm-builder
 
-ARG THIS_ARCH
-ARG PLUGIN_NAME
+FROM ubuntu as wasm-builder
+
 ARG GO_VERSION
 ARG TINYGO_VERSION
-
-ARG this_arch=${THIS_ARCH:-amd64}
-ARG plugin_name=${PLUGIN_NAME:-hello-world}
-ARG go_version=${GO_VERSION:-1.19}
-ARG tinygo_version=${TINYGO_VERSION:-0.26.0}
-
-ARG go_pkg_name=go$go_version.linux-$this_arch.tar.gz
-ARG tinygo_pkg_name=tinygo_${tinygo_version}_$this_arch.deb
-
 
 RUN apt-get update \
   && apt-get install -y wget build-essential \
   && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://golang.google.cn/dl/$go_pkg_name
-RUN rm -rf /usr/local/go && tar -C /usr/local -xzf $go_pkg_name
-ENV PATH=$PATH:/usr/local/go/bin
+RUN arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	go_url=; \
+    tinygo_url=; \
+    go_version=${GO_VERSION:-1.19}; \
+    tinygo_version=${TINYGO_VERSION:-0.26.0}; \
+    echo "arch:           '$arch'"; \
+    echo "go go_version:  '$go_version'"; \
+    echo "tinygo_version: '$tinygo_version'"; \
+    ## only support amd64, arm64 and armhf yet.
+    ## go_urls for other architectures:
+    ##  armel: install by source code
+    ##  i386: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
+    ##  mips64el: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
+    ##  ppc64el: https://dl.google.com/go/go1.20.1.linux-ppc64le.tar.gz
+    ##  s390x: https://dl.google.com/go/go1.20.1.linux-s390x.tar.gz
+    ## On these architectures you have to build the tinygo deb package yourself.
+	case "$arch" in \
+		'amd64') \
+            go_url="https://golang.google.cn/dl/go$go_version.linux-amd64.tar.gz"; \
+            tinygo_url="https://github.com/tinygo-org/tinygo/releases/download/v$tinygo_version/tinygo_${tinygo_version}_amd64.deb"; \
+			;; \
+		'arm64') \
+            go_url="https://golang.google.cn/dl/go$go_version.linux-arm64.tar.gz"; \
+            tinygo_url="https://github.com/tinygo-org/tinygo/releases/download/v$tinygo_version/tinygo_${tinygo_version}_arm64.deb"; \
+			;; \
+		'armhf') \
+            go_url="https://golang.google.cn/dl/go$go_version.linux-armv6l.tar.gz"; \
+            tinygo_url="https://github.com/tinygo-org/tinygo/releases/download/v$tinygo_version/tinygo_${tinygo_version}_armhf.deb"; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch' "; exit 1 ;; \
+	esac; \
+    echo "go_url: '$go_url'"; \
+    echo "tinygo_url: '$tinygo_url'"; \
+    wget -O go.tgz "$go_url" --progress=dot:giga; \
+    wget -O tinygo.deb "$tinygo_url" --progress=dot:giga; \
+    echo "Download complete"
 
-RUN wget https://github.com/tinygo-org/tinygo/releases/download/v$tinygo_version/$tinygo_pkg_name
-RUN dpkg -i $tinygo_pkg_name
-ENV export PATH=$PATH:/usr/local/bin
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go.tgz && rm -rf go.tgz
+RUN dpkg -i tinygo.deb && rm -rf tinygo.deb
+ENV PATH=$PATH:/usr/local/go/bin:/usr/local/bin
+
+ARG WASM_BUILDER=wasm-builder
+FROM $WASM_BUILDER as building
+
+ARG PLUGIN_NAME
+ARG plugin_name=${PLUGIN_NAME:-hello-world}
 
 WORKDIR /workspace
 
@@ -35,6 +65,6 @@ WORKDIR /workspace/extensions/$plugin_name
 RUN go mod tidy
 RUN tinygo build -o /main.wasm -scheduler=none -target=wasi ./main.go
 
-FROM scratch
+FROM scratch as output
 
-COPY --from=builder /main.wasm plugin.wasm
+COPY --from=building /main.wasm plugin.wasm

--- a/plugins/wasm-go/DockerfileBuilder
+++ b/plugins/wasm-go/DockerfileBuilder
@@ -19,7 +19,7 @@ RUN arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
     echo "tinygo_version: '$tinygo_version'"; \
     ## only support amd64, arm64 and armhf yet.
     ## go_urls for other architectures:
-    ##  armel: install by source code
+    ##  armel: install from source code
     ##  i386: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
     ##  mips64el: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
     ##  ppc64el: https://dl.google.com/go/go1.20.1.linux-ppc64le.tar.gz

--- a/plugins/wasm-go/Makefile
+++ b/plugins/wasm-go/Makefile
@@ -3,41 +3,16 @@ REGISTRY ?=
 BUILD_TIME := $(shell date "+%Y%m%d-%H%M%S")
 COMMIT_ID := $(shell git rev-parse --short HEAD 2>/dev/null)
 IMG ?= ${REGISTRY}${PLUGIN_NAME}:${BUILD_TIME}-${COMMIT_ID}
-BUILDER_IMG ?= ${REGISTRY}wasm-go-builder:go${GO_VERSION}-tinygo${TINYGO_VERSION}
 
 .DEFAULT:
 build:
 	DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=${PLUGIN_NAME} \
-	                               --build-arg GO_VERSION=${GO_VERSION} \
-	                               --build-arg TINYGO_VERSION=${TINYGO_VERSION} \
-	                               -t ${IMG} \
-	                               -f DockerfileBuilder \
-	                               --output extensions/${PLUGIN_NAME} .
+	                            -t ${IMG} \
+	                            --output extensions/${PLUGIN_NAME} \
+	                            .
 	@echo ""
 	@echo "image:            ${IMG}"
 	@echo "output wasm file: extensions/${PLUGIN_NAME}/plugin.wasm"
 
 build-push: build
 	docker push ${IMG}
-
-builder:
-	DOCKER_BUILDKIT=1 docker build --target wasm-builder \
-	                               --build-arg GO_VERSION=${GO_VERSION} \
-	                               --build-arg TINYGO_VERSION=${TINYGO_VERSION} \
-	                               -t ${BUILDER_IMG} \
-	                               -f DockerfileBuilder \
-	                               .
-	@echo "You can use the following command to build the final image in the next stage"
-	@echo "WASM_BUILDER=${BUILDER_IMG} PLUGIN_NAME=${PLUGIN_NAME} make bb"
-
-bb: build-on-builder
-build-on-builder:
-	DOCKER_BUILDKIT=1 docker build --target building \
-	                               --target output \
-	                               --build-arg WASM_BUILDER=${WASM_BUILDER} \
-	                               -t ${IMG} \
-	                               -f DockerfileBuilder \
-	                               --output extensions/${PLUGIN_NAME} .
-	@echo ""
-	@echo "image:            ${IMG}"
-	@echo "output wasm file: extensions/${PLUGIN_NAME}/plugin.wasm"

--- a/plugins/wasm-go/Makefile
+++ b/plugins/wasm-go/Makefile
@@ -16,3 +16,17 @@ build:
 
 build-push: build
 	docker push ${IMG}
+
+# builder:
+# To build a wasm-go-builder image.
+# If you want to use Go/TinyGo with another version, please modify GO_VERSION/TINYGO_VERSION.
+# After your wasm-go-builder image is built, you can use --build-arg BUILDER=<your-wasm-go-builder> to build plugin image.
+builder:
+	docker buildx build --platform linux/amd64,linux/arm64 \
+			--build-arg BASE_IMAGE=docker.io/ubuntu \
+			--build-arg GO_VERSION=1.19 \
+			--build-arg TINYGO_VERSION=0.26.0 \
+			-f DockerfileBuilder \
+			-t wasm-go-builder:go1.19-tinygo0.26.0 \
+			--push \
+			.

--- a/plugins/wasm-go/Makefile
+++ b/plugins/wasm-go/Makefile
@@ -3,10 +3,11 @@ REGISTRY ?=
 BUILD_TIME := $(shell date "+%Y%m%d-%H%M%S")
 COMMIT_ID := $(shell git rev-parse --short HEAD 2>/dev/null)
 IMG ?= ${REGISTRY}${PLUGIN_NAME}:${BUILD_TIME}-${COMMIT_ID}
+BUILDER_IMG ?= ${REGISTRY}wasm-go-builder:go${GO_VERSION}-tinygo${TINYGO_VERSION}
 
+.DEFAULT:
 build:
 	DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=${PLUGIN_NAME} \
-	                               --build-arg THIS_ARCH=${THIS_ARCH} \
 	                               --build-arg GO_VERSION=${GO_VERSION} \
 	                               --build-arg TINYGO_VERSION=${TINYGO_VERSION} \
 	                               -t ${IMG} \
@@ -18,3 +19,25 @@ build:
 
 build-push: build
 	docker push ${IMG}
+
+builder:
+	DOCKER_BUILDKIT=1 docker build --target wasm-builder \
+	                               --build-arg GO_VERSION=${GO_VERSION} \
+	                               --build-arg TINYGO_VERSION=${TINYGO_VERSION} \
+	                               -t ${BUILDER_IMG} \
+	                               -f DockerfileBuilder \
+	                               .
+	@echo "You can use the following command to build the final image in the next stage"
+	@echo "WASM_BUILDER=${BUILDER_IMG} PLUGIN_NAME=${PLUGIN_NAME} make bb"
+
+bb: build-on-builder
+build-on-builder:
+	DOCKER_BUILDKIT=1 docker build --target building \
+	                               --target output \
+	                               --build-arg WASM_BUILDER=${WASM_BUILDER} \
+	                               -t ${IMG} \
+	                               -f DockerfileBuilder \
+	                               --output extensions/${PLUGIN_NAME} .
+	@echo ""
+	@echo "image:            ${IMG}"
+	@echo "output wasm file: extensions/${PLUGIN_NAME}/plugin.wasm"

--- a/plugins/wasm-go/README.md
+++ b/plugins/wasm-go/README.md
@@ -2,7 +2,7 @@
 
 ## 介绍
 
-此 SDK 用于开发 Higress 的 Wasm 插件
+此 SDK 用于使用 Go 语言开发 Higress 的 Wasm 插件。
 
 ## 使用 Higress wasm-go builder 快速构建
 
@@ -31,11 +31,11 @@ output wasm file: extensions/request-block/plugin.wasm
 
 ### 参数说明
 
-| 参数名称             | 可选/必须 | 默认值                                      | 含义                                                                   |
-|------------------|-------|------------------------------------------|----------------------------------------------------------------------|
-| `PLUGIN_NAME`    | 可选的   | hello-world                              | 要构建的插件名称。                                                            |
-| `REGISTRY`       | 可选的   | 空                                        | 生成的镜像的仓库地址，如 `example.registry.io/my-name/`.  注意 REGISTRY 值应当以 / 结尾。 |
-| `IMG`            | 可选的   | 如不设置则根据仓库地址、插件名称、构建时间以及 git commit id 生成 | 生成的镜像名称。                                                             |
+| 参数名称          | 可选/必须 | 默认值                                       | 含义                                                                   |
+|---------------|-------|-------------------------------------------|----------------------------------------------------------------------|
+| `PLUGIN_NAME` | 可选的   | hello-world                               | 要构建的插件名称。                                                            |
+| `REGISTRY`    | 可选的   | 空                                         | 生成的镜像的仓库地址，如 `example.registry.io/my-name/`.  注意 REGISTRY 值应当以 / 结尾。 |
+| `IMG`         | 可选的   | 如不设置则根据仓库地址、插件名称、构建时间以及 git commit id 生成。 | 生成的镜像名称。如非空，则会覆盖`REGISTRY` 参数。                                       |
 
 ## 本地构建
 
@@ -90,7 +90,6 @@ spec:
 ```
 
 使用 `kubectl apply -f <your-wasm-plugin-yaml>` 使资源生效。
-
 资源生效后，如果请求url携带 `swagger.html`, 则这个请求就会被拒绝，例如：
 
 ```bash
@@ -150,43 +149,3 @@ spec:
 ```
 
 所有规则会按上面配置的顺序一次执行匹配，当有一个规则匹配时，就停止匹配，并选择匹配的配置执行插件逻辑。
-
----
-## 构建 wasm-go-builder 镜像
-
-前文构建镜像时, 使用 Higress 提前构建好的包含 Go 和 Tinygo 环境的镜像作为基础镜像，该镜像的 Dockerfile 为 目录下的 [DockerfileBuilder](DockerfileBuilder) 文件。
-你可以使用如下命令构建该镜像：
-
-```bash
-docker build --build-arg BASE_IMAGE=docker.io/ubuntu \
-            --build-arg GO_VERSION=1.19 \
-            --build-arg TINYGO_VERSION=0.26.0 \
-            -f DockerfileBuilder \
-            -t wasm-go-builder:go1.19-tinygo0.26.0 \
-            .
-```
-
-如果有需要，可以使用 docker buildx 或者 podman 构建 multi-arch 镜像。
-```bash docker buildx
-$ docker buildx create --use --name higress-builder
-$ docker buildx build --platform linux/amd64,linux/arm64	\
-            --build-arg BASE_IMAGE=docker.io/ubuntu \
-            --build-arg GO_VERSION=1.19 \
-            --build-arg TINYGO_VERSION=0.26.0 \
-            -f DockerfileBuilder \
-            -t wasm-go-builder:go1.19-tinygo0.26.0 \
-            --push \
-            .
-```
-或
-```bash podman
-podman build --jobs 2 \
-            --platform linux/amd64,linux/arm64 \
-            --manifest wasm-go-builder:go1.19-tinygo0.26.0 \
-            --build-arg BASE_IMAGE=docker.io/ubuntu \
-            --build-arg GO_VERSION=1.19 \
-            --build-arg TINYGO_VERSION=0.26.0 \
-            -f DockerfileBuilder \
-            --format=docker \
-            .
-```

--- a/plugins/wasm-go/README.md
+++ b/plugins/wasm-go/README.md
@@ -16,13 +16,12 @@ $ PLUGIN_NAME=request-block make build
 <summary>输出结果</summary>
 <pre><code>
 DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=request-block \
-                               --build-arg THIS_ARCH= \
                                --build-arg GO_VERSION= \
                                --build-arg TINYGO_VERSION= \
                                -t request-block:20230213-170844-ca49714 \
                                -f DockerfileBuilder \
                                --output extensions/request-block .
-[+] Building 84.6s (16/16)                                                                                                                                                                                                                                                0.0s 
+[+] Building 84.6s (15/15)                                                                                                                                                                                                                                                0.0s 
 
 image:            request-block:20230211-184334-f402f86
 output wasm file: extensions/request-block/plugin.wasm
@@ -37,12 +36,11 @@ output wasm file: extensions/request-block/plugin.wasm
 
 | 参数名称             | 可选/必须 | 默认值                                      | 含义                                                                   |
 |------------------|-------|------------------------------------------|----------------------------------------------------------------------|
-| `THIS_ARCH`      | 可选的   | amd64                                    | 构建插件的机器的指令集架构，在非 amd64 架构的机器上构建时要手动指定。                               |
 | `PLUGIN_NAME`    | 可选的   | hello-world                              | 要构建的插件名称。                                                            |
 | `REGISTRY`       | 可选的   | 空                                        | 生成的镜像的仓库地址，如 `example.registry.io/my-name/`.  注意 REGISTRY 值应当以 / 结尾。 |
 | `IMG`            | 可选的   | 如不设置则根据仓库地址、插件名称、构建时间以及 git commit id 生成 | 生成的镜像名称。                                                             |
 | `GO_VERSION`     | 可选的   | 1.19                                     | Go 版本号。                                                              |
-| `TINYGO_VERSION` | 可选的   | 0.26.0                                   | TinyGo 版本号。                                                          |
+| `TINYGO_VERSION` | 可选的   | 0.25.0                                   | TinyGo 版本号。                                                          |
 
 ## 本地构建
 
@@ -153,3 +151,44 @@ spec:
 
 所有规则会按上面配置的顺序一次执行匹配，当有一个规则匹配时，就停止匹配，并选择匹配的配置执行插件逻辑。
 
+## 更多构建细节
+
+使用 `make build` 会从头构建 wasm-go 的 builder 镜像，然后使用 tinygo 构建 wasm。
+构建过程中会下载 Go 和 Tinygo 安装包，以及执行 apt-get update，会花费大量时间在网络 IO 上。
+如果不想每次构建都从头开始，可以使用分阶段构建。下面介绍分阶段构建的 make 规则。
+
+### `make builder`
+
+`make builder` 用来构建 wasm-go 编译环境镜像。
+
+```bash
+make builder
+```
+<details>
+<summary>输出结果</summary>
+<pre><code>You can use the following command to build the final image in the next stage
+WASM_BUILDER=wasm-go-builder:go1.19-tinygo0.26.0 PLUGIN_NAME= make bb
+</code></pre>
+</details>
+
+可以指定 `GO_VERSION`, `TINYGO_VERSION` 参数决定 Go 和 Tinygo 版本号;
+指定 `REGISTRY` 设置要推送的镜像仓库。
+
+一旦构建出 builder 镜像，以后就可以复用这个镜像来构建 wasm-go, 而不必每次都从头开始构建。
+
+### `make build-on-builder` 或 `make bb`
+
+`make build-on-builder` 是利用上一阶段输出的 builder 镜像来构建 wasm-go.
+`make bb` 是 `make build-on-builder` 的别名。
+
+```bash
+WASM_BUILDER=wasm-go-builder:go1.20-tinygo0.27.0 PLUGIN_NAME=request-block make bb
+```
+<details>
+<summary>输出结果</summary>
+<pre><code>image:            request-block:20230216-143723-c5845c1
+output wasm file: extensions/request-block/plugin.wasm
+</code></pre>
+</details>
+
+其中 `WASM_BUILDER=wasm-go-builder:go1.20-tinygo0.27.0` 是上一阶段输出的 builder 镜像。

--- a/plugins/wasm-go/README.md
+++ b/plugins/wasm-go/README.md
@@ -4,7 +4,7 @@
 
 此 SDK 用于开发 Higress 的 Wasm 插件
 
-## 使用 Docker 快速构建
+## 使用 Higress wasm-go builder 快速构建
 
 使用以下命令可以快速构建 wasm-go 插件:
 
@@ -16,14 +16,11 @@ $ PLUGIN_NAME=request-block make build
 <summary>输出结果</summary>
 <pre><code>
 DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=request-block \
-                               --build-arg GO_VERSION= \
-                               --build-arg TINYGO_VERSION= \
-                               -t request-block:20230213-170844-ca49714 \
-                               -f DockerfileBuilder \
+                               -t request-block:20230223-173305-3b1a471 \
                                --output extensions/request-block .
-[+] Building 84.6s (15/15)                                                                                                                                                                                                                                                0.0s 
+[+] Building 67.7s (12/12) FINISHED
 
-image:            request-block:20230211-184334-f402f86
+image:            request-block:20230223-173305-3b1a471
 output wasm file: extensions/request-block/plugin.wasm
 </code></pre>
 </details>
@@ -39,8 +36,6 @@ output wasm file: extensions/request-block/plugin.wasm
 | `PLUGIN_NAME`    | 可选的   | hello-world                              | 要构建的插件名称。                                                            |
 | `REGISTRY`       | 可选的   | 空                                        | 生成的镜像的仓库地址，如 `example.registry.io/my-name/`.  注意 REGISTRY 值应当以 / 结尾。 |
 | `IMG`            | 可选的   | 如不设置则根据仓库地址、插件名称、构建时间以及 git commit id 生成 | 生成的镜像名称。                                                             |
-| `GO_VERSION`     | 可选的   | 1.19                                     | Go 版本号。                                                              |
-| `TINYGO_VERSION` | 可选的   | 0.25.0                                   | TinyGo 版本号。                                                          |
 
 ## 本地构建
 
@@ -62,10 +57,15 @@ tinygo build -o main.wasm -scheduler=none -target=wasi ./extensions/request-bloc
 
 ### step2. 构建并推送插件的 docker 镜像
 
-使用这份简单的 [dockerfile](./Dockerfile).
+使用这份简单的 Dockerfile
+
+```Dockerfile
+FROM scratch
+COPY main.wasm plugin.wasm
+```
 
 ```bash
-docker build -t <your_registry_hub>/request-block:1.0.0 .
+docker build -t <your_registry_hub>/request-block:1.0.0 -f <your_dockerfile> .
 docker push <your_registry_hub>/request-block:1.0.0
 ```
 
@@ -151,44 +151,42 @@ spec:
 
 所有规则会按上面配置的顺序一次执行匹配，当有一个规则匹配时，就停止匹配，并选择匹配的配置执行插件逻辑。
 
-## 更多构建细节
+---
+## 构建 wasm-go-builder 镜像
 
-使用 `make build` 会从头构建 wasm-go 的 builder 镜像，然后使用 tinygo 构建 wasm。
-构建过程中会下载 Go 和 Tinygo 安装包，以及执行 apt-get update，会花费大量时间在网络 IO 上。
-如果不想每次构建都从头开始，可以使用分阶段构建。下面介绍分阶段构建的 make 规则。
-
-### `make builder`
-
-`make builder` 用来构建 wasm-go 编译环境镜像。
+前文构建镜像时, 使用 Higress 提前构建好的包含 Go 和 Tinygo 环境的镜像作为基础镜像，该镜像的 Dockerfile 为 目录下的 [DockerfileBuilder](DockerfileBuilder) 文件。
+你可以使用如下命令构建该镜像：
 
 ```bash
-make builder
+docker build --build-arg BASE_IMAGE=docker.io/ubuntu \
+            --build-arg GO_VERSION=1.19 \
+            --build-arg TINYGO_VERSION=0.26.0 \
+            -f DockerfileBuilder \
+            -t wasm-go-builder:go1.19-tinygo0.26.0 \
+            .
 ```
-<details>
-<summary>输出结果</summary>
-<pre><code>You can use the following command to build the final image in the next stage
-WASM_BUILDER=wasm-go-builder:go1.19-tinygo0.26.0 PLUGIN_NAME= make bb
-</code></pre>
-</details>
 
-可以指定 `GO_VERSION`, `TINYGO_VERSION` 参数决定 Go 和 Tinygo 版本号;
-指定 `REGISTRY` 设置要推送的镜像仓库。
-
-一旦构建出 builder 镜像，以后就可以复用这个镜像来构建 wasm-go, 而不必每次都从头开始构建。
-
-### `make build-on-builder` 或 `make bb`
-
-`make build-on-builder` 是利用上一阶段输出的 builder 镜像来构建 wasm-go.
-`make bb` 是 `make build-on-builder` 的别名。
-
-```bash
-WASM_BUILDER=wasm-go-builder:go1.20-tinygo0.27.0 PLUGIN_NAME=request-block make bb
+如果有需要，可以使用 docker buildx 或者 podman 构建 multi-arch 镜像。
+```bash docker buildx
+$ docker buildx create --use --name higress-builder
+$ docker buildx build --platform linux/amd64,linux/arm64	\
+            --build-arg BASE_IMAGE=docker.io/ubuntu \
+            --build-arg GO_VERSION=1.19 \
+            --build-arg TINYGO_VERSION=0.26.0 \
+            -f DockerfileBuilder \
+            -t wasm-go-builder:go1.19-tinygo0.26.0 \
+            --push \
+            .
 ```
-<details>
-<summary>输出结果</summary>
-<pre><code>image:            request-block:20230216-143723-c5845c1
-output wasm file: extensions/request-block/plugin.wasm
-</code></pre>
-</details>
-
-其中 `WASM_BUILDER=wasm-go-builder:go1.20-tinygo0.27.0` 是上一阶段输出的 builder 镜像。
+或
+```bash podman
+podman build --jobs 2 \
+            --platform linux/amd64,linux/arm64 \
+            --manifest wasm-go-builder:go1.19-tinygo0.26.0 \
+            --build-arg BASE_IMAGE=docker.io/ubuntu \
+            --build-arg GO_VERSION=1.19 \
+            --build-arg TINYGO_VERSION=0.26.0 \
+            -f DockerfileBuilder \
+            --format=docker \
+            .
+```

--- a/plugins/wasm-go/README_EN.md
+++ b/plugins/wasm-go/README_EN.md
@@ -1,36 +1,75 @@
 ## Intro
 
-This SDK is used to develop the WASM Plugins of Higress.
-## Requirements
+This SDK is used to develop the WASM Plugins for Higress in Go.
 
-(need support Go's type parameters)
+## Quick build with Higress wasm-go builder
+
+The wasm-go plugin can be built quickly with the following command:
+
+```bash
+$ PLUGIN_NAME=request-block make build
+```
+
+<details>
+<summary>Output</summary>
+<pre><code>
+DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=request-block \
+                               -t request-block:20230223-173305-3b1a471 \
+                               --output extensions/request-block .
+[+] Building 67.7s (12/12) FINISHED
+
+image:            request-block:20230223-173305-3b1a471
+output wasm file: extensions/request-block/plugin.wasm
+</code></pre>
+</details>
+
+This command eventually builds a wasm file and a Docker image.
+This local wasm file is exported to the specified plugin's directory and can be used directly for debugging.
+You can also use `make build-push` to build and push the image at the same time.
+
+### Environmental parameters
+
+| Name          | Optional/Required | Default                                                                                                      | 含义                                                                                                                                  |
+|---------------|-------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `PLUGIN_NAME` | Optional          | hello-world                                                                                                  | The name of the plugin to build.                                                                                                    |
+| `REGISTRY`    | Optional          | empty                                                                                                        | The regitstry address of the generated image, e.g. `example.registry.io/my-name/`.  Note that the REGISTRY value should end with /. |
+| `IMG`         | Optional          | If it is empty, it is generated based on the repository address, plugin name, build time, and git commit id. | The generated image tag will override the `REGISTRY` parameter if it is not empty.                                                  |
+
+## Build on local yourself
+
+You can also build wasm locally and copy it to a Docker image. This requires a local build environment:
 
 Go version: >= 1.18
 
 TinyGo version: >= 0.25.0
 
-## Quick Examples
+The following is an example of building the plugin [request-block](extensions/request-block).
 
-Use the [request-block](example/request-block) as an example
-
-### step1. compile to wasm
+### step1. build wasm
 
 ```bash
-tinygo build -o main.wasm -scheduler=none -target=wasi ./example/request-block/main.go
+tinygo build -o main.wasm -scheduler=none -target=wasi ./extensions/request-block/main.go
 ```
 
-### step2. build&push docker image
+### step2. build and push docker image
 
-Use this [dockerfile](./Dockerfile).
+A simple Dockerfile:
+
+```Dockerfile
+FROM scratch
+COPY main.wasm plugin.wasm
+```
 
 ```bash
-docker build -t <your_registry_hub>/request-block:1.0.0 .
+docker build -t <your_registry_hub>/request-block:1.0.0 -f <your_dockerfile> .
 docker push <your_registry_hub>/request-block:1.0.0
 ```
 
-### step3. create WasmPlugin resource
+## Apply WasmPlugin API
 
 Read this [document](https://istio.io/latest/docs/reference/config/proxy_extensions/wasm-plugin/) to learn more about wasmplugin.
+
+Create a WasmPlugin API resource:
 
 ```yaml
 apiVersion: extensions.higress.io/v1alpha1
@@ -48,7 +87,8 @@ spec:
   url: oci://<your_registry_hub>/request-block:1.0.0
 ```
 
-If the url in request contains the `swagger.html`, the request will be blocked.
+When the resource is applied on the Kubernetes cluster with `kubectl apply -f <your-wasm-plugin-yaml>`,
+the request will be blocked if the string `swagger.html` in the url. 
 
 ```bash
 curl <your_gateway_address>/api/user/swagger.html


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

wasm-go plugin 构建流程改为以 wasm-go-builder image 作为基础镜像构建 wasm-go plugin 制品.
以减少花在网络上的重复的 apt-get, wget 时间.

并且提供了构建 wasm-go-builder image 的 DockerfileBuilder 文件和方法.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

#189 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

无关主要业务逻辑, 无 Go 代码。

### Ⅳ. Describe how to verify it

分别执行 `make build` `make build-push` 以验证功能。

### Ⅴ. Special notes for reviews
@johnlanni 
