### PR TITLE
feat: support rewrite config after `parse_rule_config` invoked

### DIFF
--- a/plugins/wasm-rust/src/rule_matcher.rs
+++ b/plugins/wasm-rust/src/rule_matcher.rs
@@ -163,6 +163,17 @@ where
         return self.global_config.as_ref();
     }
 
+    pub fn rewrite_config(&mut self, rewrite: fn(config: &PluginConfig) -> PluginConfig) {
+        self.global_config = match self.global_config.as_ref() {
+            None => None,
+            Some(config) => Some(rewrite(config))
+        };
+
+        for rule_config in &mut self.rule_config {
+            rule_config.config = rewrite(&rule_config.config);
+        }
+    }
+
     fn parse_route_match_config(config: &Value) -> HashSet<String> {
         let empty_vec = Vec::new();
         let keys = config[MATCH_ROUTE_KEY].as_array().unwrap_or(&empty_vec);


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Support rewrite config after `parse_rule_config` invoked. 

The configuration we usually get just describes what we want to do, but at runtime we have many efficient data structures to allow us to complete these tasks more efficiently. For example, there is a coverage relationship between CIDRs, so we only need to keep the one with the largest coverage interval. In addition, for string matching, Radix Trie is far more efficient than list matching, and this needs to be rewritten after the configuration is parsed.

There is no other way for extensions to do the rewriting, because both `global_config` and `rule_config` belong to `rule_matcher`, and they are not public (and cannot be public). So we need a mapping function to do the rewriting. `fn(config: &PluginConfig) -> PluginConfig` is not `&mut` intentional, I always think that pure functions can simplify the user's mind.

There is an example that how to rewrite config

```rust
#[derive(Default, Debug, Deserialize)]
struct DemoConfig {
    words: Vec<String>,
    trie: Option<Trie> // fields need rewrite should be `Option` because they are not actual configuraion
}

struct DemoRoot { /* rule_matcher and other fields are ignored */ }

impl RootContext for DemoRoot {
    fn on_configure(&mut self, _plugin_configuration_size: usize) -> bool {
        /* codes with invoking parse_rule_config... */

        rule_matcher.rewrite_config(|config| {
            let trie = covert(config.words);
            DemoConfig {
                words: vec![],    // there is no need to still hold words
                trie: Some(trie)
            }
        });

        true
    }
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

