### PR TITLE
fix nacos connection leakage and weight setting for nacos service

### DIFF
--- a/registry/nacos/v2/watcher.go
+++ b/registry/nacos/v2/watcher.go
@@ -16,6 +16,7 @@ package v2
 
 import (
 	"errors"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -455,6 +456,7 @@ func (w *watcher) generateServiceEntry(host string, services []model.Instance) *
 			Address: service.Ip,
 			Ports:   map[string]uint32{port.Protocol: port.Number},
 			Labels:  service.Metadata,
+			Weight:  uint32(math.Ceil(service.Weight)),
 		}
 		endpoints = append(endpoints, endpoint)
 	}
@@ -491,6 +493,7 @@ func (w *watcher) Stop() {
 	}
 
 	w.isStop = true
+	w.namingClient.CloseClient()
 	close(w.stop)
 	w.Ready(false)
 }

--- a/registry/nacos/watcher.go
+++ b/registry/nacos/watcher.go
@@ -15,6 +15,7 @@
 package nacos
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -359,6 +360,7 @@ func (w *watcher) generateServiceEntry(host string, services []model.SubscribeSe
 			Address: service.Ip,
 			Ports:   map[string]uint32{port.Protocol: port.Number},
 			Labels:  service.Metadata,
+			Weight:  uint32(math.Ceil(service.Weight)),
 		}
 		endpoints = append(endpoints, &endpoint)
 	}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Fixed an error where namingClient was not closed when the nacos registry was deleted, resulting in connection leakage
Added the ability to set weights for nacos services

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #530 
fixes #529 
