### PR TITLE
fix: hide auto-generated completion command when run hgctl --help

### DIFF
--- a/pkg/cmd/hgctl/root.go
+++ b/pkg/cmd/hgctl/root.go
@@ -25,7 +25,7 @@ func GetRootCommand() *cobra.Command {
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,
 	}
-
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newConfigCommand())
 	rootCmd.AddCommand(newInstallCmd())


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
when run hgctl --help, it will show : 
```
Available Commands:
  completion     generate the autocompletion script for the specified shell

```
i have tested completion command which  can not work well , so hide it first.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

