### PR TITLE
Compatible with nginx.ingress.kubernetes.io/canary-by-header-pattern annotation

### DIFF
--- a/pkg/ingress/kube/annotations/canary.go
+++ b/pkg/ingress/kube/annotations/canary.go
@@ -154,7 +154,7 @@ func ApplyByHeader(canary, route *networking.HTTPRoute, canaryIngress *Ingress) 
 				match.Headers = map[string]*networking.StringMatch{
 					canaryConfig.Header: {
 						MatchType: &networking.StringMatch_Regex{
-							Regex: canaryConfig.HeaderPattern,
+							Regex: ".*" + canaryConfig.HeaderPattern + ".*",
 						},
 					},
 				}

--- a/test/e2e/conformance/tests/httproute-canary-header.go
+++ b/test/e2e/conformance/tests/httproute-canary-header.go
@@ -34,6 +34,7 @@ var HTTPRouteCanaryHeader = suite.ConformanceTest{
 		testcases := []http.Assertion{
 			{
 				Meta: http.AssertionMeta{
+					TestCaseName:    "case 1: canary header value matches",
 					TargetBackend:   "infra-backend-v1",
 					TargetNamespace: "higress-conformance-infra",
 				},
@@ -49,8 +50,10 @@ var HTTPRouteCanaryHeader = suite.ConformanceTest{
 						StatusCode: 200,
 					},
 				},
-			}, {
+			},
+			{
 				Meta: http.AssertionMeta{
+					TestCaseName:    "case 2: canary header value does not match",
 					TargetBackend:   "infra-backend-v2",
 					TargetNamespace: "higress-conformance-infra",
 				},
@@ -65,8 +68,10 @@ var HTTPRouteCanaryHeader = suite.ConformanceTest{
 						StatusCode: 200,
 					},
 				},
-			}, {
+			},
+			{
 				Meta: http.AssertionMeta{
+					TestCaseName:    "case 3: canary header value matches when the exact path matches",
 					TargetBackend:   "infra-backend-v2",
 					TargetNamespace: "higress-conformance-infra",
 				},
@@ -82,8 +87,10 @@ var HTTPRouteCanaryHeader = suite.ConformanceTest{
 						StatusCode: 200,
 					},
 				},
-			}, {
+			},
+			{
 				Meta: http.AssertionMeta{
+					TestCaseName:    "case 4: canary header value matches when the prefix path matches",
 					TargetBackend:   "infra-backend-v1",
 					TargetNamespace: "higress-conformance-infra",
 				},
@@ -102,6 +109,7 @@ var HTTPRouteCanaryHeader = suite.ConformanceTest{
 			},
 			{
 				Meta: http.AssertionMeta{
+					TestCaseName:    "case 5: canary header value does not match when the exact path matches",
 					TargetBackend:   "infra-backend-v3",
 					TargetNamespace: "higress-conformance-infra",
 				},
@@ -119,6 +127,7 @@ var HTTPRouteCanaryHeader = suite.ConformanceTest{
 			},
 			{
 				Meta: http.AssertionMeta{
+					TestCaseName:    "case 6: canary header value does not match when the prefix path matches",
 					TargetBackend:   "infra-backend-v3",
 					TargetNamespace: "higress-conformance-infra",
 				},
@@ -126,6 +135,87 @@ var HTTPRouteCanaryHeader = suite.ConformanceTest{
 					ActualRequest: http.Request{
 						Path: "/foo/bar",
 						Host: "canary.higress.io",
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 7: canary header pattern matches",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/baz",
+						Host: "canary.higress.io",
+						Headers: map[string]string{
+							"traffic-split-higress": "test.com",
+						},
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 8: canary header pattern matches including the suffix",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/baz",
+						Host: "canary.higress.io",
+						Headers: map[string]string{
+							"traffic-split-higress": "test.com.abc",
+						},
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 9: canary header is not set",
+					TargetBackend:   "infra-backend-v2",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/baz",
+						Host: "canary.higress.io",
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 10: canary header pattern does not match",
+					TargetBackend:   "infra-backend-v2",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/baz",
+						Host: "canary.higress.io",
+						Headers: map[string]string{
+							"traffic-split-higress": "test.org",
+						},
 					},
 				},
 				Response: http.AssertionResponse{

--- a/test/e2e/conformance/tests/httproute-canary-header.yaml
+++ b/test/e2e/conformance/tests/httproute-canary-header.yaml
@@ -109,3 +109,45 @@ spec:
                 name: infra-backend-v3
                 port:
                   number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "traffic-split-higress"
+    nginx.ingress.kubernetes.io/canary-by-header-pattern: "test.com"
+  name: ingress-baz-canary-pattern
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: canary.higress.io
+      http:
+        paths:
+          - path: /baz
+            pathType: Exact
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-baz
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: canary.higress.io
+      http:
+        paths:
+          - path: /baz
+            pathType: Exact
+            backend:
+              service:
+                name: infra-backend-v2
+                port:
+                  number: 8080


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Compatible with `nginx.ingress.kubernetes.io/canary-by-header-pattern` annotation.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/alibaba/higress/issues/671

### Ⅲ. Test
Manifests
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: production
  labels:
    app: production
spec:
  replicas: 1
  selector:
    matchLabels:
      app: production
  template:
    metadata:
      labels:
        app: production
    spec:
      containers:
      - name: production
        image: registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4
        ports:
        - containerPort: 80
        env:
          - name: NODE_NAME
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
          - name: POD_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: POD_IP
            valueFrom:
              fieldRef:
                fieldPath: status.podIP
---
apiVersion: v1
kind: Service
metadata:
  name: production
  labels:
    app: production
spec:
  ports:
  - port: 80
    targetPort: 80
    protocol: TCP
    name: http
  selector:
    app: production
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: canary
  labels:
    app: canary
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canary
  template:
    metadata:
      labels:
        app: canary
    spec:
      containers:
      - name: canary
        image: registry.k8s.io/ingress-nginx/e2e-test-echo@sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4
        ports:
        - containerPort: 80
        env:
          - name: NODE_NAME
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
          - name: POD_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: POD_IP
            valueFrom:
              fieldRef:
                fieldPath: status.podIP
---
apiVersion: v1
kind: Service
metadata:
  name: canary
  labels:
    app: canary
spec:
  ports:
  - port: 80
    targetPort: 80
    protocol: TCP
    name: http
  selector:
    app: canary
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: production
spec:
  ingressClassName: higress
  rules:
  - host: echo.prod.mydomain.com
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: production
            port:
              number: 80
---
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: canary
  annotations:
    nginx.ingress.kubernetes.io/canary: "true"
    nginx.ingress.kubernetes.io/canary-by-header: "canary-header"
    nginx.ingress.kubernetes.io/canary-by-header-pattern: "test.XXX.com"
spec:
  ingressClassName: higress
  rules:
  - host: echo.prod.mydomain.com
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: canary
            port:
              number: 80
```

Test request.
```bash
kubectl port-forward  -n higress-system  svc/higress-gateway  18080:80

for i in $(seq 1 10); do curl -s --resolve echo.prod.mydomain.com:18080:127.0.0.1 echo.prod.mydomain.com:18080 \
-H "canary-header: http://test.XXX.com/YYY" | grep "Hostname"; done

Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd


for i in $(seq 1 10); do curl -s --resolve echo.prod.mydomain.com:18080:127.0.0.1 echo.prod.mydomain.com:18080 \
-H "canary-header: http://test.XXX.com/ZZZ" | grep "Hostname"; done

Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd
Hostname: canary-847fbf5f84-9wprd


for i in $(seq 1 10); do curl -s --resolve echo.prod.mydomain.com:18080:127.0.0.1 echo.prod.mydomain.com:18080 \
-H "canary-header: http://test.YYY.com" | grep "Hostname"; done

Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
Hostname: production-b9c8f68b6-j6cll
```



### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

