### PR TITLE
feat: update doc for running Ingress API conformance tests

### DIFF
--- a/test/README_CN.md
+++ b/test/README_CN.md
@@ -32,15 +32,15 @@ Higress 提供了运行 Ingress API 一致性测试和 wasmplugin 测试的 make
 4. kube-load-image: 将 dev higress-controller 镜像加载到 kind 集群中。
 5. install-dev: 使用 helm 安装带有 dev 镜像的 higress-controller，并安装最新的 higress-gateway、istiod。
 6. run-e2e-test:
-    1. 设置一致性测试套件，例如在 `e2e_test.go` / `higressTests Slice` 中定义我们想要运行的一致性测试。我们选择打开的每个测试都在 `test/ingress/conformance/tests` 中定义。
+    1. 所有测试都在 `test/e2e/conformance/tests` 中定义，并在初始化阶段被注册到`ConformanceTests`中。`ConormanceTests` 是一个全局变量，用于存储所有的一致性测试用例。
     2. 准备资源并将它们安装到集群中，例如后端服务/部署。
-    3. 在 `e2e_test.go` / `higressTests Slice` 中加载我们选择打开的一致性测试，并逐个运行它们，如果不符合预期，则失败。
+    3. 加载选择打开的一致性测试，并逐个运行它们，如果不符合预期，则失败。
 
 ### 如何编写测试用例
 
 要添加新的测试用例，首先需要在 `test/ingress/conformance/tests` 中添加 `xxx.go` 和 `xxx.yaml`。`xxx.yaml` 是您需要在集群中应用的 Ingress 资源，`xxx.go` 定义了 HigressConformanceTest。
 
-然后，您应该将您定义的 HigressConformanceTest 添加到 `e2e_test.go` / `higressTests Slice` 中。
+然后，您应该将您定义的测试用例注册到`ConormanceTests`中，方法是在xxx.go中使用`init()` 函数调用`Register(YOUR_PLUGIN_SHORT_NAME)`。
 
 通过查看 `test/ingress/conformance/tests/httproute-simple-same-namespace.go` 和 `test/ingress/conformance/tests/httproute-simple-same-namespace.yaml` 中的代码，您可以快速了解并尝试编写一个测试用例。
 
@@ -57,10 +57,10 @@ Higress 提供了运行 Ingress API 一致性测试和 wasmplugin 测试的 make
     - **make higress-conformance-test-clean:** 可用于清理 higress-controller、higress-gateway 等 deployment 的测试环境。
 
 2. **make higress-wasmplugin-test:** 用于运行整个 WasmPlugin 测试流程，包括搭建测试环境、编译 WasmPlugin 插件、运行测试用例、清理测试环境。
-    - **make higress-wasmplugin-test-prepare:** 可用于搭建 higress-controller、higress-gateway 等 deployment 的环境，并编译 WasmPlugin 插件。
+    - **make higress-wasmplugin-test-prepare:** 可用于搭建 higress-controller、higress-gateway 等 deployment 的环境，并编译 WasmPlugin 插件。通过设置变量`PLUGIN_NAME`仅编译指定插件。
     - **make run-higress-e2e-test-wasmplugin:** 可用于运行测试用例。
         - **make run-higress-e2e-test-wasmplugin-setup:** 可用于安装测试用例所需的基础资源，例如 nacos、dubbo 等。
-        - **make run-higress-e2e-test-wasmplugin-run:** 可用于运行测试用例。
+        - **make run-higress-e2e-test-wasmplugin-run:** 可用于运行测试用例。通过设置变量`TEST_SHORTNAME`仅运行指定测试。
         - **make run-higress-e2e-test-wasmplugin-clean:** 可用于清理测试用例在 setup 阶段所安装的基础资源。
     - **make higress-wasmplugin-test-clean:** 可用于清理 higress-controller、higress-gateway 等 deployment 的测试环境。
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
The commit adds support for running Ingress API conformance tests. The tests are defined in the `test/e2e/conformance/tests` directory and are registered in the `ConformanceTests` global variable. This allows developers to select and run specific conformance tests. The commit also updates the documentation to reflect the changes.
