### PR TITLE
tools(hgctl): add windows build

### DIFF
--- a/.github/workflows/latest-release.yaml
+++ b/.github/workflows/latest-release.yaml
@@ -18,6 +18,8 @@ jobs:
         tar -zcvf hgctl_latest_linux_arm64.tar.gz out/linux_arm64/
         tar -zcvf hgctl_latest_darwin_amd64.tar.gz out/darwin_amd64/
         tar -zcvf hgctl_latest_darwin_arm64.tar.gz out/darwin_arm64/
+        zip -q -r hgctl_latest_windows_amd64.zip out/windows_amd64/
+        zip -q -r hgctl_latest_windows_arm64.zip out/windows_arm64/
 
     # Ignore the error when we delete the latest release, it might not exist.
 
@@ -54,6 +56,8 @@ jobs:
           hgctl_latest_linux_arm64.tar.gz
           hgctl_latest_darwin_amd64.tar.gz
           hgctl_latest_darwin_arm64.tar.gz
+          hgctl_latest_windows_amd64.zip
+          hgctl_latest_windows_arm64.zip
         body: |
           This is the "latest" release of **Higress**, which contains the most recent commits from the main branch.
           

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -92,7 +92,8 @@ build-hgctl-multiarch: prebuild $(OUT)
 	GOPROXY=$(GOPROXY) GOOS=linux GOARCH=arm64 LDFLAGS=$(RELEASE_LDFLAGS) tools/hack/gobuild.sh ./out/linux_arm64/ $(HGCTL_BINARIES)
 	GOPROXY=$(GOPROXY) GOOS=darwin GOARCH=amd64 LDFLAGS=$(RELEASE_LDFLAGS) tools/hack/gobuild.sh ./out/darwin_amd64/ $(HGCTL_BINARIES)
 	GOPROXY=$(GOPROXY) GOOS=darwin GOARCH=arm64 LDFLAGS=$(RELEASE_LDFLAGS) tools/hack/gobuild.sh ./out/darwin_arm64/ $(HGCTL_BINARIES)
-
+	GOPROXY=$(GOPROXY) GOOS=windows GOARCH=amd64 LDFLAGS=$(RELEASE_LDFLAGS) tools/hack/gobuild.sh ./out/windows_amd64/ $(HGCTL_BINARIES)
+	GOPROXY=$(GOPROXY) GOOS=windows GOARCH=arm64 LDFLAGS=$(RELEASE_LDFLAGS) tools/hack/gobuild.sh ./out/windows_arm64/ $(HGCTL_BINARIES)
 # Create targets for OUT_LINUX/binary
 # There are two use cases here:
 # * Building all docker images (generally in CI). In this case we want to build everything at once, so they share work

--- a/pkg/cmd/hgctl/plugin/build/build.go
+++ b/pkg/cmd/hgctl/plugin/build/build.go
@@ -20,10 +20,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/signal"
 	"os/user"
 	"strings"
-	"syscall"
 
 	"github.com/alibaba/higress/pkg/cmd/hgctl/plugin/option"
 	ptypes "github.com/alibaba/higress/pkg/cmd/hgctl/plugin/types"
@@ -633,11 +631,7 @@ func (b *Builder) config(f ConfigFunc) (err error) {
 		b.w = os.Stdout
 	}
 
-	b.sig = make(chan os.Signal, 1)
-	b.stop = make(chan struct{}, 1)
-	b.done = make(chan struct{}, 1)
-	signal.Notify(b.sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM,
-		syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGQUIT, syscall.SIGTSTP)
+	signalNotify(b)
 
 	if b.Debugger == nil {
 		b.Debugger = utils.NewDefaultDebugger(b.Debug, b.w)

--- a/pkg/cmd/hgctl/plugin/build/signal.go
+++ b/pkg/cmd/hgctl/plugin/build/signal.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux || darwin || bsd
+
+package build
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func signalNotify(b *Builder) {
+	b.sig = make(chan os.Signal, 1)
+	b.stop = make(chan struct{}, 1)
+	b.done = make(chan struct{}, 1)
+	signal.Notify(b.sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM,
+		syscall.SIGUSR1, syscall.SIGUSR2, syscall.SIGQUIT, syscall.SIGTSTP)
+}

--- a/pkg/cmd/hgctl/plugin/build/signal_windows.go
+++ b/pkg/cmd/hgctl/plugin/build/signal_windows.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package build
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func signalNotify(b *Builder) {
+	b.sig = make(chan os.Signal, 1)
+	b.stop = make(chan struct{}, 1)
+	b.done = make(chan struct{}, 1)
+	signal.Notify(b.sig, syscall.SIGHUP, syscall.SIGINT,
+		syscall.SIGTERM, syscall.SIGQUIT)
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Add windows build for hgctl.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixs #668  

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
Run `make build-hgctl-multiarch` and can see prebuilt binnary for windows/amd64 and windows/arm64

### Ⅴ. Special notes for reviews
Some signal like `syscall.SIGUSR1` is removed for windows build by using conditional compilation directive because windows doesn't have those signal.

Meanwhile, the distributions of hgctl for windows use zip to archive for convenience, but this cause that `get-hgctl.sh` needs to be modified. In my opinion, we can simply add a note in documents for windows user to download `hgctl` manually, ~~and keep the download script unchanged.~~ 

Now windows user can also use `get-hgctl.sh`  to install `hgctl`. The default install loction is `%USERPROFILE%/hgctl/bin`.
