### PR TITLE
fix: Remove -p/--console-password parameters from get-higress.sh

### DIFF
--- a/tools/get-higress.sh
+++ b/tools/get-higress.sh
@@ -97,9 +97,6 @@ outputUsage() {
  -k, --data-enc-key=KEY     the key used to encrypt sensitive configurations
                             MUST contain 32 characters
                             A random key will be generated if unspecified
- -p, --console-password=CONSOLE-PASSWORD
-                            the password to be used to visit Higress Console
-                            default to "admin" if unspecified
      --nacos-port=NACOS-PORT
                             the HTTP port used to access the built-in Nacos
                             default to 8848 if unspecified


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Remove -p/--console-password parameters from get-higress.sh since Higress Console now provides an admin initialization workflow.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

