### PR TITLE
support ignore the PushRequest to the xDS server

### DIFF
--- a/istio/1.12/patches/istio/20240327-ignore-push-request.patch
+++ b/istio/1.12/patches/istio/20240327-ignore-push-request.patch
@@ -1,0 +1,161 @@
+diff -Naur istio/pilot/pkg/features/pilot.go istio_new/pilot/pkg/features/pilot.go
+--- istio/pilot/pkg/features/pilot.go	2024-03-27 17:13:47
++++ istio_new/pilot/pkg/features/pilot.go	2024-03-27 16:53:30
+@@ -578,6 +578,11 @@
+ 	DefaultUpstreamConcurrencyThreshold = env.RegisterIntVar("DEFAULT_UPSTREAM_CONCURRENCY_THRESHOLD", 1000000,
+ 		"The default threshold of max_requests/max_pending_requests/max_connections of circuit breaker").Get()
+ 	HigressSystemNs = env.RegisterStringVar("HIGRESS_SYSTEM_NS", "higress-system", "The system namespace of Higress").Get()
++
++	IgnorePushRequest = env.RegisterBoolVar(
++		"PILOT_IGNORE_PUSH_REQUEST",
++		false,
++		"Determines whether or not ignore the PushRequest to the xDS server.").Get()
+ 	// End added by ingress
+ )
+ 
+diff -Naur istio/pilot/pkg/model/push_context.go istio_new/pilot/pkg/model/push_context.go
+--- istio/pilot/pkg/model/push_context.go	2024-03-27 17:13:47
++++ istio_new/pilot/pkg/model/push_context.go	2024-03-27 17:12:46
+@@ -400,6 +400,8 @@
+ 	NamespaceUpdate TriggerReason = "namespace"
+ 	// ClusterUpdate describes a push triggered by a Cluster change
+ 	ClusterUpdate TriggerReason = "cluster"
++	// ignorePushRequestUpdate describes a push triggered after disable ignorePushRequest
++	IgnorePushRequestUpdate TriggerReason = "force push after disable ignorePushRequest"
+ )
+ 
+ // Merge two update requests together
+diff -Naur istio/pilot/pkg/xds/debug.go istio_new/pilot/pkg/xds/debug.go
+--- istio/pilot/pkg/xds/debug.go	2024-03-27 17:13:47
++++ istio_new/pilot/pkg/xds/debug.go	2024-03-27 17:01:58
+@@ -208,6 +208,9 @@
+ 	// Added by ingress
+ 	s.addDebugHandler(mux, internalMux, "/debug/ingressRoutez", "List all auto generated routes from ingress.", s.ingressRoutez)
+ 	s.addDebugHandler(mux, internalMux, "/debug/ingressDomainz", "List all auto generated gateway from ingress.", s.ingressDomainz)
++	s.addDebugHandler(mux, internalMux, "/debug/ignorePushRequest", "Ignore the PushRequest push to xDS server", s.ignorePushRequestHandler)
++	s.addDebugHandler(mux, internalMux, "/debug/ignorePushRequest?disable=true", "Not ignore the PushRequest push to xDS server", s.ignorePushRequestHandler)
++	s.addDebugHandler(mux, internalMux, "/debug/ignorePushRequest?disable=true&push=true", "Not ignore the PushRequest push to xDS server and force push once", s.ignorePushRequestHandler)
+ 	// End added by ingress
+ }
+ 
+@@ -1015,4 +1018,40 @@
+ 
+ func (s *DiscoveryServer) ingressDomainz(w http.ResponseWriter, _ *http.Request) {
+ 	writeJSON(w, s.Env.IngressStore.GetIngressDomains())
++}
++
++func (s *DiscoveryServer) ignorePushRequestHandler(w http.ResponseWriter, req *http.Request) {
++	if err := req.ParseForm(); err != nil {
++		w.WriteHeader(http.StatusBadRequest)
++		_, _ = w.Write([]byte("Failed to parse request\n"))
++		return
++	}
++
++	disable := req.Form.Get("disable")
++
++	if disable == "" || disable == "false" {
++		if req.Form.Get("push") != "" {
++			_, _ = w.Write([]byte("Not allow force push when ignoring PushRequest push to xDS server\n"))
++			return
++		}
++
++		s.ignorePushRequest.Store(true)
++		_, _ = w.Write([]byte("Ignore the PushRequest push to xDS server from now"))
++	} else if disable == "true" {
++		s.ignorePushRequest.Store(false)
++		describe := "Not ignore the PushRequest push to xDS server from now"
++		if req.Form.Get("push") != "" {
++			s.ConfigUpdate(&model.PushRequest{
++				Full:   true,
++				Reason: []model.TriggerReason{model.IgnorePushRequestUpdate},
++			})
++			describe += " and force push once"
++		}
++
++		_, _ = w.Write([]byte(describe))
++	} else {
++		_, _ = w.Write([]byte("Request qurey \"disable\" args value must be true or false\n"))
++	}
++
++	return
+ }
+diff -Naur istio/pilot/pkg/xds/discovery.go istio_new/pilot/pkg/xds/discovery.go
+--- istio/pilot/pkg/xds/discovery.go	2024-03-27 17:13:47
++++ istio_new/pilot/pkg/xds/discovery.go	2024-03-27 17:00:49
+@@ -166,6 +166,9 @@
+ 	// ClusterAliases are aliase names for cluster. When a proxy connects with a cluster ID
+ 	// and if it has a different alias we should use that a cluster ID for proxy.
+ 	ClusterAliases map[cluster.ID]cluster.ID
++
++	// Whether or not ignore the PushRequest to the xDS server
++	ignorePushRequest *atomic.Bool
+ }
+ 
+ // EndpointShards holds the set of endpoint shards of a service. Registries update
+@@ -212,8 +215,9 @@
+ 			debounceMax:       features.DebounceMax,
+ 			enableEDSDebounce: features.EnableEDSDebounce,
+ 		},
+-		Cache:      model.DisabledCache{},
+-		instanceID: instanceID,
++		Cache:             model.DisabledCache{},
++		instanceID:        instanceID,
++		ignorePushRequest: atomic.NewBool(features.IgnorePushRequest),
+ 	}
+ 
+ 	out.ClusterAliases = make(map[cluster.ID]cluster.ID)
+@@ -409,12 +413,14 @@
+ // ConfigUpdate implements ConfigUpdater interface, used to request pushes.
+ // It replaces the 'clear cache' from v1.
+ func (s *DiscoveryServer) ConfigUpdate(req *model.PushRequest) {
+-	if req.Full {
+-		log.Infof("full push happen, reason:%v", req.Reason)
++	if !s.ignorePushRequest.Load() {
++		if req.Full {
++			log.Infof("full push happen, reason:%v", req.Reason)
++		}
++		inboundConfigUpdates.Increment()
++		s.InboundUpdates.Inc()
++		s.pushChannel <- req
+ 	}
+-	inboundConfigUpdates.Increment()
+-	s.InboundUpdates.Inc()
+-	s.pushChannel <- req
+ }
+ 
+ // Debouncing and push request happens in a separate thread, it uses locks
+diff -Naur istio/pilot/pkg/xds/monitoring.go istio_new/pilot/pkg/xds/monitoring.go
+--- istio/pilot/pkg/xds/monitoring.go	2024-03-27 17:13:46
++++ istio_new/pilot/pkg/xds/monitoring.go	2024-03-27 17:18:35
+@@ -204,18 +204,19 @@
+ 
+ // triggerMetric is a precomputed monitoring.Metric for each trigger type. This saves on a lot of allocations
+ var triggerMetric = map[model.TriggerReason]monitoring.Metric{
+-	model.EndpointUpdate:  pushTriggers.With(typeTag.Value(string(model.EndpointUpdate))),
+-	model.ConfigUpdate:    pushTriggers.With(typeTag.Value(string(model.ConfigUpdate))),
+-	model.ServiceUpdate:   pushTriggers.With(typeTag.Value(string(model.ServiceUpdate))),
+-	model.ProxyUpdate:     pushTriggers.With(typeTag.Value(string(model.ProxyUpdate))),
+-	model.GlobalUpdate:    pushTriggers.With(typeTag.Value(string(model.GlobalUpdate))),
+-	model.UnknownTrigger:  pushTriggers.With(typeTag.Value(string(model.UnknownTrigger))),
+-	model.DebugTrigger:    pushTriggers.With(typeTag.Value(string(model.DebugTrigger))),
+-	model.SecretTrigger:   pushTriggers.With(typeTag.Value(string(model.SecretTrigger))),
+-	model.NetworksTrigger: pushTriggers.With(typeTag.Value(string(model.NetworksTrigger))),
+-	model.ProxyRequest:    pushTriggers.With(typeTag.Value(string(model.ProxyRequest))),
+-	model.NamespaceUpdate: pushTriggers.With(typeTag.Value(string(model.NamespaceUpdate))),
+-	model.ClusterUpdate:   pushTriggers.With(typeTag.Value(string(model.ClusterUpdate))),
++	model.EndpointUpdate:          pushTriggers.With(typeTag.Value(string(model.EndpointUpdate))),
++	model.ConfigUpdate:            pushTriggers.With(typeTag.Value(string(model.ConfigUpdate))),
++	model.ServiceUpdate:           pushTriggers.With(typeTag.Value(string(model.ServiceUpdate))),
++	model.ProxyUpdate:             pushTriggers.With(typeTag.Value(string(model.ProxyUpdate))),
++	model.GlobalUpdate:            pushTriggers.With(typeTag.Value(string(model.GlobalUpdate))),
++	model.UnknownTrigger:          pushTriggers.With(typeTag.Value(string(model.UnknownTrigger))),
++	model.DebugTrigger:            pushTriggers.With(typeTag.Value(string(model.DebugTrigger))),
++	model.SecretTrigger:           pushTriggers.With(typeTag.Value(string(model.SecretTrigger))),
++	model.NetworksTrigger:         pushTriggers.With(typeTag.Value(string(model.NetworksTrigger))),
++	model.ProxyRequest:            pushTriggers.With(typeTag.Value(string(model.ProxyRequest))),
++	model.NamespaceUpdate:         pushTriggers.With(typeTag.Value(string(model.NamespaceUpdate))),
++	model.ClusterUpdate:           pushTriggers.With(typeTag.Value(string(model.ClusterUpdate))),
++	model.IgnorePushRequestUpdate: pushTriggers.With(typeTag.Value(string(model.IgnorePushRequestUpdate))),
+ }
+ 
+ func recordPushTriggers(reasons ...model.TriggerReason) {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
  - 可以控制"控制平面"是否能主动向"数据平面"推送资源
    - 默认允许推送，不改变原来的行为
  - 在 higress controller debug界面提供开关，接口功能说明如下图
  
![4781711533812_ pic](https://github.com/alibaba/higress/assets/22722774/cf21fe29-8439-44c6-8163-29aff8d6a80d)


### Ⅱ. Does this pull request fix one issue?
  - [issue](https://github.com/alibaba/higress/issues/887)


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
  

### Ⅳ. Describe how to verify it
  - step 1:  配置ingress、wasmplugin、 全局配置资源前点击` /debug/ignorePushRequest`，禁止推送
  - step 2: 配置ingress、wasmplugin、 全局配置资源
  - step 3: 查看数据平面相关配置没有生效或者higress controller没有出现推送日志
  - step 4: 点击` /debug/ignorePushRequest?disable=true` 或者 `/debug/ignorePushRequest?disable=true&push=true`接口，允许推送，两者的区别是后者允许推送的同时强制推送一次数据
  - step 5:  查看数据平面相关配置已经生效或者higress controller出现推送日志，日志内容如下：
  ```
2024-03-27T10:13:32.406062Z	info	ads	full push happen, reason:[force push after disable ignorePushRequest]
2024-03-27T10:13:32.510065Z	info	ads	Push debounce stable[2] 1: 101.962084ms since last change, 101.961875ms since last push, full=true
2024-03-27T10:13:32.510486Z	info	ingress	resource type networking.istio.io/v1alpha3/ServiceEntry, configs number 1
2024-03-27T10:13:32.510530Z	info	ingress	resource type networking.istio.io/v1alpha3/VirtualService, configs number 1
2024-03-27T10:13:32.510593Z	info	ingress	Found 0 number of basic auth
2024-03-27T10:13:32.510621Z	info	ingress	Found 0 number of envoyFilters
2024-03-27T10:13:32.510671Z	info	ingress	resource type networking.istio.io/v1alpha3/DestinationRule, configs number 1
2024-03-27T10:13:32.510730Z	info	ingress	resource type extensions.istio.io/v1alpha1/WasmPlugin, configs number 1
2024-03-27T10:13:32.510745Z	info	ingress	controller tracing ConstructEnvoyFilters
2024-03-27T10:13:32.510749Z	info	ingress	controller gzip ConstructEnvoyFilters
2024-03-27T10:13:32.511198Z	info	ingress	controller global-option ConstructEnvoyFilters
. . .
  ```

### Ⅴ. Special notes for reviews
 

