### PR TITLE
optimize mcp cds

### DIFF
--- a/istio/1.12/patches/istio/20240529-optimize-mcp-cds.patch
+++ b/istio/1.12/patches/istio/20240529-optimize-mcp-cds.patch
@@ -1,0 +1,17 @@
+diff -Naur istio/pilot/pkg/model/push_context.go istio-new/pilot/pkg/model/push_context.go
+--- istio/pilot/pkg/model/push_context.go	2024-05-29 19:29:45.000000000 +0800
++++ istio-new/pilot/pkg/model/push_context.go	2024-05-29 19:11:03.000000000 +0800
+@@ -769,6 +769,13 @@
+ 	for _, s := range svcs {
+ 		svcHost := string(s.Hostname)
+ 
++		// Added by ingress
++		if s.Attributes.Namespace == "mcp" {
++			gwSvcs = append(gwSvcs, s)
++			continue
++		}
++		// End added by ingress
++
+ 		if _, ok := hostsFromGateways[svcHost]; ok {
+ 			gwSvcs = append(gwSvcs, s)
+ 		}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Previously, setting `global.onlyPushRouteCluster` to `true` in Helm values led to services configured via mcpbridge not being pushed to Envoy, which was unfriendly to users.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

