### PR TITLE
ci: enable building files caching

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -23,6 +23,28 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Setup Golang Caches
+      uses: actions/cache@v3
+      with:
+        path: |-
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ github.run_id }}
+        restore-keys: ${{ runner.os }}-go
+
+    - name: Setup Submodule Caches
+      uses: actions/cache@v3
+      with:
+        path: |-
+            envoy
+            istio
+            external
+            .git/modules
+        key: ${{ runner.os }}-submodules-${{ github.run_id }}
+        restore-keys: ${{ runner.os }}-submodules
+    
+    - run: git stash # restore patch
+
     # test
     - name: Run Coverage Tests
       run: GOPROXY="https://proxy.golang.org,direct" make go.test.coverage
@@ -38,15 +60,37 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint,coverage-test]
     steps:
+      - name: "Checkout ${{ github.ref }}"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
       - name: "Setup Go"
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
 
-      - name: "checkout ${{ github.ref }}"
-        uses: actions/checkout@v3
+      - name: Setup Golang Caches
+        uses: actions/cache@v3
         with:
-          fetch-depth: 2
+          path: |-
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-go
+
+      - name: Setup Submodule Caches
+        uses: actions/cache@v3
+        with:
+          path: |-
+            envoy
+            istio
+            external
+            .git/modules
+          key: ${{ runner.os }}-submodules-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-submodules
+
+      - run: git stash # restore patch
 
       - name: "Build Higress Binary"
         run: GOPROXY="https://proxy.golang.org,direct" make build
@@ -67,14 +111,39 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
+    - uses: actions/checkout@v3
+      
     - name: "Setup Go"
       uses: actions/setup-go@v3
       with:
         go-version: 1.19
-    - uses: actions/checkout@v3
+
+    - name: Setup Golang Caches
+      uses: actions/cache@v3
+      with:
+        path: |-
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-go
+      
+    - name: Setup Submodule Caches
+      uses: actions/cache@v3
+      with:
+        path: |-
+            envoy
+            istio
+            external
+            .git/modules
+        key: ${{ runner.os }}-submodules-${{ github.run_id }}
+        restore-keys: ${{ runner.os }}-submodules
+          
+    - run: git stash # restore patch
+
     - name: "Run Ingress Conformance Tests"
       run: GOPROXY="https://proxy.golang.org,direct" make ingress-conformance-test
-
+      
   publish:
     runs-on: ubuntu-latest
     needs: [ingress-conformance-test,gateway-conformance-test]


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Cache go dependencies and compile caches, submodules and prebuild artifacts. The workflow can be completed within **ten minutes** after the cache is ready. 

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
no

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
no

### Ⅳ. Describe how to verify it
When the cache is ready, a significant reduction in workflow runtime can be observed.

### Ⅴ. Special notes for reviews
Two tricks are used here to accomplish expectations:
1. `.git/modules` is cached to ensure that `git submodule update -init` runs correctly.
2. `git stash` will be run after the cache is pulled to avoid patches files being overwritten by the cache.

These two points require additional testing to avoid unexpected errors. I will reply here with the test results after a brief test.
