### PR TITLE
fix rds cache

### DIFF
--- a/istio/1.12/patches/istio/20240202-fix-rds-cache.patch
+++ b/istio/1.12/patches/istio/20240202-fix-rds-cache.patch
@@ -1,0 +1,41 @@
+diff -Naur istio/pilot/pkg/xds/discovery.go istio-new/pilot/pkg/xds/discovery.go
+--- istio/pilot/pkg/xds/discovery.go	2024-02-02 16:26:49.000000000 +0800
++++ istio-new/pilot/pkg/xds/discovery.go	2024-02-02 15:38:53.000000000 +0800
+@@ -18,6 +18,7 @@
+ 	"context"
+ 	"fmt"
+ 	"strconv"
++	"strings"
+ 	"sync"
+ 	"time"
+ 
+@@ -41,6 +42,7 @@
+ 	"istio.io/istio/pilot/pkg/util/sets"
+ 	v3 "istio.io/istio/pilot/pkg/xds/v3"
+ 	"istio.io/istio/pkg/cluster"
++	"istio.io/istio/pkg/config/constants"
+ 	"istio.io/istio/pkg/security"
+ )
+ 
+@@ -332,6 +334,21 @@
+ 	} else {
+ 		// Otherwise, just clear the updated configs
+ 		s.Cache.Clear(req.ConfigsUpdated)
++		//Added by ingress
++		trimKeyMap := make(map[model.ConfigKey]struct{})
++		for configKey := range req.ConfigsUpdated {
++			if strings.HasPrefix(configKey.Name, constants.IstioIngressGatewayName+"-") {
++				trimKeyMap[model.ConfigKey{
++					Kind:      configKey.Kind,
++					Name:      strings.TrimPrefix(configKey.Name, constants.IstioIngressGatewayName+"-"),
++					Namespace: configKey.Namespace,
++				}] = struct{}{}
++			}
++		}
++		if len(trimKeyMap) > 0 {
++			s.Cache.Clear(trimKeyMap)
++		}
++		//End added by ingress
+ 	}
+ }
+ 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

The logic of Higress is to remove the "istio-auto generated-k8s-ingress-" prefix and then merge vs with the same name. This will cause the rds cache to be unable to find the corresponding cache key for cleaning.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

