### PR TITLE
fix: Fix e2e 'request header control' and add some testcases

### DIFF
--- a/test/ingress/conformance/tests/httproute-request-header-control.go
+++ b/test/ingress/conformance/tests/httproute-request-header-control.go
@@ -32,6 +32,12 @@ var HTTPRouteRequestHeaderControl = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		testcases := []http.Assertion{
 			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 1: add one",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+
 				Request: http.AssertionRequest{
 					ActualRequest: http.Request{
 						Path: "/foo1",
@@ -39,6 +45,8 @@ var HTTPRouteRequestHeaderControl = suite.ConformanceTest{
 					},
 					ExpectedRequest: &http.ExpectedRequest{
 						Request: http.Request{
+							Path: "/foo1",
+							Host: "foo.com",
 							Headers: map[string]string{
 								"stage": "test",
 							},
@@ -53,6 +61,12 @@ var HTTPRouteRequestHeaderControl = suite.ConformanceTest{
 				},
 			},
 			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 2: add more",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+
 				Request: http.AssertionRequest{
 					ActualRequest: http.Request{
 						Path: "/foo2",
@@ -60,6 +74,8 @@ var HTTPRouteRequestHeaderControl = suite.ConformanceTest{
 					},
 					ExpectedRequest: &http.ExpectedRequest{
 						Request: http.Request{
+							Path: "/foo2",
+							Host: "foo.com",
 							Headers: map[string]string{
 								"stage":  "test",
 								"canary": "true",
@@ -75,6 +91,12 @@ var HTTPRouteRequestHeaderControl = suite.ConformanceTest{
 				},
 			},
 			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 3: update one",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+
 				Request: http.AssertionRequest{
 					ActualRequest: http.Request{
 						Path: "/foo3",
@@ -85,9 +107,10 @@ var HTTPRouteRequestHeaderControl = suite.ConformanceTest{
 					},
 					ExpectedRequest: &http.ExpectedRequest{
 						Request: http.Request{
+							Path: "/foo3",
+							Host: "foo.com",
 							Headers: map[string]string{
-								"stage":  "pro",
-								"canary": "true",
+								"stage": "pro",
 							},
 						},
 					},
@@ -100,16 +123,91 @@ var HTTPRouteRequestHeaderControl = suite.ConformanceTest{
 				},
 			},
 			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 4: update more",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+
 				Request: http.AssertionRequest{
 					ActualRequest: http.Request{
 						Path: "/foo4",
+						Host: "foo.com",
+						Headers: map[string]string{
+							"stage":  "test",
+							"canary": "true",
+						},
+					},
+					ExpectedRequest: &http.ExpectedRequest{
+						Request: http.Request{
+							Path: "/foo4",
+							Host: "foo.com",
+							Headers: map[string]string{
+								"stage":  "pro",
+								"canary": "false",
+							},
+						},
+					},
+				},
+
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 5: remove one",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/foo5",
 						Host: "foo.com",
 						Headers: map[string]string{
 							"stage": "test",
 						},
 					},
 					ExpectedRequest: &http.ExpectedRequest{
+						Request: http.Request{
+							Path: "/foo5",
+							Host: "foo.com",
+						},
 						AbsentHeaders: []string{"stage"},
+					},
+				},
+
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 6: remove more",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/foo6",
+						Host: "foo.com",
+						Headers: map[string]string{
+							"stage":  "test",
+							"canary": "true",
+						},
+					},
+					ExpectedRequest: &http.ExpectedRequest{
+						Request: http.Request{
+							Path: "/foo6",
+							Host: "foo.com",
+						},
+						AbsentHeaders: []string{"stage", "canary"},
 					},
 				},
 

--- a/test/ingress/conformance/tests/httproute-request-header-control.yaml
+++ b/test/ingress/conformance/tests/httproute-request-header-control.yaml
@@ -61,7 +61,7 @@ kind: Ingress
 metadata:
   annotations:
     higress.io/request-header-control-update: stage pro
-  name: httproute-request-header-control-update
+  name: httproute-request-header-control-update-one
   namespace: higress-conformance-infra
 spec:
   ingressClassName: higress
@@ -81,8 +81,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    higress.io/request-header-control-remove: stage
-  name: httproute-request-header-control-remove
+    higress.io/request-header-control-update: |
+      stage pro
+      canary false
+  name: httproute-request-header-control-update-more
   namespace: higress-conformance-infra
 spec:
   ingressClassName: higress
@@ -92,6 +94,48 @@ spec:
         paths:
           - pathType: Exact
             path: "/foo4"
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    higress.io/request-header-control-remove: stage
+  name: httproute-request-header-control-remove-one
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "foo.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/foo5"
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    higress.io/request-header-control-remove: stage,canary
+  name: httproute-request-header-control-remove-more
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "foo.com"
+      http:
+        paths:
+          - pathType: Exact
+            path: "/foo6"
             backend:
               service:
                 name: infra-backend-v1

--- a/test/ingress/e2e_test.go
+++ b/test/ingress/e2e_test.go
@@ -72,6 +72,7 @@ func TestHigressConformanceTests(t *testing.T) {
 		tests.HTTPRouteMatchPath,
 		tests.HttpForceRedirectHttps,
 		tests.HttpRedirectAsHttps,
+		tests.HTTPRouteRequestHeaderControl,
 	}
 
 	cSuite.Run(t, higressTests)


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

FIxes #343 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

Test Results:

```bash
--- PASS: TestHigressConformanceTests (38.56s)
    --- PASS: TestHigressConformanceTests/HTTPRouteSimpleSameNamespace (4.21s)
        --- PASS: TestHigressConformanceTests/HTTPRouteSimpleSameNamespace/Simple_HTTP_request_should_reach_infra-backend (4.20s)
    --- PASS: TestHigressConformanceTests/HTTPRouteHostNameSameNamespace (1.43s)
        --- PASS: TestHigressConformanceTests/HTTPRouteHostNameSameNamespace/HTTP_request_should_reach_infra-backend_with_different_hostname (1.42s)
    --- PASS: TestHigressConformanceTests/HTTPRouteRewritePath (1.09s)
        --- PASS: TestHigressConformanceTests/HTTPRouteRewritePath/Rewrite_HTTPRoute_Path (1.08s)
    --- PASS: TestHigressConformanceTests/HTTPRouteRewriteHost (1.13s)
        --- PASS: TestHigressConformanceTests/HTTPRouteRewriteHost/Rewrite_HTTPRoute_Host (1.11s)
    --- PASS: TestHigressConformanceTests/HTTPRouteCanaryHeader (1.18s)
        --- PASS: TestHigressConformanceTests/HTTPRouteCanaryHeader/Canary_HTTPRoute_Traffic_Split (1.16s)
    --- PASS: TestHigressConformanceTests/HTTPRouteEnableCors (1.16s)
        --- PASS: TestHigressConformanceTests/HTTPRouteEnableCors/Enable_Cors_Cases_Split (1.11s)
    --- PASS: TestHigressConformanceTests/HTTPRouteEnableIgnoreCase (1.13s)
        --- PASS: TestHigressConformanceTests/HTTPRouteEnableIgnoreCase/Enable_IgnoreCase_Cases_Split (1.12s)
    --- PASS: TestHigressConformanceTests/HTTPRouteMatchMethods (1.10s)
        --- PASS: TestHigressConformanceTests/HTTPRouteMatchMethods/Match_HTTPRoute_by_methods (1.09s)
    --- PASS: TestHigressConformanceTests/HTTPRouteMatchQueryParams (1.09s)
        --- PASS: TestHigressConformanceTests/HTTPRouteMatchQueryParams/Match_HTTPRoute_by_queryParams (1.08s)
    --- PASS: TestHigressConformanceTests/HTTPRouteMatchHeaders (1.10s)
        --- PASS: TestHigressConformanceTests/HTTPRouteMatchHeaders/Match_HTTPRoute_by_headers (1.09s)
    --- PASS: TestHigressConformanceTests/HTTPRouteAppRoot (1.04s)
        --- PASS: TestHigressConformanceTests/HTTPRouteAppRoot/HTTPRoute_app_root (1.03s)
    --- PASS: TestHigressConformanceTests/HTTPRoutePermanentRedirect (1.07s)
        --- PASS: TestHigressConformanceTests/HTTPRoutePermanentRedirect/HTTPRoute_permanent_redirect (1.06s)
    --- PASS: TestHigressConformanceTests/HTTPRoutePermanentRedirectCode (1.04s)
        --- PASS: TestHigressConformanceTests/HTTPRoutePermanentRedirectCode/HTTPRoute_permanent_redirect_code (1.04s)
    --- PASS: TestHigressConformanceTests/HTTPRouteTemporalRedirect (1.04s)
        --- PASS: TestHigressConformanceTests/HTTPRouteTemporalRedirect/HTTPRoute_temporal_redirect (1.02s)
    --- PASS: TestHigressConformanceTests/HTTPRouteSameHostAndPath (1.19s)
        --- PASS: TestHigressConformanceTests/HTTPRouteSameHostAndPath/Match_Routes_With_same_host_and_path (1.12s)
    --- PASS: TestHigressConformanceTests/HTTPRouteCanaryHeaderWithCustomizedHeader (1.18s)
        --- PASS: TestHigressConformanceTests/HTTPRouteCanaryHeaderWithCustomizedHeader/Canary_HTTPRoute_Traffic_Split_With_customized_header (1.14s)
    --- PASS: TestHigressConformanceTests/HTTPRouteWhitelistSourceRange (1.09s)
        --- PASS: TestHigressConformanceTests/HTTPRouteWhitelistSourceRange/HTTP_request_should_reach_infra-backend_with_different_hostname (1.07s)
    --- PASS: TestHigressConformanceTests/HTTPRouteCanaryWeight (1.13s)
        --- PASS: TestHigressConformanceTests/HTTPRouteCanaryWeight/Canary_HTTPRoute_Traffic_Split (1.10s)
    --- PASS: TestHigressConformanceTests/HTTPRouteMatchPath (1.13s)
        --- PASS: TestHigressConformanceTests/HTTPRouteMatchPath/HTTPRoute_Match_different_path_Cases (1.12s)
    --- PASS: TestHigressConformanceTests/HttpForceRedirectHttps (1.08s)
        --- PASS: TestHigressConformanceTests/HttpForceRedirectHttps/HTTPFORCEREDIRCTHTTPS (1.01s)
    --- PASS: TestHigressConformanceTests/HttpRedirectAsHttps (0.02s)
        --- PASS: TestHigressConformanceTests/HttpRedirectAsHttps/HTTPREDIRCTASHTTPS (0.00s)
    --- PASS: TestHigressConformanceTests/HTTPRouteRequestHeaderControl (1.23s)
        --- PASS: TestHigressConformanceTests/HTTPRouteRequestHeaderControl/Request_header_control (1.19s)

```

### Ⅴ. Special notes for reviews

