### PR TITLE
fix: fix kubetype-gen for http2rpc wrong plural value issue

### DIFF
--- a/api/networking/v1/http_2_rpc.pb.go
+++ b/api/networking/v1/http_2_rpc.pb.go
@@ -30,7 +30,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 // +cue-gen:Http2Rpc:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Http2Rpc:subresource:status
 // +cue-gen:Http2Rpc:scope:Namespaced
-// +cue-gen:Http2Rpc:resource:categories=higress-io,plural=Http2Rpcs
+// +cue-gen:Http2Rpc:resource:categories=higress-io,plural=http2rpcs
 // +cue-gen:Http2Rpc:preserveUnknownFields:false
 // -->
 //

--- a/api/networking/v1/http_2_rpc.proto
+++ b/api/networking/v1/http_2_rpc.proto
@@ -32,7 +32,7 @@ option go_package = "github.com/alibaba/higress/api/networking/v1";
 // +cue-gen:Http2Rpc:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Http2Rpc:subresource:status
 // +cue-gen:Http2Rpc:scope:Namespaced
-// +cue-gen:Http2Rpc:resource:categories=higress-io,plural=Http2Rpcs
+// +cue-gen:Http2Rpc:resource:categories=higress-io,plural=http2rpcs
 // +cue-gen:Http2Rpc:preserveUnknownFields:false
 // -->
 //

--- a/client/pkg/apis/networking/v1/types.gen.go
+++ b/client/pkg/apis/networking/v1/types.gen.go
@@ -32,7 +32,7 @@ import (
 // +cue-gen:Http2Rpc:annotations:helm.sh/resource-policy=keep
 // +cue-gen:Http2Rpc:subresource:status
 // +cue-gen:Http2Rpc:scope:Namespaced
-// +cue-gen:Http2Rpc:resource:categories=higress-io,plural=Http2Rpcs
+// +cue-gen:Http2Rpc:resource:categories=higress-io,plural=http2rpcs
 // +cue-gen:Http2Rpc:preserveUnknownFields:false
 // -->
 //


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
fix kubetype-gen for http2rpc wrong plural value issue

### Ⅱ. Does this pull request fix one issue?
NO

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
NO

### Ⅳ. Describe how to verify it
NO

### Ⅴ. Special notes for reviews
NO
