### PR TITLE
Fix the issue with multiple system prompts when using qwen-long file id mode.

### DIFF
--- a/plugins/wasm-go/Makefile
+++ b/plugins/wasm-go/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME ?= hello-world
 BUILDER_REGISTRY ?= higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/
-REGISTRY ?=
+REGISTRY ?= higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/
 GO_VERSION ?= 1.19
 TINYGO_VERSION ?= 0.28.1
 ORAS_VERSION ?= 1.0.0
@@ -12,12 +12,14 @@ COMMIT_ID := $(shell git rev-parse --short HEAD 2>/dev/null)
 IMAGE_TAG = $(if $(strip $(PLUGIN_VERSION)),${PLUGIN_VERSION},${BUILD_TIME}-${COMMIT_ID})
 IMG ?= ${REGISTRY}${PLUGIN_NAME}:${IMAGE_TAG}
 GOPROXY := $(shell go env GOPROXY)
+EXTRA_TAGS ?=
 
 .DEFAULT:
 build:
 	DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=${PLUGIN_NAME} \
 	                            --build-arg BUILDER=${BUILDER}  \
 	                            --build-arg GOPROXY=$(GOPROXY) \
+                                    --build-arg EXTRA_TAGS=$(EXTRA_TAGS) \
 	                            -t ${IMG} \
 	                            --output extensions/${PLUGIN_NAME} \
 	                            .
@@ -28,6 +30,7 @@ build-image:
 	DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=${PLUGIN_NAME} \
 	                            --build-arg BUILDER=${BUILDER}  \
 	                            --build-arg GOPROXY=$(GOPROXY) \
+                                    --build-arg EXTRA_TAGS=$(EXTRA_TAGS) \
 	                            -t ${IMG} \
 	                            .
 	@echo ""

--- a/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
@@ -446,7 +446,7 @@ func (m *qwenProvider) insertContextMessage(request *qwenTextGenRequest, content
 			}
 			builder.WriteString(message.Content)
 		}
-		request.Input.Messages = append([]qwenMessage{{Role: roleSystem, Content: builder.String()}}, append([]qwenMessage{fileMessage}, request.Input.Messages[firstNonSystemMessageIndex:]...)...)
+		request.Input.Messages = append([]qwenMessage{{Role: roleSystem, Content: builder.String()}, fileMessage}, request.Input.Messages[firstNonSystemMessageIndex:]...)
 		return 1
 	}
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
@@ -99,7 +99,7 @@ func (m *qwenProvider) OnRequestBody(ctx wrapper.HttpContext, apiName ApiName, b
 				log.Errorf("failed to load context file: %v", err)
 				_ = util.SendResponse(500, util.MimeTypeTextPlain, fmt.Sprintf("failed to load context file: %v", err))
 			}
-			m.insertContextMessage(request, content)
+			m.insertContextMessage(request, content, false)
 			if err := replaceJsonRequestBody(request, log); err != nil {
 				_ = util.SendResponse(500, util.MimeTypeTextPlain, fmt.Sprintf("failed to replace request body: %v", err))
 			}
@@ -301,7 +301,7 @@ func (m *qwenProvider) buildQwenTextGenerationRequest(origRequest *chatCompletio
 			builder.WriteString("fileid://")
 			builder.WriteString(fileId)
 		}
-		contextMessageId := m.insertContextMessage(request, builder.String())
+		contextMessageId := m.insertContextMessage(request, builder.String(), true)
 		if contextMessageId == 0 {
 			// The context message cannot come first. We need to add another dummy system message before it.
 			request.Input.Messages = append([]qwenMessage{{Role: roleSystem, Content: qwenDummySystemMessageContent}}, request.Input.Messages...)
@@ -417,7 +417,7 @@ func (m *qwenProvider) convertStreamEvent(ctx wrapper.HttpContext, responseBuild
 	return nil
 }
 
-func (m *qwenProvider) insertContextMessage(request *qwenTextGenRequest, content string) int {
+func (m *qwenProvider) insertContextMessage(request *qwenTextGenRequest, content string, onlyOneSystemBeforeFile bool) int {
 	fileMessage := qwenMessage{
 		Role:    roleSystem,
 		Content: content,
@@ -435,9 +435,19 @@ func (m *qwenProvider) insertContextMessage(request *qwenTextGenRequest, content
 	if firstNonSystemMessageIndex == -1 {
 		request.Input.Messages = append([]qwenMessage{fileMessage}, request.Input.Messages...)
 		return 0
-	} else {
+	} else if !onlyOneSystemBeforeFile {
 		request.Input.Messages = append(request.Input.Messages[:firstNonSystemMessageIndex], append([]qwenMessage{fileMessage}, request.Input.Messages[firstNonSystemMessageIndex:]...)...)
 		return firstNonSystemMessageIndex
+	} else {
+		builder := strings.Builder{}
+		for _, message := range request.Input.Messages[:firstNonSystemMessageIndex] {
+			if builder.Len() != 0 {
+				builder.WriteString("\n")
+			}
+			builder.WriteString(message.Content)
+		}
+		request.Input.Messages = append([]qwenMessage{{Role: roleSystem, Content: builder.String()}}, append([]qwenMessage{fileMessage}, request.Input.Messages[firstNonSystemMessageIndex:]...)...)
+		return 1
 	}
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

When using fileid mode, apart from the system of fileid, Qwen-long only allows one initial system.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

