### PR TITLE
feat: Support building and pushing Higress docker images via GitHub actions

### DIFF
--- a/.github/workflows/build-image-and-push.yaml
+++ b/.github/workflows/build-image-and-push.yaml
@@ -1,0 +1,142 @@
+name: Build Docker Images and Push to Image Registry
+
+on:
+  push:
+    tags:
+    - "v*.*.*"
+  workflow_dispatch: ~
+
+jobs:
+  build-controller-image:
+    runs-on: ubuntu-latest
+    environment:
+      name: image-registry-controller
+    env:
+      CONTROLLER_IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
+      CONTROLLER_IMAGE_NAME: ${{ vars.CONTROLLER_IMAGE_NAME || 'higress/higress' }}
+    steps:
+      - name: "Checkout ${{ github.ref }}"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: "Setup Go"
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Setup Golang Caches
+        uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-go
+
+      - name: Setup Submodule Caches
+        uses: actions/cache@v3
+        with:
+          path: |-
+            envoy
+            istio
+            external
+            .git/modules
+          key: ${{ runner.os }}-submodules-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-submodules
+
+      - name: Calculate Docker metadata
+        id: docker-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.CONTROLLER_IMAGE_REGISTRY }}/${{ env.CONTROLLER_IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.CONTROLLER_IMAGE_REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build Docker Image and Push
+        run: |
+          GOPROXY="https://proxy.golang.org,direct" make docker-build
+          BUILT_IMAGE="higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/higress"
+          readarray -t IMAGES <<< "${{ steps.docker-meta.outputs.tags }}"
+          for image in ${IMAGES[@]}; do
+            docker tag $BUILT_IMAGE:$GITHUB_SHA $image
+            docker push $image
+          done
+
+  build-pilot-image:
+    runs-on: ubuntu-latest
+    environment:
+      name: image-registry-pilot
+    env:
+      PILOT_IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
+      PILOT_IMAGE_NAME: ${{ vars.PILOT_IMAGE_NAME || 'higress/pilot' }}
+    steps:
+      - name: "Checkout ${{ github.ref }}"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: "Setup Go"
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Setup Golang Caches
+        uses: actions/cache@v3
+        with:
+          path: |-
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-go
+
+      - name: Setup Submodule Caches
+        uses: actions/cache@v3
+        with:
+          path: |-
+            envoy
+            istio
+            external
+            .git/modules
+          key: ${{ runner.os }}-submodules-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-submodules
+
+      - name: Calculate Docker metadata
+        id: docker-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.PILOT_IMAGE_REGISTRY }}/${{ env.PILOT_IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.PILOT_IMAGE_REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build Docker Image and Push
+        run: |
+          sudo GOPROXY="https://proxy.golang.org,direct" make build-istio
+          BUILT_IMAGE="higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/pilot"
+          readarray -t IMAGES <<< "${{ steps.docker-meta.outputs.tags }}"
+          for image in ${IMAGES[@]}; do
+            docker tag $BUILT_IMAGE:$GITHUB_SHA $image
+            docker push $image
+          done

--- a/.github/workflows/deploy-to-oss.yaml
+++ b/.github/workflows/deploy-to-oss.yaml
@@ -4,10 +4,13 @@ on:
   push:
     tags:
     - "v*.*.*"
+  workflow_dispatch: ~
 
 jobs:
   deploy-to-oss:
     runs-on: ubuntu-latest
+    environment:
+      name: oss
     steps:
       # Step 1
       - name: Checkout

--- a/istio/1.12/patches/istio/20221027-init.patch
+++ b/istio/1.12/patches/istio/20221027-init.patch
@@ -140,7 +140,7 @@ index 25479439b7..bd34442260 100755
  
  # This script builds and version stamps the output
  
-+export GOPROXY="https://proxy.golang.com.cn,direct"
++export GOPROXY=${GOPROXY:-"https://proxy.golang.com.cn,direct"}
 +
  VERBOSE=${VERBOSE:-"0"}
  V=""
@@ -215,10 +215,11 @@ index 271fe77a2d..c9e625efdc 100755
      --init \
      --sig-proxy=true \
      ${DOCKER_SOCKET_MOUNT:--v /var/run/docker.sock:/var/run/docker.sock} \
-@@ -55,7 +59,15 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
+@@ -55,7 +59,16 @@ read -ra DOCKER_RUN_OPTIONS <<< "${DOCKER_RUN_OPTIONS:-}"
      --env-file <(env | grep -v ${ENV_BLOCKLIST}) \
      -e IN_BUILD_CONTAINER=1 \
      -e TZ="${TIMEZONE:-$TZ}" \
++    -e GOPROXY="${GOPROXY}" \
 +    -e HUB="${HUB}" \
 +    -e ENVOY_TAR_PATH="${ENVOY_TAR_PATH}" \
 +    --mount "type=bind,source=${MOUNT_PACKAGE_SOURCE},destination=/home/package" \


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Support building and pushing Higress docker images via GitHub actions. Since building gateway images is time consuming and cannot finish within the timeout of 4 hrs, only controller and pilot images are supported in the implementation.

And the implementation uses environments with review enabled to support on-demand image building. So to make it work, alibaba/higress repo needs to have following environments created and review enabled:
- image-registry-controller
- image-registry-pilot
- oss

![image](https://github.com/alibaba/higress/assets/2909796/a149b66f-9dc4-46ae-97a0-99a3707f1c67)
![image](https://github.com/alibaba/higress/assets/2909796/29836896-2ffd-4aaf-be5e-16c043703674)

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

