### PR TITLE
feat: Add oras binary into wasm-go-builder image for OCI image building

### DIFF
--- a/plugins/wasm-go/DockerfileBuilder
+++ b/plugins/wasm-go/DockerfileBuilder
@@ -1,53 +1,62 @@
 # The Dockerfile for wasm-go builder only support amd64 and arm64 yet.
 # If you want to build on another architecture, the following information may be helpful.
 #
-# - arch: amd64 \
+# - arch: amd64
 #   base image: docker.io/ubuntu
 #   go_url: https://golang.google.cn/dl/go1.20.1.linux-amd64.tar.gz"
 #   tinygo_url: https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_amd64.deb
+#   oras_url: https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_amd64.tar.gz
 #
 # - arch: arm64
 #   base image: docker.io/ubuntu
 #   go_url: https://golang.google.cn/dl/go1.20.1.linux-arm64.tar.gz
 #   tinygo_url: https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_arm64.deb
+#   oras_url: https://github.com/oras-project/oras/releases/download/v1.0.0/oras_1.0.0_linux_arm64.tar.gz
 #
 # - arch: armel
 #   base image: build yourself
 #   go_url: install from source code
 #   tinygo_url: build yourself
+#   oras_url: build your self
 #
 # - arch: i386
 #   base image: build yourself
 #   go_url: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
 #   tinygo_url: build yourself
+#   oras_url: build your self
 #
 # - arch: mips64el
 #   base image: build your self
 #   go_url: https://dl.google.com/go/go1.20.1.linux-386.tar.gz
 #   tinygo_url: build your self
+#   oras_url: build your self
 #
 # - arch: ppc64el
 #   base image: build your self
 #   go_url: https://dl.google.com/go/go1.20.1.linux-ppc64le.tar.gz
 #   tinygo_url: build your self
+#   oras_url: build your self
 #
 # - arch: s390x
 #   base image: docker.io/ubuntu
 #   go_url: https://dl.google.com/go/go1.20.1.linux-s390x.tar.gz
 #   tinygo_url: build your self
+#   oras_url: build your self
 #
 # - arch: armhf
 #   base image: build your self
 #   go_url: https://golang.google.cn/dl/go1.20.1.linux-armv6l.tar.gz
 #   tinygo_url: https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_armhf.deb
+#   oras_url: build your self
 
 ARG BASE_IMAGE=docker.io/ubuntu
 FROM $BASE_IMAGE
 
 ARG GO_VERSION
 ARG TINYGO_VERSION
+ARG ORAS_VERSION
 
-LABEL go_version=$GO_VERSION tinygo_version=$TINYGO_VERSION
+LABEL go_version=$GO_VERSION tinygo_version=$TINYGO_VERSION oras_version=$ORAS_VERSION
 
 RUN apt-get update \
   && apt-get install -y wget build-essential \
@@ -59,26 +68,33 @@ RUN arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
     tinygo_url=; \
     go_version=${GO_VERSION:-1.19}; \
     tinygo_version=${TINYGO_VERSION:-0.27.0}; \
+    oras_version=${ORAS_VERSION:-1.0.0}; \
     echo "arch:           '$arch'"; \
     echo "go go_version:  '$go_version'"; \
     echo "tinygo_version: '$tinygo_version'"; \
+    echo "oras_version: '$oras_version'"; \
 	case "$arch" in \
 		'amd64') \
             go_url="https://golang.google.cn/dl/go$go_version.linux-amd64.tar.gz"; \
             tinygo_url="https://github.com/tinygo-org/tinygo/releases/download/v$tinygo_version/tinygo_${tinygo_version}_amd64.deb"; \
+            oras_url="https://github.com/oras-project/oras/releases/download/v$oras_version/oras_${oras_version}_linux_amd64.tar.gz"; \
 			;; \
 		'arm64') \
             go_url="https://golang.google.cn/dl/go$go_version.linux-arm64.tar.gz"; \
             tinygo_url="https://github.com/tinygo-org/tinygo/releases/download/v$tinygo_version/tinygo_${tinygo_version}_arm64.deb"; \
+            oras_url="https://github.com/oras-project/oras/releases/download/v$oras_version/oras_${oras_version}_linux_arm64.tar.gz"; \
 			;; \
 		*) echo >&2 "error: unsupported architecture '$arch' "; exit 1 ;; \
 	esac; \
     echo "go_url: '$go_url'"; \
     echo "tinygo_url: '$tinygo_url'"; \
+    echo "oras_url: '$oras_url'"; \
     wget -O go.tgz "$go_url" --progress=dot:giga; \
     wget -O tinygo.deb "$tinygo_url" --progress=dot:giga; \
+    wget -O oras.tgz "$oras_url" --progress=dot:giga; \
     echo "Download complete"; \
     rm -rf /usr/local/go && tar -C /usr/local -xzf go.tgz && rm -rf go.tgz; \
+    tar -C /usr/local/bin -xzf oras.tgz && rm -rf oras.tgz; \
     dpkg -i tinygo.deb && rm -rf tinygo.deb
 
 ENV PATH=$PATH:/usr/local/go/bin:/usr/local/bin


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Add oras binary into wasm-go-builder image for OCI image building

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

