### PR TITLE
fix mcp destination bug

### DIFF
--- a/pkg/ingress/kube/ingress/controller.go
+++ b/pkg/ingress/kube/ingress/controller.go
@@ -17,13 +17,14 @@ package ingress
 import (
 	"errors"
 	"fmt"
-	"github.com/alibaba/higress/pkg/cert"
 	"path"
 	"reflect"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/alibaba/higress/pkg/cert"
 
 	"github.com/hashicorp/go-multierror"
 	networking "istio.io/api/networking/v1alpha3"
@@ -890,15 +891,28 @@ func (c *controller) storeBackendTrafficPolicy(wrapper *common.WrapperConfig, ba
 	}
 	if common.ValidateBackendResource(backend.Resource) && wrapper.AnnotationsConfig.Destination != nil {
 		for _, dest := range wrapper.AnnotationsConfig.Destination.McpDestination {
+			portNumber := dest.Destination.GetPort().GetNumber()
 			serviceKey := common.ServiceKey{
 				Namespace:   "mcp",
 				Name:        dest.Destination.Host,
+				Port:        int32(portNumber),
 				ServiceFQDN: dest.Destination.Host,
 			}
 			if _, exist := store[serviceKey]; !exist {
-				store[serviceKey] = &common.WrapperTrafficPolicy{
-					TrafficPolicy: &networking.TrafficPolicy{},
-					WrapperConfig: wrapper,
+				if serviceKey.Port != 0 {
+					store[serviceKey] = &common.WrapperTrafficPolicy{
+						PortTrafficPolicy: &networking.TrafficPolicy_PortTrafficPolicy{
+							Port: &networking.PortSelector{
+								Number: uint32(serviceKey.Port),
+							},
+						},
+						WrapperConfig: wrapper,
+					}
+				} else {
+					store[serviceKey] = &common.WrapperTrafficPolicy{
+						TrafficPolicy: &networking.TrafficPolicy{},
+						WrapperConfig: wrapper,
+					}
 				}
 			}
 		}

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -891,15 +891,28 @@ func (c *controller) storeBackendTrafficPolicy(wrapper *common.WrapperConfig, ba
 	}
 	if common.ValidateBackendResource(backend.Resource) && wrapper.AnnotationsConfig.Destination != nil {
 		for _, dest := range wrapper.AnnotationsConfig.Destination.McpDestination {
+			portNumber := dest.Destination.GetPort().GetNumber()
 			serviceKey := common.ServiceKey{
 				Namespace:   "mcp",
 				Name:        dest.Destination.Host,
+				Port:        int32(portNumber),
 				ServiceFQDN: dest.Destination.Host,
 			}
 			if _, exist := store[serviceKey]; !exist {
-				store[serviceKey] = &common.WrapperTrafficPolicy{
-					TrafficPolicy: &networking.TrafficPolicy{},
-					WrapperConfig: wrapper,
+				if serviceKey.Port != 0 {
+					store[serviceKey] = &common.WrapperTrafficPolicy{
+						PortTrafficPolicy: &networking.TrafficPolicy_PortTrafficPolicy{
+							Port: &networking.PortSelector{
+								Number: uint32(serviceKey.Port),
+							},
+						},
+						WrapperConfig: wrapper,
+					}
+				} else {
+					store[serviceKey] = &common.WrapperTrafficPolicy{
+						TrafficPolicy: &networking.TrafficPolicy{},
+						WrapperConfig: wrapper,
+					}
 				}
 			}
 		}
@@ -942,6 +955,7 @@ func (c *controller) createDefaultRoute(wrapper *common.WrapperConfig, backend *
 		port := &networking.PortSelector{}
 		if service.Port.Number > 0 {
 			port.Number = uint32(service.Port.Number)
+
 		} else {
 			resolvedPort, err := resolveNamedPort(service, namespace, c.serviceLister)
 			if err != nil {

--- a/pkg/ingress/kube/ingressv1/controller.go
+++ b/pkg/ingress/kube/ingressv1/controller.go
@@ -955,7 +955,6 @@ func (c *controller) createDefaultRoute(wrapper *common.WrapperConfig, backend *
 		port := &networking.PortSelector{}
 		if service.Port.Number > 0 {
 			port.Number = uint32(service.Port.Number)
-
 		} else {
 			resolvedPort, err := resolveNamedPort(service, namespace, c.serviceLister)
 			if err != nil {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Fix the issue where, when using the `destination` annotation, if a Kubernetes service has multiple ports, the generated Istio DestinationRule configuration gets overwritten.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

