### PR TITLE
fix: Consider the new ingress package is available as default

### DIFF
--- a/pkg/ingress/kube/common/tool.go
+++ b/pkg/ingress/kube/common/tool.go
@@ -48,13 +48,15 @@ func V1Available(client kube.Client) bool {
 
 	serverVersion, err := client.GetKubernetesVersion()
 	if err != nil {
-		return false
+		// Consider the new ingress package is available as default
+		return true
 	}
 
 	runningVersion, err := version.ParseGeneric(serverVersion.String())
 	if err != nil {
+		// Consider the new ingress package is available as default
 		IngressLog.Errorf("unexpected error parsing running Kubernetes version: %v", err)
-		return false
+		return true
 	}
 
 	return runningVersion.AtLeast(version119)


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Consider the new ingress package is available as default, just in case anything goes wrong during initialization, then Higress falls into v1beta1/Ingress and can't recover before restarting.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

