### PR TITLE
cleanup: Remove redundant building configurations

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -95,9 +95,6 @@ export PARENT_GIT_REVISION:=$(TAG)
 
 export ENVOY_TAR_PATH:=/home/package/envoy.tar.gz
 
-build-istio: prebuild
-	cd external/istio; rm -rf out; GOOS_LOCAL=linux TARGET_OS=linux TARGET_ARCH=amd64 BUILD_WITH_CONTAINER=1 DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.pilot" make docker
-
 external/package/envoy.tar.gz:
 	cd external/proxy; BUILD_WITH_CONTAINER=1  make test_release
 
@@ -106,16 +103,13 @@ build-gateway: prebuild external/package/envoy.tar.gz
 
 pre-install:
 	cp api/kubernetes/customresourcedefinitions.gen.yaml helm/higress/crds
-	cd helm/istio; helm dependency update
-	cd helm/kind/higress; helm dependency update
-	cd helm/kind/istio; helm dependency update
 
 define create_ns
    kubectl get namespace | grep $(1) || kubectl create namespace $(1)
 endef
 
 install: pre-install
-	helm install higress helm/kind/higress -n higress-system --create-namespace
+	helm install higress helm/higress -n higress-system --create-namespace --set-json='global.kind=true'
 
 ENVOY_LATEST_IMAGE_TAG ?= 0.6.0
 ISTIO_LATEST_IMAGE_TAG ?= 0.6.0
@@ -127,21 +121,11 @@ uninstall:
 	helm uninstall higress -n higress-system
 
 upgrade: pre-install
-	helm upgrade higress helm/kind/higress -n higress-system
+	helm upgrade higress helm/higress -n higress-system --set-json='global.kind=true'
 
 helm-push:
 	cp api/kubernetes/customresourcedefinitions.gen.yaml helm/higress/crds
 	cd helm; tar -zcf higress.tgz higress; helm push higress.tgz "oci://$(CHARTS)"
-
-helm-push-istio:
-	cd helm/istio; helm dependency update
-	cd helm; tar -zcf istio.tgz istio; helm push istio.tgz "oci://$(CHARTS)"
-
-helm-push-kind:
-	cd helm/kind/higress; helm dependency update
-	cd helm/kind; tar -zcf higress.tgz higress; helm push higress.tgz "oci://$(CHARTS)"
-	cd helm/kind/istio; helm dependency update
-	cd helm/kind; tar -zcf istio.tgz istio; helm push istio.tgz "oci://$(CHARTS)"
 
 cue = cue-gen -paths=./external/api/common-protos
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

1. Remove istio related building process.
2. Replace kind/higress chart with higress chart and corresponding --set arguments.

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews