### PR TITLE
feat: build go wasm plugin images using github action

### DIFF
--- a/.github/workflows/build-and-push-wasm-go-plugin.yaml
+++ b/.github/workflows/build-and-push-wasm-go-plugin.yaml
@@ -48,27 +48,41 @@ jobs:
             PLUGIN_DIRS=$(basename -a ./extensions/*)
           fi
           
-          for plugin in ${PLUGIN_DIRS[@]}; do
-            echo "Build and push wasm go plugin: ${plugin}"
-            max_retries=3
-            retries=0
-            while [[ "${retries}" -lt "${max_retries}" ]]; do
-              IMAGE="${{ env.IMAGE_REGISTRY_SERVICE }}/${{ env.IMAGE_REPOSITORY }}/wasm-go-${plugin}:${PLUGIN_VERSION}"
-              PLUGIN_DIR="./extensions/${plugin}"      
-              GOPROXY="https://proxy.golang.org,direct" PLUGIN_NAME="${plugin}" make build
+          for PLUGIN in ${PLUGIN_DIRS[@]}; do
+            echo "Build and push wasm go plugin: ${PLUGIN}"
+            MAX_RETRIES=3
+            RETRIES=0
+            while [[ "${RETRIES}" -lt "${MAX_RETRIES}" ]]; do
+              IMAGE="${{ env.IMAGE_REGISTRY_SERVICE }}/${{ env.IMAGE_REPOSITORY }}/wasm-go-${PLUGIN}:${PLUGIN_VERSION}"
+              PLUGIN_DIR="./extensions/${PLUGIN}"      
+              GOPROXY="https://proxy.golang.org,direct" PLUGIN_NAME="${PLUGIN}" make build
           
               if [[ $? -eq 0 ]]; then
                 tar czvf "${PLUGIN_DIR}/plugin.tar.gz" "${PLUGIN_DIR}/plugin.wasm"
-                oras push "$IMAGE" "${PLUGIN_DIR}/plugin.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip"
+                PUSH_FILES=("${PLUGIN_DIR}/plugin.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip")
+                declare -A FILES=(
+                  ["spec.yaml"]="application/vnd.module.wasm.spec.v1+yaml"
+                  ["README.md"]="application/vnd.module.wasm.doc.v1+markdown"
+                  ["README_EN.md"]="application/vnd.module.wasm.doc.v1.en+markdown"
+                )
+                
+                for FILE in "${!FILES[@]}"; do
+                  FILE_PATH="${PLUGIN_DIR}/${FILE}"
+                  if [[ -f "${FILE_PATH}" ]]; then
+                    PUSH_FILES+=("${FILE_PATH}:${FILES[$FILE]}")
+                  fi
+                done
+
+                oras push "${IMAGE}" "${PUSH_FILES[@]}"
                 break
               else
-                (( retries++ ))
-                echo "Build failed. Retrying ${retries}/${max_retries}..."
+                (( RETRIES++ ))
+                echo "Build failed. Retrying ${RETRIES}/${MAX_RETRIES}..."
               fi
             done
           
-            if [[ "${retries}" -eq "${max_retries}" ]]; then
-              echo "Build failed after ${max_retries} retries."
+            if [[ "${RETRIES}" -eq "${MAX_RETRIES}" ]]; then
+              echo "Build failed after ${MAX_RETRIES} retries."
               exit 1
             fi
           done

--- a/.github/workflows/build-and-push-wasm-go-plugin.yaml
+++ b/.github/workflows/build-and-push-wasm-go-plugin.yaml
@@ -1,0 +1,74 @@
+name: Build Wasm Go Plugins and Push to Image Registry
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      plugin_name:
+        description: "Enter the plugin name"
+        required: true
+      plugin_version:
+        description: "Enter the plugin version"
+        required: true
+
+jobs:
+  build-and-push-wasm-go-plugin:
+    runs-on: ubuntu-latest
+    environment:
+      name: image-registry-wasm-go-plugin
+    env:
+      IMAGE_REGISTRY_SERVICE: ${{ vars.IMAGE_REGISTRY_SERVICE || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
+      IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'plugins' }}
+    steps:
+      - name: "Checkout ${{ github.ref }}"
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@v1
+        with:
+          version: 1.2.0
+
+      - name: Login to Docker Registry
+        run: oras login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} ${{ env.IMAGE_REGISTRY_SERVICE }}
+
+      - name: Build Plugin Image and Push
+        working-directory: plugins/wasm-go
+        run: |
+          set +e 
+          
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PLUGIN_VERSION=${{ github.event.inputs.plugin_version }}
+            PLUGIN_DIRS=(${{ github.event.inputs.plugin_name }})
+          else
+            PLUGIN_VERSION=${{ github.ref_name }}
+            PLUGIN_DIRS=$(basename -a ./extensions/*)
+          fi
+          
+          for plugin in ${PLUGIN_DIRS[@]}; do
+            echo "Build and push wasm go plugin: ${plugin}"
+            max_retries=3
+            retries=0
+            while [[ "${retries}" -lt "${max_retries}" ]]; do
+              IMAGE="${{ env.IMAGE_REGISTRY_SERVICE }}/${{ env.IMAGE_REPOSITORY }}/wasm-go-${plugin}:${PLUGIN_VERSION}"
+              PLUGIN_DIR="./extensions/${plugin}"      
+              GOPROXY="https://proxy.golang.org,direct" PLUGIN_NAME="${plugin}" make build
+          
+              if [[ $? -eq 0 ]]; then
+                tar czvf "${PLUGIN_DIR}/plugin.tar.gz" "${PLUGIN_DIR}/plugin.wasm"
+                oras push "$IMAGE" "${PLUGIN_DIR}/plugin.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip"
+                break
+              else
+                (( retries++ ))
+                echo "Build failed. Retrying ${retries}/${max_retries}..."
+              fi
+            done
+          
+            if [[ "${retries}" -eq "${max_retries}" ]]; then
+              echo "Build failed after ${max_retries} retries."
+              exit 1
+            fi
+          done

--- a/.github/workflows/build-image-and-push.yaml
+++ b/.github/workflows/build-image-and-push.yaml
@@ -224,8 +224,8 @@ jobs:
         with:
           registry: ${{ env.GATEWAY_IMAGE_REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}            
-          
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
       - name: Build Gateway Image and Push
         run: |
           GOPROXY="https://proxy.golang.org,direct" make build-gateway


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

支持通过 GitHub Actions 来构建和发布 Wasm 插件镜像。其中由于编译 Wasm 文件时偶尔会失败，因此添加了 3 次的重试机制。
默认情况下 Github Action 中的 shell 设置了 `-e`，因此在命令失败时会立即退出，导致无法捕获错误 ([issue discussion](https://github.com/orgs/community/discussions/46992#discussioncomment-4961541)) 。所以在 shell 开头加上 `set +e` 覆盖这个默认值，允许捕获错误进行重试。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/alibaba/higress/issues/1052

### Ⅳ. Describe how to verify it
**准备工作**
在 `image-registry-wasm-go-plugin` Environment 中设置 secrets 和 variables.
<img width="840" alt="image" src="https://github.com/alibaba/higress/assets/40051120/6ef49292-86e6-4a36-a578-4537940efa0e">

**1. 通过 push tag 触发，构建所有 Wasm 插件并推送镜像仓库。**
[github action job](https://github.com/cr7258/higress/actions/runs/9688432199)
<img width="1234" alt="image" src="https://github.com/alibaba/higress/assets/40051120/1a789084-25b5-439a-a47e-98631790c044">

**2. 手动触发，构建指定的插件。**
手动触发需要将默认分支切换到代码的分支才能看到 `Run workflow` 按钮进行测试。

[github action job](https://github.com/cr7258/higress/actions/runs/9688440892)
<img width="1325" alt="image" src="https://github.com/alibaba/higress/assets/40051120/da9d26f1-d99b-42de-9b04-ae06a7c6b823">
<img width="1270" alt="image" src="https://github.com/alibaba/higress/assets/40051120/a32c0245-c5ab-4ec3-9895-8ff2ecfed7e8">

[错误重试](https://github.com/cr7258/higress/actions/runs/9688652749/job/26735612988#step:5:1090)
<img width="1441" alt="image" src="https://github.com/alibaba/higress/assets/40051120/6d141ff1-ba7b-49ef-a664-2fcd11f5c705">


