### PR TITLE
increase health check timeout

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -154,13 +154,13 @@ build-pilot-local:
 build-gateway: prebuild external/package/envoy-amd64.tar.gz external/package/envoy-arm64.tar.gz build-pilot
 	cd external/istio; BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=true DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.proxyv2" make docker
 
-build-gateway-local: prebuild external/package/envoy-amd64.tar.gz external/package/envoy-arm64.tar.gz build-pilot
+build-gateway-local: prebuild external/package/envoy-amd64.tar.gz external/package/envoy-arm64.tar.gz
 	cd external/istio; rm -rf out/linux_${GOARCH_LOCAL}; GOOS_LOCAL=linux TARGET_OS=linux BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=false DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.proxyv2" make docker
 
 build-istio: prebuild build-pilot
 	cd external/istio; BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=true DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.pilot" make docker
 
-build-istio-local: prebuild build-pilot-local
+build-istio-local: prebuild
 	cd external/istio; rm -rf out/linux_${GOARCH_LOCAL}; GOOS_LOCAL=linux TARGET_OS=linux BUILD_WITH_CONTAINER=1 BUILDX_PLATFORM=false DOCKER_BUILD_VARIANTS=default DOCKER_TARGETS="docker.pilot" make docker
 
 build-wasmplugins:

--- a/istio/1.12/patches/istio/20240204-increase-healthcheck-timeout.patch
+++ b/istio/1.12/patches/istio/20240204-increase-healthcheck-timeout.patch
@@ -1,0 +1,21 @@
+diff -Naur istio/pilot/cmd/pilot-agent/status/util/stats.go istio-new/pilot/cmd/pilot-agent/status/util/stats.go
+--- istio/pilot/cmd/pilot-agent/status/util/stats.go	2024-02-04 18:48:18.000000000 +0800
++++ istio-new/pilot/cmd/pilot-agent/status/util/stats.go	2024-02-04 09:35:42.000000000 +0800
+@@ -37,7 +37,7 @@
+ 	updateStatsRegex   = "^(cluster_manager\\.cds|listener_manager\\.lds)\\.(update_success|update_rejected)$"
+ )
+ 
+-var readinessTimeout = time.Second * 3 // Default Readiness timeout. It is set the same in helm charts.
++var readinessTimeout = time.Second * 60 // Default Readiness timeout. It is set the same in helm charts.
+ 
+ type stat struct {
+ 	name  string
+@@ -105,7 +105,7 @@
+ 		localHostAddr = "localhost"
+ 	}
+ 
+-	stats, err := http.DoHTTPGet(fmt.Sprintf("http://%s:%d/stats?usedonly", localHostAddr, adminPort))
++	stats, err := http.DoHTTPGetWithTimeout(fmt.Sprintf("http://%s:%d/stats?usedonly", localHostAddr, adminPort), readinessTimeout)
+ 	if err != nil {
+ 		return nil, err
+ 	}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
When there are a large number of clusters and routes in the cluster, the timeout period of 3 seconds is not enough

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

