### PR TITLE
feat: add ssl ciphers and protocol version on gateway api

### DIFF
--- a/pkg/ingress/kube/gateway/istio/model.go
+++ b/pkg/ingress/kube/gateway/istio/model.go
@@ -32,12 +32,15 @@ import (
 
 const (
 	// Start - Updated by Higress
-	defaultClassName             = constants.DefaultGatewayClass
-	gatewayAliasForAnnotationKey = "gateway.higress.io/alias-for"
-	gatewayTLSTerminateModeKey   = "gateway.higress.io/tls-terminate-mode"
-	gatewayNameOverride          = "gateway.higress.io/name-override"
-	gatewaySAOverride            = "gateway.higress.io/service-account"
-	serviceTypeOverride          = "networking.higress.io/service-type"
+	defaultClassName                = constants.DefaultGatewayClass
+	gatewayAliasForAnnotationKey    = "gateway.higress.io/alias-for"
+	gatewayTLSTerminateModeKey      = "gateway.higress.io/tls-terminate-mode"
+	gatewayNameOverride             = "gateway.higress.io/name-override"
+	gatewaySAOverride               = "gateway.higress.io/service-account"
+	serviceTypeOverride             = "networking.higress.io/service-type"
+	gatewaySSLCipherKey             = "gateway.higress.io/ssl-cipher"
+	gatewayTLSMinProtocolVersionKey = "gateway.higress.io/tls_min_protocol_version"
+	gatewayTLSMaxProtocolVersionKey = "gateway.higress.io/tls_max_protocol_version"
 	// End - Updated by Higress
 )
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
  - 在 feat/istio-1.19.0 分支上 ，使得 gateway api支持配置`ssl cipher suites `以及 `ssl protocol version`

### Ⅱ. Does this pull request fix one issue?
 - [issue](https://github.com/alibaba/higress/issues/900#issuecomment-2063195883)


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
  - apply下方gateway api资源
 ```
 apiVersion: gateway.networking.k8s.io/v1
kind: GatewayClass
metadata:
  name: higress-gateways
spec:
  controllerName: "higress.io/gateway-controller"
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: higress-gateway
  namespace: higress-system
spec:
  gatewayClassName: higress
  listeners:
  - name: fazheng
    port: 4006
    protocol: HTTPS
    allowedRoutes:
      namespaces:
        from: All
    tls:
      options:
        gateway.higress.io/tls-terminate-mode: "MUTUAL"
        gateway.higress.io/ssl-cipher: "ECDHE-ECDSA-AES128-GCM-SHA256:AES256-SHA"  ==》 1
        gateway.higress.io/tls_min_protocol_version: "TLSV1_1"  ==》 2
        gateway.higress.io/tls_max_protocol_version: "TLSV1_2"  ==》 2
      certificateRefs:
      - kind: Secret
        name: wildcard-foobar-com
  - name: yewu
    port: 4005
    protocol: HTTPS
    allowedRoutes:
      namespaces:
        from: All
    tls:
      certificateRefs:
      - kind: Secret
        name: wildcard-foobar-com
 ```
   
   - 查看数据平面envoy配置是否调整
 
![5351713422355_ pic](https://github.com/alibaba/higress/assets/22722774/d127b788-290c-4c60-84ec-6553dce9830b)


### Ⅴ. Special notes for reviews

