### PR TITLE
fix: Fix the incorrect default metrics port shown in the usage

### DIFF
--- a/tools/get-higress.sh
+++ b/tools/get-higress.sh
@@ -99,7 +99,7 @@ outputUsage() {
                             default to 443 if unspecified
      --gateway-metrics-port=GATEWAY-METRICS-PORT
                             the metrics port to be listened by the gateway
-                            default to 15012 if unspecified
+                            default to 15020 if unspecified
      --console-port=CONSOLE-PORT
                             the port used to visit Higress Console
                             default to 8080 if unspecified


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Fix the incorrect default metrics port shown in the usage.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

