### PR TITLE
feat: Add the ZhipuAI (ChatGLM) provider to the ai-proxy wasm plugin #950

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/README.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README.md
@@ -21,7 +21,7 @@ description: AI 代理插件配置参考
 
 | 名称             | 数据类型            | 填写要求 | 默认值 | 描述                                                                               |
 |----------------|-----------------|------|-----|----------------------------------------------------------------------------------|
-| `type`         | string          | 必填   | -   | AI 服务提供商名称。目前支持以下取值：openai, azure, moonshot, qwen                                |
+| `type`         | string          | 必填   | -   | AI 服务提供商名称。目前支持以下取值：openai, azure, moonshot, qwen, zhipuai                                |
 | `apiTokens`    | array of string | 必填   | -   | 用于在访问 AI 服务时进行认证的令牌。如果配置了多个 token，插件会在请求时随机进行选择。部分服务提供商只支持配置一个 token。            |
 | `timeout`      | number          | 非必填  | -   | 访问 AI 服务的超时时间。单位为毫秒。默认值为 120000，即 2 分钟                                           |
 | `modelMapping` | map of string   | 非必填  | -   | AI 模型映射表，用于将请求中的模型名称映射为服务提供商支持模型名称。<br/>可以使用 "*" 为键来配置通用兜底映射关系                   |
@@ -76,6 +76,10 @@ Azure OpenAI 所对应的 `type` 为 `azure`。它特有的配置字段如下：
 #### 零一万物（Yi）
 
 零一万物所对应的 `type` 为 `yi`。它并无特有的配置字段。
+
+#### 智谱AI（Zhipu AI）
+
+智谱AI所对应的 `type` 为 `zhipuai`。它并无特有的配置字段。
 
 #### DeepSeek（DeepSeek）
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -23,6 +23,7 @@ const (
 	providerTypeBaichuan = "baichuan"
 	providerTypeYi       = "yi"
 	providerTypeDeepSeek = "deepseek"
+	providerTypeZhipuAi  = "zhipuai"
 
 	protocolOpenAI   = "openai"
 	protocolOriginal = "original"
@@ -60,6 +61,7 @@ var (
 		providerTypeBaichuan: &baichuanProviderInitializer{},
 		providerTypeYi:       &yiProviderInitializer{},
 		providerTypeDeepSeek: &deepseekProviderInitializer{},
+		providerTypeZhipuAi:  &zhipuAiProviderInitializer{},
 	}
 )
 
@@ -89,7 +91,7 @@ type ResponseBodyHandler interface {
 
 type ProviderConfig struct {
 	// @Title zh-CN AI服务提供商
-	// @Description zh-CN AI服务提供商类型，目前支持的取值为："moonshot"、"qwen"、"openai"、"azure"、"baichuan"、"yi"
+	// @Description zh-CN AI服务提供商类型，目前支持的取值为："moonshot"、"qwen"、"openai"、"azure"、"baichuan"、"yi"、"zhipuai"
 	typ string `required:"true" yaml:"type" json:"type"`
 	// @Title zh-CN API Tokens
 	// @Description zh-CN 在请求AI服务时用于认证的API Token列表。不同的AI服务提供商可能有不同的名称。部分供应商只支持配置一个API Token（如Azure OpenAI）。

--- a/plugins/wasm-go/extensions/ai-proxy/provider/zhipuai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/zhipuai.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
+	"github.com/alibaba/higress/plugins/wasm-go/pkg/wrapper"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+const (
+	zhipuAiDomain             = "open.bigmodel.cn"
+	zhipuAiChatCompletionPath = "/api/paas/v4/chat/completions"
+)
+
+type zhipuAiProviderInitializer struct{}
+
+func (m *zhipuAiProviderInitializer) ValidateConfig(config ProviderConfig) error {
+	return nil
+}
+
+func (m *zhipuAiProviderInitializer) CreateProvider(config ProviderConfig) (Provider, error) {
+	return &zhipuAiProvider{
+		config:       config,
+		contextCache: createContextCache(&config),
+	}, nil
+}
+
+type zhipuAiProvider struct {
+	config       ProviderConfig
+	contextCache *contextCache
+}
+
+func (m *zhipuAiProvider) GetProviderType() string {
+	return providerTypeZhipuAi
+}
+
+func (m *zhipuAiProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, log wrapper.Log) (types.Action, error) {
+	if apiName != ApiNameChatCompletion {
+		return types.ActionContinue, errUnsupportedApiName
+	}
+	_ = util.OverwriteRequestPath(zhipuAiChatCompletionPath)
+	_ = util.OverwriteRequestHost(zhipuAiDomain)
+	_ = proxywasm.ReplaceHttpRequestHeader("Authorization", "Bearer "+m.config.GetRandomToken())
+
+	if m.contextCache == nil {
+		ctx.DontReadRequestBody()
+	} else {
+		_ = proxywasm.RemoveHttpRequestHeader("Content-Length")
+	}
+
+	return types.ActionContinue, nil
+}
+
+func (m *zhipuAiProvider) OnRequestBody(ctx wrapper.HttpContext, apiName ApiName, body []byte, log wrapper.Log) (types.Action, error) {
+	if apiName != ApiNameChatCompletion {
+		return types.ActionContinue, errUnsupportedApiName
+	}
+	if m.contextCache == nil {
+		return types.ActionContinue, nil
+	}
+	request := &chatCompletionRequest{}
+	if err := decodeChatCompletionRequest(body, request); err != nil {
+		return types.ActionContinue, err
+	}
+	err := m.contextCache.GetContent(func(content string, err error) {
+		defer func() {
+			_ = proxywasm.ResumeHttpRequest()
+		}()
+		if err != nil {
+			log.Errorf("failed to load context file: %v", err)
+			_ = util.SendResponse(500, util.MimeTypeTextPlain, fmt.Sprintf("failed to load context file: %v", err))
+		}
+		insertContextMessage(request, content)
+		if err := replaceJsonRequestBody(request, log); err != nil {
+			_ = util.SendResponse(500, util.MimeTypeTextPlain, fmt.Sprintf("failed to replace request body: %v", err))
+		}
+	}, log)
+	if err == nil {
+		return types.ActionPause, nil
+	}
+	return types.ActionContinue, err
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Add the ZhipuAI (ChatGLM) provider to the `ai-proxy` wasm plugin.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
#### 0. cd repo (ai-proxy)
#### 1. build main.wasm
```bash
tinygo build -o main.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./
```
#### 2. docker-compose up -d 
`docker-compose.yaml`
```bash
version: '3.7'
services:
  envoy:
    image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway:v1.4.0-rc.1
    entrypoint: /usr/local/bin/envoy
    # 注意这里对wasm开启了debug级别日志，正式部署时则默认info级别
    command: -c /etc/envoy/envoy.yaml --component-log-level wasm:debug
    depends_on:
    - httpbin
    networks:
    - wasmtest
    ports:
    - "10000:10000"
    volumes:
    - ./envoy.yaml:/etc/envoy/envoy.yaml
    - ./main.wasm:/etc/envoy/plugin.wasm
    - ./main.wasm:/etc/envoy/main.wasm

  httpbin:
    image: kennethreitz/httpbin:latest
    networks:
    - wasmtest
    ports:
    - "12345:80"

networks:
  wasmtest: {}
```

`envoy.yaml`
```bash
# File generated by hgctl. Modify as required.

admin:
  address:
    socket_address:
      protocol: TCP
      address: 0.0.0.0
      port_value: 9901
static_resources:
  listeners:
    - name: listener_0
      address:
        socket_address:
          protocol: TCP
          address: 0.0.0.0
          port_value: 10000
      filter_chains:
        - filters:
            - name: envoy.filters.network.http_connection_manager
              typed_config:
                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                scheme_header_transformation:
                  scheme_to_overwrite: https
                stat_prefix: ingress_http
                # Output envoy logs to stdout
                access_log:
                  - name: envoy.access_loggers.stdout
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
                # Modify as required
                route_config:
                  name: local_route
                  virtual_hosts:
                    - name: local_service
                      domains: [ "*" ]
                      routes:
                        - match:
                            prefix: "/"
                          route:
                            cluster: zhipuai
                            timeout: 300s
                http_filters:
                  - name: wasmtest
                    typed_config:
                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                      value:
                        config:
                          name: wasmtest
                          vm_config:
                            runtime: envoy.wasm.runtime.v8
                            code:
                              local:
                                filename: /etc/envoy/main.wasm
                          configuration:
                            "@type": "type.googleapis.com/google.protobuf.StringValue"
                            value: |
                              {
                                "provider": {
                                  "type": "zhipuai",
                                  "domain": "open.bigmodel.cn",
                                  "apiTokens": [
                                    "*"
                                  ],
                                  "timeout": 1200000,
                                  "modelMapping": {
                                    "gpt-3": "glm-3-turbo",
                                    "gpt-35-turbo": "glm-4v",
                                    "gpt-4-turbo": "glm-4",
                                    "*": "glm-3-turbo"
                                  }
                                }
                              }
                  - name: envoy.filters.http.router
  clusters:
    - name: zhipuai
      connect_timeout: 30s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: zhipuai
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: open.bigmodel.cn
                      port_value: 443
      transport_socket:
        name: envoy.transport_sockets.tls
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
          "sni": "open.bigmodel.cn"

#### 3. Q&A
```bash
curl "http://localhost:10000/v1/chat/completions"  -H "Content-Type: application/json" -d '{
  "model": "glm-4",            
  "messages": [                                                     
    {                        
      "role": "user",                
      "content": "你好，你是哪个公司的？"
    }                                                                                 
  ]                                                 
}'  
```
```bash
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "你好，我是人工智能助手，不属于任何公司，\n我是由清华大学 KEG 实验室和智谱 AI 共同开发的。\n我的目的是为了帮助用户解决问题，提供信息和建议。\n有什么我可以帮到你的吗？",
        "role": "assistant"
      }
    }
  ],
  "created": 1716851431,
  "id": "*",
  "model": "glm-4",
  "request_id": "*",
  "usage": {
    "completion_tokens": 47,
    "prompt_tokens": 11,
    "total_tokens": 58
  }
}
```

### Ⅴ. Special notes for reviews

