### PR TITLE
optimize on construct envoyfilter

### DIFF
--- a/pkg/ingress/kube/configmap/global.go
+++ b/pkg/ingress/kube/configmap/global.go
@@ -326,30 +326,23 @@ func (g *GlobalOptionController) ConstructEnvoyFilters() ([]*config.Config, erro
 		configPatch = append(configPatch, disableXEnvoyHeadersConfig...)
 	}
 
-	if global.Downstream == nil {
-		return generateEnvoyFilter(namespace, configPatch), nil
+	if global.Downstream != nil {
+		downstreamStruct := g.constructDownstream(global.Downstream)
+		bufferLimitStruct := g.constructBufferLimit(global.Downstream)
+		downstreamConfig := g.generateDownstreamEnvoyFilter(downstreamStruct, bufferLimitStruct, namespace)
+		if downstreamConfig != nil {
+			configPatch = append(configPatch, downstreamConfig...)
+		}
 	}
 
-	downstreamStruct := g.constructDownstream(global.Downstream)
-	bufferLimitStruct := g.constructBufferLimit(global.Downstream)
-	if len(downstreamStruct) == 0 && len(bufferLimitStruct) == 0 {
-		return generateEnvoyFilter(namespace, configPatch), nil
+	if global.Upstream != nil {
+		upstreamStruct := g.constructUpstream(global.Upstream)
+		bufferLimitStruct := g.constructUpstreamBufferLimit(global.Upstream)
+		upstreamConfig := g.generateUpstreamEnvoyFilter(upstreamStruct, bufferLimitStruct, namespace)
+		if upstreamConfig != nil {
+			configPatch = append(configPatch, upstreamConfig...)
+		}
 	}
-
-	downstreamConfig := g.generateDownstreamEnvoyFilter(downstreamStruct, bufferLimitStruct, namespace)
-	configPatch = append(configPatch, downstreamConfig...)
-
-	if global.Upstream == nil {
-		return generateEnvoyFilter(namespace, configPatch), nil
-	}
-
-	upstreamStruct := g.constructUpstream(global.Upstream)
-	bufferLimitStruct = g.constructUpstreamBufferLimit(global.Upstream)
-	if len(upstreamStruct) == 0 {
-		return generateEnvoyFilter(namespace, configPatch), nil
-	}
-	upstreamConfig := g.generateUpstreamEnvoyFilter(upstreamStruct, bufferLimitStruct, namespace)
-	configPatch = append(configPatch, upstreamConfig...)
 
 	return generateEnvoyFilter(namespace, configPatch), nil
 }
@@ -376,8 +369,10 @@ func (g *GlobalOptionController) RegisterItemEventHandler(eventHandler ItemEvent
 
 // generateDownstreamEnvoyFilter generates the downstream envoy filter.
 func (g *GlobalOptionController) generateDownstreamEnvoyFilter(downstreamValueStruct string, bufferLimitStruct string, namespace string) []*networking.EnvoyFilter_EnvoyConfigObjectPatch {
-	downstreamConfig := []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
-		{
+	var downstreamConfig []*networking.EnvoyFilter_EnvoyConfigObjectPatch
+
+	if len(downstreamValueStruct) != 0 {
+		downstreamConfig = append(downstreamConfig, &networking.EnvoyFilter_EnvoyConfigObjectPatch{
 			ApplyTo: networking.EnvoyFilter_NETWORK_FILTER,
 			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 				Context: networking.EnvoyFilter_GATEWAY,
@@ -395,8 +390,11 @@ func (g *GlobalOptionController) generateDownstreamEnvoyFilter(downstreamValueSt
 				Operation: networking.EnvoyFilter_Patch_MERGE,
 				Value:     util.BuildPatchStruct(downstreamValueStruct),
 			},
-		},
-		{
+		})
+	}
+
+	if len(bufferLimitStruct) != 0 {
+		downstreamConfig = append(downstreamConfig, &networking.EnvoyFilter_EnvoyConfigObjectPatch{
 			ApplyTo: networking.EnvoyFilter_LISTENER,
 			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 				Context: networking.EnvoyFilter_GATEWAY,
@@ -405,14 +403,17 @@ func (g *GlobalOptionController) generateDownstreamEnvoyFilter(downstreamValueSt
 				Operation: networking.EnvoyFilter_Patch_MERGE,
 				Value:     util.BuildPatchStruct(bufferLimitStruct),
 			},
-		},
+		})
 	}
+
 	return downstreamConfig
 }
 
 func (g *GlobalOptionController) generateUpstreamEnvoyFilter(upstreamValueStruct string, bufferLimit string, namespace string) []*networking.EnvoyFilter_EnvoyConfigObjectPatch {
-	upstreamConfig := []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
-		{
+	var upstreamConfig []*networking.EnvoyFilter_EnvoyConfigObjectPatch
+
+	if len(upstreamValueStruct) != 0 {
+		upstreamConfig = append(upstreamConfig, &networking.EnvoyFilter_EnvoyConfigObjectPatch{
 			ApplyTo: networking.EnvoyFilter_CLUSTER,
 			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 				Context: networking.EnvoyFilter_GATEWAY,
@@ -421,8 +422,11 @@ func (g *GlobalOptionController) generateUpstreamEnvoyFilter(upstreamValueStruct
 				Operation: networking.EnvoyFilter_Patch_MERGE,
 				Value:     util.BuildPatchStruct(upstreamValueStruct),
 			},
-		},
-		{
+		})
+	}
+
+	if len(bufferLimit) != 0 {
+		upstreamConfig = append(upstreamConfig, &networking.EnvoyFilter_EnvoyConfigObjectPatch{
 			ApplyTo: networking.EnvoyFilter_CLUSTER,
 			Match: &networking.EnvoyFilter_EnvoyConfigObjectMatch{
 				Context: networking.EnvoyFilter_GATEWAY,
@@ -431,8 +435,9 @@ func (g *GlobalOptionController) generateUpstreamEnvoyFilter(upstreamValueStruct
 				Operation: networking.EnvoyFilter_Patch_MERGE,
 				Value:     util.BuildPatchStruct(bufferLimit),
 			},
-		},
+		})
 	}
+
 	return upstreamConfig
 }
 

--- a/pkg/ingress/kube/configmap/global.go
+++ b/pkg/ingress/kube/configmap/global.go
@@ -308,8 +308,7 @@ func (g *GlobalOptionController) ConstructEnvoyFilters() ([]*config.Config, erro
 	configPatch := make([]*networking.EnvoyFilter_EnvoyConfigObjectPatch, 0)
 	global := g.GetGlobal()
 	if global == nil {
-		configs := make([]*config.Config, 0)
-		return configs, nil
+		return []*config.Config{}, nil
 	}
 
 	namespace := g.Namespace
@@ -342,6 +341,10 @@ func (g *GlobalOptionController) ConstructEnvoyFilters() ([]*config.Config, erro
 		if upstreamConfig != nil {
 			configPatch = append(configPatch, upstreamConfig...)
 		}
+	}
+
+	if len(configPatch) == 0 {
+		return []*config.Config{}, nil
 	}
 
 	return generateEnvoyFilter(namespace, configPatch), nil


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
   - 构造envoyfilter的函数有点奇怪，所以提一个PR，以下几点的源码位置见comment
     - 1 downsteam是否为空不应该影响upstream的envoyfilter的构建， 以后在 downsteam 的位置之后增加其他配置，都会有该问题
     - 2 upstream的idletimeout是否为空不应该影响bufferLimit的envoyfilter的构建
     - 3 generateDownstreamEnvoyFilter和generateUpstreamEnvoyFilter函数不应该构造patch的value为空的envoyfilter，原来的代码路径看起来会出现该情况

### Ⅱ. Does this pull request fix one issue?
   [issue](https://github.com/alibaba/higress/issues/890)

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it
   - make run-higress-e2e-test 观察全局配置测试用例测试结果是否`pass`

### Ⅴ. Special notes for reviews
   - 因为有默认配置，所以上述3点没有被触发，但原来的代码读起来很奇怪

