### PR TITLE
opt(hgctl/dashboard): avoid printing error messages cannot open browser

### DIFF
--- a/pkg/cmd/hgctl/dashboard.go
+++ b/pkg/cmd/hgctl/dashboard.go
@@ -361,7 +361,6 @@ func ClosePortForwarderOnInterrupt(fw kubernetes.PortForwarder) {
 }
 
 func openBrowser(url string, writer io.Writer, browser bool) {
-
 	fmt.Fprintf(writer, "%s\n", url)
 
 	if !browser {
@@ -379,7 +378,6 @@ func openBrowser(url string, writer io.Writer, browser bool) {
 	default:
 		fmt.Fprintf(writer, "Unsupported platform %q; open %s in your browser.\n", runtime.GOOS, url)
 	}
-
 }
 
 func openCommand(writer io.Writer, command string, args ...string) {

--- a/pkg/cmd/hgctl/dashboard.go
+++ b/pkg/cmd/hgctl/dashboard.go
@@ -390,6 +390,7 @@ func openCommand(writer io.Writer, command string, args ...string) {
 			return
 		}
 		fmt.Fprintf(writer, "Failed to open browser; open %s in your browser.\nError: %s\n", args[0], err.Error())
+		return
 	}
 
 	err = exec.Command(command, args...).Start()

--- a/pkg/cmd/hgctl/dashboard.go
+++ b/pkg/cmd/hgctl/dashboard.go
@@ -372,11 +372,11 @@ func openBrowser(url string, writer io.Writer, browser bool) {
 
 	switch runtime.GOOS {
 	case "linux":
-		err = openCommand("xdg-open", url)
+		err = openCommand(writer, "xdg-open", url)
 	case "windows":
-		err = openCommand("rundll32", "url.dll,FileProtocolHandler", url)
+		err = openCommand(writer, "rundll32", "url.dll,FileProtocolHandler", url)
 	case "darwin":
-		err = openCommand("open", url)
+		err = openCommand(writer, "open", url)
 	default:
 		fmt.Fprintf(writer, "Unsupported platform %q; open %s in your browser.\n", runtime.GOOS, url)
 	}
@@ -386,9 +386,10 @@ func openBrowser(url string, writer io.Writer, browser bool) {
 	}
 }
 
-func openCommand(command string, args ...string) error {
+func openCommand(writer io.Writer, command string, args ...string) error {
 	_, err := exec.LookPath(command)
 	if err != nil {
+		fmt.Fprintf(writer, "Could not open your browser. Please open it manually.\n")
 		return nil
 	}
 

--- a/pkg/cmd/hgctl/dashboard.go
+++ b/pkg/cmd/hgctl/dashboard.go
@@ -372,11 +372,11 @@ func openBrowser(url string, writer io.Writer, browser bool) {
 
 	switch runtime.GOOS {
 	case "linux":
-		err = exec.Command("xdg-open", url).Start()
+		err = openCommand("xdg-open", url)
 	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+		err = openCommand("rundll32", "url.dll,FileProtocolHandler", url)
 	case "darwin":
-		err = exec.Command("open", url).Start()
+		err = openCommand("open", url)
 	default:
 		fmt.Fprintf(writer, "Unsupported platform %q; open %s in your browser.\n", runtime.GOOS, url)
 	}
@@ -384,4 +384,14 @@ func openBrowser(url string, writer io.Writer, browser bool) {
 	if err != nil {
 		fmt.Fprintf(writer, "Failed to open browser; open %s in your browser.\nError: %s\n", url, err.Error())
 	}
+}
+
+func openCommand(command string, args ...string) error {
+	_, err := exec.LookPath(command)
+	if err != nil {
+		return nil
+	}
+
+	cmd := exec.Command(command, args...)
+	return cmd.Start()
 }

--- a/pkg/cmd/hgctl/dashboard.go
+++ b/pkg/cmd/hgctl/dashboard.go
@@ -361,7 +361,6 @@ func ClosePortForwarderOnInterrupt(fw kubernetes.PortForwarder) {
 }
 
 func openBrowser(url string, writer io.Writer, browser bool) {
-	var err error
 
 	fmt.Fprintf(writer, "%s\n", url)
 
@@ -372,27 +371,29 @@ func openBrowser(url string, writer io.Writer, browser bool) {
 
 	switch runtime.GOOS {
 	case "linux":
-		err = openCommand(writer, "xdg-open", url)
+		openCommand(writer, "xdg-open", url)
 	case "windows":
-		err = openCommand(writer, "rundll32", "url.dll,FileProtocolHandler", url)
+		openCommand(writer, "rundll32", "url.dll,FileProtocolHandler", url)
 	case "darwin":
-		err = openCommand(writer, "open", url)
+		openCommand(writer, "open", url)
 	default:
 		fmt.Fprintf(writer, "Unsupported platform %q; open %s in your browser.\n", runtime.GOOS, url)
 	}
 
-	if err != nil {
-		fmt.Fprintf(writer, "Failed to open browser; open %s in your browser.\nError: %s\n", url, err.Error())
-	}
 }
 
-func openCommand(writer io.Writer, command string, args ...string) error {
+func openCommand(writer io.Writer, command string, args ...string) {
 	_, err := exec.LookPath(command)
 	if err != nil {
-		fmt.Fprintf(writer, "Could not open your browser. Please open it manually.\n")
-		return nil
+		if errors.Is(err, exec.ErrNotFound) {
+			fmt.Fprintf(writer, "Could not open your browser. Please open it maually.\n")
+			return
+		}
+		fmt.Fprintf(writer, "Failed to open browser; open %s in your browser.\nError: %s\n", args[0], err.Error())
 	}
 
-	cmd := exec.Command(command, args...)
-	return cmd.Start()
+	err = exec.Command(command, args...).Start()
+	if err != nil {
+		fmt.Fprintf(writer, "Failed to open browser; open %s in your browser.\nError: %s\n", args[0], err.Error())
+	}
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Avoid printing error messages when commands do not exist.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #652 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

This is related to the presence or absence of a GUI.

### Ⅳ. Describe how to verify it

This is executed in the centos container of Docker.

![image](https://github.com/alibaba/higress/assets/88550136/e3c2facf-e774-4aec-aa4d-ff010b88ef94)

This is executed in local.

![image](https://github.com/alibaba/higress/assets/88550136/ab4fe8d0-3dae-4705-968a-b72ef903c7bb)


### Ⅴ. Special notes for reviews

