### PR TITLE
feat: higress global configmap support config route timeout

### DIFF
--- a/test/e2e/conformance/tests/configmap-global.go
+++ b/test/e2e/conformance/tests/configmap-global.go
@@ -963,7 +963,7 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							"max_concurrent_streams":         100,
 							"initial_stream_window_size":     65535,
 							"initial_connection_window_size": 1048576,
-							"stream_idle_timeout":            "0s",
+							"stream_idle_timeout":            "180s",
 							"max_request_headers_kb":         60,
 							"idle_timeout":                   "180s",
 						},

--- a/test/e2e/conformance/tests/configmap-global.go
+++ b/test/e2e/conformance/tests/configmap-global.go
@@ -50,6 +50,7 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							InitialStreamWindowSize:     65535,
 							InitialConnectionWindowSize: 1048576,
 						},
+						RouteTimeout: 15,
 					},
 					Upstream: &configmap.Upstream{
 						IdleTimeout:            10,
@@ -122,6 +123,14 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 						},
 					},
 					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "15s",
+						},
+					},
+					{
 						Path:            "configs.#.dynamic_active_clusters.#.cluster",
 						CheckType:       envoy.CheckTypeMatch,
 						TargetNamespace: "higress-system",
@@ -146,6 +155,7 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							InitialStreamWindowSize:     65535,
 							InitialConnectionWindowSize: 1048576,
 						},
+						RouteTimeout: 15,
 					},
 					Upstream: &configmap.Upstream{
 						IdleTimeout:            10,
@@ -210,6 +220,14 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 						},
 					},
 					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "15s",
+						},
+					},
+					{
 						Path:            "configs.#.dynamic_active_clusters.#.cluster",
 						CheckType:       envoy.CheckTypeMatch,
 						TargetNamespace: "higress-system",
@@ -234,6 +252,7 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							InitialStreamWindowSize:     65535,
 							InitialConnectionWindowSize: 1048576,
 						},
+						RouteTimeout: 15,
 					},
 					Upstream: &configmap.Upstream{
 						IdleTimeout:            10,
@@ -303,6 +322,14 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 						},
 					},
 					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "15s",
+						},
+					},
+					{
 						Path:            "configs.#.dynamic_active_clusters.#.cluster",
 						CheckType:       envoy.CheckTypeMatch,
 						TargetNamespace: "higress-system",
@@ -327,6 +354,7 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							InitialStreamWindowSize:     65535,
 							InitialConnectionWindowSize: 1048576,
 						},
+						RouteTimeout: 15,
 					},
 					Upstream: &configmap.Upstream{
 						IdleTimeout:            10,
@@ -385,6 +413,14 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							"common_http_protocol_options": map[string]interface{}{
 								"idle_timeout": "180s",
 							},
+						},
+					},
+					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "15s",
 						},
 					},
 					{
@@ -469,6 +505,14 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 						},
 					},
 					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "0s",
+						},
+					},
+					{
 						Path:            "configs.#.dynamic_active_clusters.#.cluster",
 						CheckType:       envoy.CheckTypeMatch,
 						TargetNamespace: "higress-system",
@@ -492,6 +536,7 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							InitialStreamWindowSize:     65535,
 							InitialConnectionWindowSize: 1048576,
 						},
+						RouteTimeout: 15,
 					},
 					DisableXEnvoyHeaders: true,
 					AddXRealIpHeader:     true,
@@ -560,6 +605,14 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 						},
 					},
 					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "15s",
+						},
+					},
+					{
 						Path:            "configs.#.dynamic_active_clusters.#.cluster",
 						CheckType:       envoy.CheckTypeMatch,
 						TargetNamespace: "higress-system",
@@ -584,6 +637,7 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							InitialStreamWindowSize:     65535,
 							InitialConnectionWindowSize: 1048576,
 						},
+						RouteTimeout: 60,
 					},
 					DisableXEnvoyHeaders: true,
 					AddXRealIpHeader:     true,
@@ -652,6 +706,14 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 						},
 					},
 					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "60s",
+						},
+					},
+					{
 						Path:            "configs.#.dynamic_active_clusters.#.cluster",
 						CheckType:       envoy.CheckTypeMatch,
 						TargetNamespace: "higress-system",
@@ -714,6 +776,14 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							"stream_idle_timeout":            "180s",
 							"max_request_headers_kb":         60,
 							"idle_timeout":                   "180s",
+						},
+					},
+					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "0s",
 						},
 					},
 					{
@@ -804,6 +874,106 @@ var ConfigMapGlobalEnvoy = suite.ConformanceTest{
 							"stream_idle_timeout":            "0s",
 							"max_request_headers_kb":         60,
 							"idle_timeout":                   "0s",
+						},
+					},
+					{
+						Path:            "configs.#.dynamic_active_clusters.#.cluster",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"common_http_protocol_options": map[string]interface{}{
+								"idle_timeout": "10s",
+							},
+							"per_connection_buffer_limit_bytes": 10485760,
+						},
+					},
+				},
+			},
+			{
+				name: "close the setting of route timeout in downstream",
+				higressConfig: &configmap.HigressConfig{
+					Downstream: &configmap.Downstream{
+						IdleTimeout:            180,
+						MaxRequestHeadersKb:    60,
+						ConnectionBufferLimits: 32768,
+						Http2: &configmap.Http2{
+							MaxConcurrentStreams:        100,
+							InitialStreamWindowSize:     65535,
+							InitialConnectionWindowSize: 1048576,
+						},
+						RouteTimeout: 0,
+					},
+					Upstream: &configmap.Upstream{
+						IdleTimeout: 10,
+					},
+					DisableXEnvoyHeaders: true,
+					AddXRealIpHeader:     true,
+				},
+				envoyAssertion: []envoy.Assertion{
+					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config",
+						CheckType:       envoy.CheckTypeExist,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"request_headers_to_add": []interface{}{
+								map[string]interface{}{
+									"append": false,
+									"header": map[string]interface{}{
+										"key":   "x-real-ip",
+										"value": "%REQ(X-ENVOY-EXTERNAL-ADDRESS)%",
+									},
+								},
+							},
+						},
+					},
+					{
+						Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config",
+						CheckType:       envoy.CheckTypeExist,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"@type":       "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+							"stat_prefix": "outbound_0.0.0.0_80",
+						},
+					},
+					{
+						Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config.http_filters",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"name": "envoy.filters.http.router",
+							"typed_config": map[string]interface{}{
+								"@type":                  "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router",
+								"suppress_envoy_headers": true,
+							},
+						},
+					},
+					{
+						Path:            "configs.#.dynamic_listeners.#.active_state.listener",
+						CheckType:       envoy.CheckTypeExist,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"per_connection_buffer_limit_bytes": 32768,
+						},
+					},
+					{
+						Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config",
+						CheckType:       envoy.CheckTypeExist,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"max_concurrent_streams":         100,
+							"initial_stream_window_size":     65535,
+							"initial_connection_window_size": 1048576,
+							"stream_idle_timeout":            "0s",
+							"max_request_headers_kb":         60,
+							"idle_timeout":                   "180s",
+						},
+					},
+					{
+						Path:            "configs.#.dynamic_route_configs.#.route_config.virtual_hosts.#.routes.#.route",
+						CheckType:       envoy.CheckTypeMatch,
+						TargetNamespace: "higress-system",
+						ExpectEnvoyConfig: map[string]interface{}{
+							"timeout": "0s",
 						},
 					},
 					{


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
  - higress 全局配置支持配置route级别timeout
     - 默认route的timeout为0，不改变原来的效果
  - 对应的参数说明文档 [PR](https://github.com/higress-group/higress-group.github.io/pull/215)

### Ⅱ. Does this pull request fix one issue?
  - [issue](https://github.com/alibaba/higress/issues/884)

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
  - 已添加e2e测试用例

### Ⅳ. Describe how to verify it
  - 运行e2e测试，ConfigMapGlobalEnvoy 测试用例全部`pass`
     - make run-higress-e2e-test 
     ```
    --- PASS: TestHigressConformanceTests (261.38s)
    --- PASS: TestHigressConformanceTests/ConfigMapGlobalEnvoy (245.93s)
        --- PASS: TestHigressConformanceTests/ConfigMapGlobalEnvoy/ConfigMap_Global_Envoy (245.92s)
    --- SKIP: TestHigressConformanceTests/ConfigmapGzip (0.00s)
    --- PASS: TestHigressConformanceTests/ConfigMapGzipEnvoy (13.10s)
        --- PASS: TestHigressConformanceTests/ConfigMapGzipEnvoy/ConfigMap_Gzip_Envoy (13.08s)
   
    PASS
     ok      command-line-arguments  262.245s
  ```  