### PR TITLE
e2e: add e2e test for fallback annotations

### DIFF
--- a/test/ingress/conformance/tests/httproute-default-backend.go
+++ b/test/ingress/conformance/tests/httproute-default-backend.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/test/ingress/conformance/utils/http"
+	"github.com/alibaba/higress/test/ingress/conformance/utils/suite"
+)
+
+func init() {
+	HigressConformanceTests = append(HigressConformanceTests, HTTPRouteDefaultBackend)
+}
+
+var HTTPRouteDefaultBackend = suite.ConformanceTest{
+	ShortName:   "HTTPRouteDefaultBackend",
+	Description: "A single Ingress in the higress-conformance-infra namespace demonstrates default backend.",
+	Manifests:   []string{"tests/httproute-default-backend.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		testcases := []http.Assertion{
+			{
+				Meta: http.AssertionMeta{
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/bar",
+						Host: "test.higress.io",
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			}, {
+				Meta: http.AssertionMeta{
+					TargetBackend:   "infra-backend-v2",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/foo",
+						Host: "test.higress.io",
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+						Headers:    map[string]string{"X-Code": "503"},
+					},
+				},
+			},
+		}
+
+		t.Run("Enable default backend", func(t *testing.T) {
+			for _, testcase := range testcases {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcase)
+			}
+		})
+
+	},
+}

--- a/test/ingress/conformance/tests/httproute-default-backend.yaml
+++ b/test/ingress/conformance/tests/httproute-default-backend.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/default-backend: infra-backend-v2
+    nginx.ingress.kubernetes.io/custom-http-errors: "301,400,404,415,503"
+  name: ingress-enable-default-backend
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: test.higress.io
+      http:
+        paths:
+          - path: /bar
+            pathType: Exact
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+          - path: /foo
+            pathType: Exact
+            backend:
+              service:
+                name: invalid   # to simulate the server is 503
+                port:
+                  number: 8080

--- a/test/ingress/e2e_test.go
+++ b/test/ingress/e2e_test.go
@@ -69,6 +69,7 @@ func TestHigressConformanceTests(t *testing.T) {
 		tests.HTTPRouteCanaryHeaderWithCustomizedHeader,
 		tests.HTTPRouteWhitelistSourceRange,
 		tests.HTTPRouteCanaryWeight,
+		tests.HTTPRouteDefaultBackend,
 	}
 
 	cSuite.Run(t, higressTests)


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

add an e2e test for `nginx.ingress.kubernetes.io/default-backend` && `nginx.ingress.kubernetes.io/custom-http-errors`

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #193 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

