### PR TITLE
fix: Fix the incorrect usage of DisableReroute

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -70,6 +70,9 @@ func onHttpRequestHeader(ctx wrapper.HttpContext, pluginConfig config.PluginConf
 	ctx.SetContext(ctxKeyApiName, apiName)
 
 	if handler, ok := activeProvider.(provider.RequestHeadersHandler); ok {
+		// Disable the route re-calculation since the plugin may modify some headers related to  the chosen route.
+		ctx.DisableReroute()
+
 		action, err := handler.OnRequestHeaders(ctx, apiName, log)
 		if err == nil {
 			return action
@@ -152,9 +155,6 @@ func onHttpResponseHeaders(ctx wrapper.HttpContext, pluginConfig config.PluginCo
 	} else if !needHandleStreamingBody {
 		ctx.BufferResponseBody()
 	}
-
-	// Disable the route re-calculation since the plugin may modify some headers related to  the chosen route.
-	ctx.DisableReroute()
 
 	return types.ActionContinue
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Move the invocation of ctx.DisableReroute function from onHttpResponseHeaders to onHttpRequestHeaders.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

