### PR TITLE
refactor: unify image customization methods

### DIFF
--- a/helm/core/templates/controller-deployment.yaml
+++ b/helm/core/templates/controller-deployment.yaml
@@ -31,11 +31,7 @@ spec:
       containers:
 {{- if not .Values.global.enableHigressIstio }}
         - name: discovery
-{{- if contains "/" .Values.pilot.image }}
-          image: "{{ .Values.pilot.image }}"
-{{- else }}
           image: "{{ .Values.pilot.hub | default .Values.global.hub }}/{{ .Values.pilot.image | default "pilot" }}:{{ .Values.pilot.tag | default .Chart.AppVersion }}"
-{{- end }}
 {{- if .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
 {{- end }}
@@ -184,7 +180,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.controller.securityContext | nindent 12 }}
-          image: "{{ .Values.hub }}/{{ .Values.controller.image }}:{{ .Values.controller.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.controller.hub | default .Values.global.hub }}/{{ .Values.controller.image | default "higress" }}:{{ .Values.controller.tag | default .Chart.AppVersion }}"
           args:
           - "serve"
           - --gatewaySelectorKey=higress

--- a/helm/core/templates/deployment.yaml
+++ b/helm/core/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
       {{- end }}
       containers:
         - name: higress-gateway
-          image: "{{ .Values.hub }}/{{ .Values.gateway.image }}:{{ .Values.gateway.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.gateway.hub | default .Values.global.hub }}/{{ .Values.gateway.image | default "gateway" }}:{{ .Values.gateway.tag | default .Chart.AppVersion }}"
           args:
             - proxy
             - router

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -369,6 +369,8 @@ gateway:
   name: "higress-gateway"
   replicas: 2
   image: gateway
+
+  hub: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress
   tag: ""
   # revision declares which revision this gateway is a part of
   revision: ""
@@ -457,6 +459,8 @@ controller:
   name: "higress-controller"
   replicas: 1
   image: higress
+
+  hub: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress
   tag: ""
   env: {}
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
#676 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
i made wasm-plugin test to check if the PR works. It showed no errors.

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

i followed the settings in `values.yaml`, the default image for controller is "higress" in customization. 

I mention this because the other two containers keep their name and image consistent. pilot's default image is "pilot". gateway's image is "gateway". The naming methods of images may be a little bit worth concerning.