### PR TITLE
Suppport fallback cluster

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -151,7 +151,7 @@ build-pilot:
 build-gateway: prebuild external/package/envoy-amd64.tar.gz external/package/envoy-arm64.tar.gz build-pilot
 	cd external/istio; BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=true DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.proxyv2" make docker
 
-build-gateway-local: prebuild external/package/envoy-amd64.tar.gz external/package/envoy-arm64.tar.gz build-pilot
+build-gateway-local: prebuild
 	cd external/istio; rm -rf out/linux_amd64; GOOS_LOCAL=linux TARGET_OS=linux BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=false DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.proxyv2" make docker
 
 build-istio: prebuild build-pilot

--- a/envoy/1.20/patches/envoy/20231008-fallback-origin-cluster.patch
+++ b/envoy/1.20/patches/envoy/20231008-fallback-origin-cluster.patch
@@ -1,0 +1,111 @@
+diff -Naur envoy/contrib/custom_cluster_plugins/cluster_fallback/source/filter.cc envoy-new/contrib/custom_cluster_plugins/cluster_fallback/source/filter.cc
+--- envoy/contrib/custom_cluster_plugins/cluster_fallback/source/filter.cc	2023-10-08 15:01:21.960871500 +0800
++++ envoy-new/contrib/custom_cluster_plugins/cluster_fallback/source/filter.cc	2023-09-27 17:03:41.613256338 +0800
+@@ -60,7 +60,7 @@
+ 
+   for (const auto& cluster_name : first_item->second) {
+     if (hasHealthHost(cluster_name)) {
+-      return base.clone(cluster_name);
++      return base.clone(cluster_name, first_item->first);
+     }
+   }
+ 
+@@ -75,7 +75,8 @@
+ 
+   auto search = clusters_config_.find(route_entry.clusterName());
+   if (search == clusters_config_.end()) {
+-    ENVOY_LOG(warn, "there is no fallback cluster config, the original routing cluster is returned");
++    ENVOY_LOG(warn,
++              "there is no fallback cluster config, the original routing cluster is returned");
+     return cluster_entry.getRouteConstSharedPtr();
+   }
+ 
+@@ -87,7 +88,7 @@
+ 
+   for (const auto& cluster_name : search->second) {
+     if (hasHealthHost(cluster_name)) {
+-      return cluster_entry.clone(cluster_name);
++      return cluster_entry.clone(cluster_name, search->first);
+     }
+   }
+ 
+diff -Naur envoy/source/common/http/headers.h envoy-new/source/common/http/headers.h
+--- envoy/source/common/http/headers.h	2023-10-08 15:01:21.968871828 +0800
++++ envoy-new/source/common/http/headers.h	2023-09-27 18:48:50.059419606 +0800
+@@ -124,6 +124,7 @@
+     const LowerCaseString TriStartTime{"req-start-time"};
+     const LowerCaseString TriRespStartTime{"resp-start-time"};
+     const LowerCaseString EnvoyOriginalHost{"original-host"};
++    const LowerCaseString HigressOriginalService{"x-higress-original-service"};
+   } AliExtendedValues;
+ #endif
+ };
+diff -Naur envoy/source/common/router/config_impl.cc envoy-new/source/common/router/config_impl.cc
+--- envoy/source/common/router/config_impl.cc	2023-10-08 15:01:21.968871828 +0800
++++ envoy-new/source/common/router/config_impl.cc	2023-09-27 18:49:18.656592237 +0800
+@@ -563,7 +563,6 @@
+         route.name());
+   }
+   // End Added
+-
+ }
+ 
+ bool RouteEntryImplBase::evaluateRuntimeMatch(const uint64_t random_value) const {
+@@ -662,6 +661,10 @@
+   }
+ 
+ #if defined(ALIMESH)
++  if (!origin_cluster_name_.empty()) {
++    headers.addCopy(Http::CustomHeaders::get().AliExtendedValues.HigressOriginalService,
++                    origin_cluster_name_);
++  }
+   headers.setReferenceKey(Http::CustomHeaders::get().AliExtendedValues.EnvoyOriginalHost,
+                           headers.getHostValue());
+ #endif
+diff -Naur envoy/source/common/router/config_impl.h envoy-new/source/common/router/config_impl.h
+--- envoy/source/common/router/config_impl.h	2023-10-08 15:01:21.968871828 +0800
++++ envoy-new/source/common/router/config_impl.h	2023-09-27 18:59:11.196893507 +0800
+@@ -584,9 +584,13 @@
+     return internal_active_redirect_policy_;
+   }
+ 
+-  RouteConstSharedPtr clone(const std::string& name) const {
+-    return std::make_shared<DynamicRouteEntry>(this, name);
++  RouteConstSharedPtr clone(const std::string& name, const std::string& origin_cluster = "") const {
++    auto entry = std::make_shared<DynamicRouteEntry>(this, name);
++    entry->setOriginClusterName(origin_cluster);
++    return entry;
+   }
++
++  void setOriginClusterName(const std::string& name) const { origin_cluster_name_ = name; }
+ #endif
+   uint32_t retryShadowBufferLimit() const override { return retry_shadow_buffer_limit_; }
+   const std::vector<ShadowPolicyPtr>& shadowPolicies() const override { return shadow_policies_; }
+@@ -787,11 +791,17 @@
+       return parent_->internalActiveRedirectPolicy();
+     }
+ 
+-    RouteConstSharedPtr clone(const std::string& name) const {
+-      return std::make_shared<Envoy::Router::RouteEntryImplBase::DynamicRouteEntry>(parent_, name);
++    RouteConstSharedPtr clone(const std::string& name,
++                              const std::string& origin_cluster = "") const {
++      auto entry =
++          std::make_shared<Envoy::Router::RouteEntryImplBase::DynamicRouteEntry>(parent_, name);
++      entry->setOriginClusterName(origin_cluster);
++      return entry;
+     }
+ 
+     virtual RouteConstSharedPtr getRouteConstSharedPtr() const { return shared_from_this(); }
++
++    void setOriginClusterName(const std::string& name) { parent_->setOriginClusterName(name); }
+ #endif
+ 
+   private:
+@@ -1039,6 +1049,7 @@
+ 
+ #if defined(ALIMESH)
+   const InternalActiveRedirectPoliciesImpl internal_active_redirect_policy_;
++  mutable std::string origin_cluster_name_;
+ #endif
+ };
+ 

--- a/istio/1.12/patches/istio/20231008-gateway-fallback.patch
+++ b/istio/1.12/patches/istio/20231008-gateway-fallback.patch
@@ -1,0 +1,90 @@
+diff -Naur istio/pilot/pkg/config/kube/gateway/conversion.go istio-new/pilot/pkg/config/kube/gateway/conversion.go
+--- istio/pilot/pkg/config/kube/gateway/conversion.go	2023-10-08 19:54:47.000000000 +0800
++++ istio-new/pilot/pkg/config/kube/gateway/conversion.go	2023-09-27 16:10:42.000000000 +0800
+@@ -18,6 +18,7 @@
+ 	"fmt"
+ 	"regexp"
+ 	"sort"
++	"strconv"
+ 	"strings"
+ 
+ 	corev1 "k8s.io/api/core/v1"
+@@ -176,7 +177,9 @@
+ 	hosts := hostnameToStringList(route.Hostnames)
+ 	for _, r := range route.Rules {
+ 		// TODO: implement rewrite, timeout, mirror, corspolicy, retries
+-		vs := &istio.HTTPRoute{}
++		vs := &istio.HTTPRoute{
++			Name: obj.Name,
++		}
+ 		for _, match := range r.Matches {
+ 			uri, err := createURIMatch(match)
+ 			if err != nil {
+@@ -246,7 +249,9 @@
+ 			}}
+ 		}
+ 
+-		route, err := buildHTTPDestination(r.BackendRefs, obj.Namespace, domain, zero)
++		fallbackCluster := obj.Annotations["higress.io/fallback-service"]
++
++		route, err := buildHTTPDestination(r.BackendRefs, obj.Namespace, domain, zero, fallbackCluster)
+ 		if err != nil {
+ 			reportError(err)
+ 			return nil
+@@ -581,11 +586,33 @@
+ 	return r
+ }
+ 
+-func buildHTTPDestination(forwardTo []k8s.HTTPBackendRef, ns string, domain string, totalZero bool) ([]*istio.HTTPRouteDestination, *ConfigError) {
++func buildHTTPDestination(forwardTo []k8s.HTTPBackendRef, ns string, domain string, totalZero bool, fallbackCluster string) ([]*istio.HTTPRouteDestination, *ConfigError) {
+ 	if forwardTo == nil {
+ 		return nil, nil
+ 	}
+ 
++	var fallbackDest *istio.Destination
++	if fallbackCluster != "" {
++		var port uint64
++		host := fallbackCluster
++		colon := strings.LastIndex(fallbackCluster, ":")
++		if colon != -1 {
++			var err error
++			port, err = strconv.ParseUint(fallbackCluster[colon+1:], 10, 32)
++			if err == nil && port > 0 && port < 65536 {
++				host = fallbackCluster[:colon]
++			}
++		}
++		fallbackDest = &istio.Destination{
++			Host: host,
++		}
++		if port > 0 {
++			fallbackDest.Port = &istio.PortSelector{
++				Number: uint32(port),
++			}
++		}
++	}
++
+ 	weights := []int{}
+ 	action := []k8s.HTTPBackendRef{}
+ 	for i, w := range forwardTo {
+@@ -612,6 +639,9 @@
+ 			Destination: dst,
+ 			Weight:      int32(weights[i]),
+ 		}
++		if fallbackDest != nil {
++			rd.FallbackClusters = append(rd.FallbackClusters, fallbackDest)
++		}
+ 		for _, filter := range fwd.Filters {
+ 			switch filter.Type {
+ 			case k8s.HTTPRouteFilterRequestHeaderModifier:
+diff -Naur istio/pilot/pkg/networking/core/v1alpha3/route/route.go istio-new/pilot/pkg/networking/core/v1alpha3/route/route.go
+--- istio/pilot/pkg/networking/core/v1alpha3/route/route.go	2023-10-08 19:54:46.000000000 +0800
++++ istio-new/pilot/pkg/networking/core/v1alpha3/route/route.go	2023-09-27 16:18:16.000000000 +0800
+@@ -669,7 +669,7 @@
+ 		}
+ 		var singleClusterConfig *fallback.ClusterFallbackConfig
+ 		var weightedClusterConfig *fallback.ClusterFallbackConfig
+-		isSupportFallback := supportFallback(node)
++		isSupportFallback := true
+ 		// Added by ingress
+ 		if len(in.Route) == 1 {
+ 			route := in.Route[0]


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Supports fallback to the specified service through annotations when the original service has no endpoint.

Example:

```yaml
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  annotations:
    higress.io/fallback-service: backend.default.svc.cluster.local:3000
  name: http
  namespace: default
spec:
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: higress-gateway
    namespace: higress-system
  rules:
  - backendRefs:
    - name: hello-00001
      weight: 50
    - name: hello-00002
      weight: 50
    matches:
    - path:
        type: PathPrefix
        value: /
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

