### PR TITLE
feat: helm charts support installing gateway in daemonset mod.

### DIFF
--- a/helm/core/templates/daemonset.yaml
+++ b/helm/core/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.gateway.kind "Daemonset" -}}
+{{- if eq .Values.gateway.kind "DaemonSet" -}}
 {{- $o11y := .Values.global.o11y  }}
 {{- $unprivilegedPortSupported := true }}
 {{- range $index, $node := (lookup "v1" "Node" "default" "").items }}

--- a/helm/core/templates/daemonset.yaml
+++ b/helm/core/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.gateway.kind "Deployment" -}}
+{{- if eq .Values.gateway.kind "Daemonset" -}}
 {{- $o11y := .Values.global.o11y  }}
 {{- $unprivilegedPortSupported := true }}
 {{- range $index, $node := (lookup "v1" "Node" "default" "").items }}
@@ -11,7 +11,7 @@
     {{- end }}
 {{- end -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ include "gateway.name" . }}
   namespace: {{ .Release.Namespace }}
@@ -20,24 +20,9 @@ metadata:
   annotations:
     {{- .Values.gateway.annotations | toYaml | nindent 4 }}
 spec:
-  {{- if not .Values.gateway.autoscaling.enabled }}
-  {{- if not (or .Values.global.local .Values.global.kind) }}
-  replicas: {{ .Values.gateway.replicas }}
-  {{- else }}
-  replicas: 1
-  {{- end }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "gateway.selectorLabels" . | nindent 6 }}
-  strategy:
-    rollingUpdate:
-      maxSurge: {{ .Values.gateway.rollingMaxSurge }}
-      {{- if or .Values.global.local .Values.global.kind }}
-      maxUnavailable: 100%
-      {{- else }}
-      maxUnavailable: {{ .Values.gateway.rollingMaxUnavailable }}
-      {{- end }}
   template:
     metadata:
       annotations:

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -396,6 +396,9 @@ gateway:
   replicas: 2
   image: gateway
 
+  # -- Use a `DaemonSet` or `Deployment`
+  kind: Deployment
+
   # The number of successive failed probes before indicating readiness failure.
   readinessFailureThreshold: 30
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
helm charts support installing gateway in daemonset mod.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
```bash
# use --dry-run or `template` sub-command to see what will happen.
helm install -n higress-system higress helm/core --set gateway.kind=Daemonset --create-namespace
```

### Ⅳ. Describe how to verify it
use this command to get daemonset manifest.

```bash
helm template higress helm/core --set gateway.kind=Daemonset
```

<details>

<summary>Output</summary>


```yaml
# Source: higress-core/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: higress-gateway
  namespace: default
  labels:
    helm.sh/chart: higress-core-1.4.1
    app: higress-gateway
    higress: default-higress-gateway
    app.kubernetes.io/version: "1.4.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: higress-gateway
  annotations:
    {}
spec:
  selector:
    matchLabels:
      app: higress-gateway
      higress: default-higress-gateway
  template:
    metadata:
      annotations:
        prometheus.io/path: /stats/prometheus
        prometheus.io/port: "15020"
        prometheus.io/scrape: "true"
        sidecar.istio.io/inject: "false"
      labels:
        sidecar.istio.io/inject: "false"
        app: higress-gateway
        higress: default-higress-gateway
    spec:
      serviceAccountName: higress-gateway
      securityContext:
        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
        sysctls:
        - name: net.ipv4.ip_unprivileged_port_start
          value: "0"
      containers:
        - name: higress-gateway
          image: "higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway:1.4.1"
          args:
            - proxy
            - router
            - --domain
            - $(POD_NAMESPACE).svc.cluster.local
            - --proxyLogLevel=warning
            - --proxyComponentLogLevel=misc:error
            - --log_output_level=all:info
            - --serviceCluster=higress-gateway
          securityContext:
            # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
            capabilities:
              drop:
              - ALL
            allowPrivilegeEscalation: false
            privileged: false
          # When enabling lite metrics, the configuration template files need to be replaced.
            runAsUser: 1337
            runAsGroup: 1337
            runAsNonRoot: true
          env:
          - name: NODE_NAME
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: spec.nodeName
          - name: POD_NAME
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: metadata.name
          - name: POD_NAMESPACE
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: metadata.namespace
          - name: INSTANCE_IP
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: status.podIP
          - name: HOST_IP
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: status.hostIP
          - name: SERVICE_ACCOUNT
            valueFrom:
              fieldRef:
                fieldPath: spec.serviceAccountName
          - name: PILOT_XDS_SEND_TIMEOUT
            value: 60s
          - name: PROXY_XDS_VIA_AGENT
            value: "true"
          - name: ENABLE_INGRESS_GATEWAY_SDS
            value: "false"
          - name: JWT_POLICY
            value: third-party-jwt
          - name: ISTIO_META_HTTP10
            value: "1"
          - name: ISTIO_META_CLUSTER_ID
            value: "Kubernetes"
          - name: INSTANCE_NAME
            value: "higress-gateway"
          - name: LITE_METRICS
            value: "on"
          ports:
          - containerPort: 15090
            protocol: TCP
            name: http-envoy-prom
          readinessProbe:
            failureThreshold: 30
            httpGet:
              path: /healthz/ready
              port: 15021
              scheme: HTTP
            initialDelaySeconds: 1
            periodSeconds: 2
            successThreshold: 1
            timeoutSeconds: 3
          resources:
            limits:
              cpu: 2000m
              memory: 2048Mi
            requests:
              cpu: 2000m
              memory: 2048Mi
          volumeMounts:
          - name: istio-token
            mountPath: /var/run/secrets/tokens
            readOnly: true
          - name: config
            mountPath: /etc/istio/config
          - name: istio-ca-root-cert
            mountPath: /var/run/secrets/istio
          - name: istio-data
            mountPath: /var/lib/istio/data
          - name: podinfo
            mountPath: /etc/istio/pod
          - name: proxy-socket
            mountPath: /etc/istio/proxy
      volumes:
      - name: istio-token
        projected:
          sources:
            - serviceAccountToken:
                audience: istio-ca
                expirationSeconds: 43200
                path: istio-token
      - name: istio-ca-root-cert
        configMap:
          name: higress-ca-root-cert
      - name: config
        configMap:
          name: higress-config
      - name: istio-data
        emptyDir: {}
      - name: proxy-socket
        emptyDir: {}
      - name: podinfo
        downwardAPI:
          defaultMode: 420
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.labels
            path: labels
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.annotations
            path: annotations
          - path: cpu-request
            resourceFieldRef:
              containerName: higress-gateway
              divisor: 1m
              resource: requests.cpu
          - path: cpu-limit
            resourceFieldRef:
              containerName: higress-gateway
              divisor: 1m
              resource: limits.cpu
```

</details>


### Ⅴ. Special notes for reviews

Maybe you need to update the README docs and the Helm lockfile before this PR is merged