### PR TITLE
fix: split `REGISTRY` into `BUILDER_REGISTRY` and `REGISTRY`

### DIFF
--- a/plugins/wasm-go/Makefile
+++ b/plugins/wasm-go/Makefile
@@ -1,11 +1,12 @@
 PLUGIN_NAME ?= hello-world
-REGISTRY ?= higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/
+BUILDER_REGISTRY ?= higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/
+REGISTRY ?=
 GO_VERSION ?= 1.19
 TINYGO_VERSION ?= 0.25.0
 ORAS_VERSION ?= 1.0.0
 HIGRESS_VERSION ?= 1.0.0-rc
 USE_HIGRESS_TINYGO ?= true
-BUILDER ?= ${REGISTRY}wasm-go-builder:go${GO_VERSION}-tinygo${TINYGO_VERSION}-oras${ORAS_VERSION}
+BUILDER ?= ${BUILDER_REGISTRY}wasm-go-builder:go${GO_VERSION}-tinygo${TINYGO_VERSION}-oras${ORAS_VERSION}
 BUILD_TIME := $(shell date "+%Y%m%d-%H%M%S")
 COMMIT_ID := $(shell git rev-parse --short HEAD 2>/dev/null)
 IMAGE_TAG = $(if $(strip $(PLUGIN_VERSION)),${PLUGIN_VERSION},${BUILD_TIME}-${COMMIT_ID})

--- a/plugins/wasm-go/README_EN.md
+++ b/plugins/wasm-go/README_EN.md
@@ -29,11 +29,11 @@ You can also use `make build-push` to build and push the image at the same time.
 
 ### Environmental parameters
 
-| Name          | Optional/Required | Default                                                                                                      | 含义                                                                                                                                  |
-|---------------|-------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| `PLUGIN_NAME` | Optional          | hello-world                                                                                                  | The name of the plugin to build.                                                                                                    |
-| `REGISTRY`    | Optional          | empty                                                                                                        | The regitstry address of the generated image, e.g. `example.registry.io/my-name/`.  Note that the REGISTRY value should end with /. |
-| `IMG`         | Optional          | If it is empty, it is generated based on the repository address, plugin name, build time, and git commit id. | The generated image tag will override the `REGISTRY` parameter if it is not empty.                                                  |
+| Name          | Optional/Required | Default                                                                                                      | meaning                                                                                                                              |
+|---------------|---------------|--------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `PLUGIN_NAME` | Optional      | hello-world                                                                                                  | The name of the plugin to build.                                                                                                     |
+| `REGISTRY`    | Optional      | empty                                                                                                        | The registry address of the generated image, e.g. `example.registry.io/my-name/`.  Note that the REGISTRY value should end with /.   |
+| `IMG`         | Optional      | If it is empty, it is generated based on the repository address, plugin name, build time, and git commit id. | The generated image tag will override the `REGISTRY` parameter if it is not empty.                                                   |
 
 ## Build on local yourself
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

As the documentation says, we can 

> The registry address of the generated image, e.g. `example.registry.io/my-name/`. Note that the REGISTRY value should end with /.

But in the Makefile, `REGISTRY` specifies both the registry of builder and the registry of artifact.

For most users, they may not want to set the builder registry and output image registry to be the same, so it is necessary to separate them.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

