### PR TITLE
feat: Use higress as the default gateway class for Gateway API integation

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -151,10 +151,16 @@ build-pilot:
 build-gateway: prebuild external/package/envoy-amd64.tar.gz external/package/envoy-arm64.tar.gz build-pilot
 	cd external/istio; BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=true DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.proxyv2" make docker
 
-build-istio: prebuild build-pilot
-	cd external/istio; BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=true DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.pilot" make docker	
+build-gateway-local: prebuild external/package/envoy-amd64.tar.gz external/package/envoy-arm64.tar.gz build-pilot
+	cd external/istio; BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=false DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.proxyv2" make docker
 
-build-wasmplugins: 
+build-istio: prebuild build-pilot
+	cd external/istio; BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=true DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.pilot" make docker
+
+build-istio-local: prebuild build-pilot
+	cd external/istio; BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=false DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.pilot" make docker
+
+build-wasmplugins:
 	./tools/hack/build-wasm-plugins.sh
 
 pre-install:

--- a/istio/1.12/patches/istio/20230922-gateway-class.patch
+++ b/istio/1.12/patches/istio/20230922-gateway-class.patch
@@ -1,0 +1,14 @@
+diff -Naur istio/pilot/pkg/config/kube/gateway/conversion.go istio_new/pilot/pkg/config/kube/gateway/conversion.go
+--- istio/pilot/pkg/config/kube/gateway/conversion.go	2023-09-22 11:06:50.400535200 +0800
++++ istio_new/pilot/pkg/config/kube/gateway/conversion.go	2023-09-22 11:07:52.954982700 +0800
+@@ -37,8 +37,8 @@
+ )
+ 
+ const (
+-	DefaultClassName = "istio"
+-	ControllerName   = "istio.io/gateway-controller"
++	DefaultClassName = "higress"
++	ControllerName   = "higress.io/gateway-controller"
+ )
+ 
+ // KubernetesResources stores all inputs to our conversion


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

1. Change the default gateway class name in istio from `istio` to `higress`.
2. Change the default gateway class controller name in istio from `istio.io/gateway-controller` to `higress.io/gateway-controller`.
3. Add two targets into Makefile so we can build images locally for testing.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

