### PR TITLE
fix: Always use the latest CRDs file when deploying helm chart to OSS

### DIFF
--- a/.github/workflows/deploy-to-oss.yaml
+++ b/.github/workflows/deploy-to-oss.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           helmv3: 3.7.2
           command: |
+            cp api/kubernetes/customresourcedefinitions.gen.yaml helm/core/crds
             helmv3 repo add higress.io https://higress.io/helm-charts
             helmv3 package helm/core --debug --app-version ${{steps.calc-version.outputs.version}} --version ${{steps.calc-version.outputs.version}} -d ./artifact
             helmv3 dependency build helm/higress

--- a/helm/core/crds/customresourcedefinitions.gen.yaml
+++ b/helm/core/crds/customresourcedefinitions.gen.yaml
@@ -213,7 +213,16 @@ spec:
               registries:
                 items:
                   properties:
+                    authSecretName:
+                      type: string
+                    consulDatacenter:
+                      type: string
                     consulNamespace:
+                      type: string
+                    consulRefreshInterval:
+                      format: int64
+                      type: integer
+                    consulServiceTag:
                       type: string
                     domain:
                       type: string


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Always use the latest CRDs file when deploying helm chart to OSS.

To facilitate local testing and deployment, I keep the `helm/core/crds/customresourcedefinitions.gen.yaml` in place and update it to the latest content.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

