### PR TITLE
feat:add build-and-push-wasm-plugin-image.yaml

### DIFF
--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: File Check
         run: | 
           workspace=${{ github.workspace }}/plugins/wasm-go/extensions/${PLUGIN_NAME}
+          push_command="./plugin.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip"
           
           # 查找spec.yaml
           if [ -f "${workspace}/spec.yaml" ]; then

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -93,7 +93,9 @@ jobs:
           cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
           go mod tidy
           tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom -tags='custommalloc nottinygc_finalizer' ./main.go
-          ls -al
+          tar czvf plugin.tar.gz plugin.wasm
+          echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}
+          oras push ${IMAGE_REGISTRY_SERVICE}/${IMAGE_REPOSITORY}:${VERSION} ${push_command}
           "
           docker exec builder bash -c "$command"
 

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -24,7 +24,7 @@ jobs:
       IMAGE_REGISTRY_SERVICE: ${{ vars.IMAGE_REGISTRY_SERVICE || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
       IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'plugins' }}
       GO_VERSION: 1.19
-      TINYGO_VERSION: 0.25.0
+      TINYGO_VERSION: 0.28.1
       ORAS_VERSION: 1.0.0
     steps:
       - name: Set plugin_name and version from inputs or ref_name
@@ -49,21 +49,18 @@ jobs:
       - name: File Check
         run: | 
           workspace=${{ github.workspace }}/plugins/wasm-go/extensions/${PLUGIN_NAME}
-          push_command="./plugin.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip"
           
           # 查找spec.yaml
           if [ -f "${workspace}/spec.yaml" ]; then
             echo "spec.yaml exists"
-            push_command="$push_command ./spec.yaml:application/vnd.module.wasm.spec.v1+yaml"
+            push_command="./spec.yaml:application/vnd.module.wasm.spec.v1+yaml $push_command "
           fi
 
           # 查找README.md
-          case "$(ls ${workspace}/README*.md 2>/dev/null)" in
-            *"README.md"*)
+          if [ -f "${workspace}/README.md" ];then
               echo "README.md exists"
-              push_command="$push_command ./README.md:application/vnd.module.wasm.doc.v1+markdown"
-              ;;
-          esac
+              push_command="./README.md:application/vnd.module.wasm.doc.v1+markdown $push_command "
+          fi
           
           # 查找README_{lang}.md
           for file in ${workspace}/README_*.md; do
@@ -71,7 +68,7 @@ jobs:
               file_name=$(basename $file)
               echo "$file_name exists"
               lang=$(basename $file | sed 's/README_//; s/.md//')
-              push_command="$push_command ./$file_name:application/vnd.module.wasm.doc.v1.$lang+markdown"
+              push_command="./$file_name:application/vnd.module.wasm.doc.v1.$lang+markdown $push_command "
             fi
           done
 
@@ -94,7 +91,7 @@ jobs:
           command="
           cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
           go mod tidy
-          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi ./main.go
+          tinygo build -o plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./
           tar czvf plugin.tar.gz /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}/plugin.wasm
           echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}
           oras push ${IMAGE_REGISTRY_SERVICE}/${IMAGE_REPOSITORY}:${VERSION} ${push_command}

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -93,7 +93,7 @@ jobs:
           cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
           export GOPROXY=https://goproxy.cn 
           go mod tidy
-          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./main.go
+          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom ./main.go
           ls -al
           "
           docker exec builder bash -c "$command"

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -94,6 +94,7 @@ jobs:
           export GOPROXY=https://goproxy.cn 
           go mod tidy
           tinygo build -o plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./
+          ls -al
           tar czvf plugin.tar.gz /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}/plugin.wasm
           echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}
           oras push ${IMAGE_REGISTRY_SERVICE}/${IMAGE_REPOSITORY}:${VERSION} ${push_command}

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -93,7 +93,7 @@ jobs:
           cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
           export GOPROXY=https://goproxy.cn 
           go mod tidy
-          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./
+          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./main.go
           ls -al
           tar czvf plugin.tar.gz /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}/plugin.wasm
           echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -94,8 +94,7 @@ jobs:
           export GOPROXY=https://goproxy.cn 
           go mod tidy
           tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./main.go
-          ls -al
-          tar czvf plugin.tar.gz /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}/plugin.wasm
+          tar czvf plugin.tar.gz plugin.wasm
           echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}
           oras push ${IMAGE_REGISTRY_SERVICE}/${IMAGE_REPOSITORY}:${VERSION} ${push_command}
           "

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -50,7 +50,7 @@ jobs:
         run: | 
           workspace=${{ github.workspace }}/plugins/wasm-go/extensions/${PLUGIN_NAME}
           push_command="./plugin.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip"
-          
+
           # 查找spec.yaml
           if [ -f "${workspace}/spec.yaml" ]; then
             echo "spec.yaml exists"
@@ -91,6 +91,7 @@ jobs:
 
           command="
           cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
+          export GOPROXY=https://goproxy.cn 
           go mod tidy
           tinygo build -o plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./
           tar czvf plugin.tar.gz /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}/plugin.wasm

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -1,0 +1,104 @@
+name: Build and Push Wasm Plugin Image
+
+on:
+  push:
+    tags:
+    - "wasm-go-*-v*.*.*" # 匹配 wasm-go-{pluginName}-vX.Y.Z 格式的标签
+  workflow_dispatch:
+    inputs:
+      plugin_name:
+        description: 'Name of the plugin'
+        required: true
+        type: string
+      version:
+        description: 'Version of the plugin (optional, without leading v)'
+        required: false
+        type: string
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    environment:
+      name: image-registry-msg
+    env:
+      IMAGE_REGISTRY_SERVICE: ${{ vars.IMAGE_REGISTRY_SERVICE || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
+      IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'plugins' }}
+      GO_VERSION: 1.19
+      TINYGO_VERSION: 0.25.0
+      ORAS_VERSION: 1.0.0
+    steps:
+      - name: Set plugin_name and version from inputs or ref_name
+        id: set_vars
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            plugin_name="${{ github.event.inputs.plugin_name }}"
+            version="${{ github.event.inputs.version }}"
+          else
+            ref_name=${{ github.ref_name }}
+            plugin_name=${ref_name#*-*-} # 删除插件名前面的字段(wasm-go-)
+            plugin_name=${plugin_name%-*} # 删除插件名后面的字段(-vX.Y.Z)
+            version=$(echo "$ref_name" | awk -F'v' '{print $2}')
+          fi
+
+          echo "PLUGIN_NAME=$plugin_name" >> $GITHUB_ENV
+          echo "VERSION=$version" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+      
+      - name: File Check
+        run: | 
+          workspace=${{ github.workspace }}/plugins/wasm-go/extensions/${PLUGIN_NAME}
+          push_command="./plugin.tar.gz:application/vnd.oci.image.layer.v1.tar+gzip"
+          
+          # 查找spec.yaml
+          if [ -f "${workspace}/spec.yaml" ]; then
+            echo "spec.yaml exists"
+            push_command="$push_command ./spec.yaml:application/vnd.module.wasm.spec.v1+yaml"
+          fi
+
+          # 查找README.md
+          case "$(ls ${workspace}/README*.md 2>/dev/null)" in
+            *"README.md"*)
+              echo "README.md exists"
+              push_command="$push_command ./README.md:application/vnd.module.wasm.doc.v1+markdown"
+              ;;
+          esac
+          
+          # 查找README_{lang}.md
+          for file in ${workspace}/README_*.md; do
+            if [ -f "$file" ]; then
+              file_name=$(basename $file)
+              echo "$file_name exists"
+              lang=$(basename $file | sed 's/README_//; s/.md//')
+              push_command="$push_command ./$file_name:application/vnd.module.wasm.doc.v1.$lang+markdown"
+            fi
+          done
+
+          echo "PUSH_COMMAND=\"$push_command\"" >> $GITHUB_ENV
+        
+      - name: Run a wasm-go-builder
+        env: 
+          PLUGIN_NAME: ${{ env.PLUGIN_NAME }}
+          BUILDER_IMAGE: higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/wasm-go-builder:go${{ env.GO_VERSION }}-tinygo${{ env.TINYGO_VERSION }}-oras${{ env.ORAS_VERSION }}
+        run: |
+          docker run -itd --name builder -v ${{ github.workspace }}:/workspace -e PLUGIN_NAME=${{ env.PLUGIN_NAME }} --rm ${{ env.BUILDER_IMAGE }} /bin/bash
+
+      - name: Build Image and Push
+        run: |
+          
+          push_command=${{ env.PUSH_COMMAND }}
+          push_command=${push_command#\"}
+          push_command=${push_command%\"} # 删除PUSH_COMMAND中的双引号，确保oras push正常解析
+
+          command="
+          cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
+          go mod tidy
+          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi ./main.go
+          tar czvf plugin.tar.gz /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}/plugin.wasm
+          echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}
+          oras push ${IMAGE_REGISTRY_SERVICE}/${IMAGE_REPOSITORY}:${VERSION} ${push_command}
+          "
+          docker exec builder bash -c "$command"
+
+          

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -94,9 +94,7 @@ jobs:
           export GOPROXY=https://goproxy.cn 
           go mod tidy
           tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./main.go
-          tar czvf plugin.tar.gz plugin.wasm
-          echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}
-          oras push ${IMAGE_REGISTRY_SERVICE}/${IMAGE_REPOSITORY}:${VERSION} ${push_command}
+          ls -al
           "
           docker exec builder bash -c "$command"
 

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -91,9 +91,8 @@ jobs:
 
           command="
           cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
-          export GOPROXY=https://goproxy.cn 
           go mod tidy
-          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom ./main.go
+          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom -tags='custommalloc nottinygc_finalizer' ./main.go
           ls -al
           "
           docker exec builder bash -c "$command"

--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -93,7 +93,7 @@ jobs:
           cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
           export GOPROXY=https://goproxy.cn 
           go mod tidy
-          tinygo build -o plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./
+          tinygo build -o ./plugin.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer" ./
           ls -al
           tar czvf plugin.tar.gz /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}/plugin.wasm
           echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

功能：添加了利用 GitHub Actions 来自动完成相应的镜像构建和发布工作的Workflow。支持通过push tag和手动触发两种方式。同时也遵循使用oras打包工具。
特点：完全按照[Wasm 插件镜像规范](https://higress.io/zh-cn/docs/user/wasm-image-spec/)进行镜像打包。

更新：

1. 添加了查找文件的逻辑，会在插件目录中查找`spec.yaml`、`README.md`和`README-{lang}.md`三个文件，有则在打包推送镜像时设置相应的`media type`。
2. 修改了review后存在的问题。
3. 修改了`builder`容器的启动命令为 `docker run -itd --name builder xxx /bin/bash`，之前使用`sleep 99999`是希望容器保持后台持续运行，这样只适合测试容器，不适合在生产环境中使用。
4. 重新提交`PR`是因为错误地提交了一些没用的`commit`，不太会删除，担心破坏仓库并且为了保持`PR`整洁所以重新提交。

### Ⅱ. Does this pull request fix one issue?

fixes #1052 

### Ⅳ. Describe how to verify it

1.准备工作
添加Repository Secrets和 Repository variables。
![img](https://gitee.com/beatrueman/images/raw/master/img/202406291116573.png)
![img](https://camo.githubusercontent.com/c70982b37d47a9898639e98f34d2db7c51a199e9dacf1b9f8118192c683f1a7f/68747470733a2f2f67697465652e636f6d2f626561747275656d616e2f696d616765732f7261772f6d61737465722f696d672f3230323430363237313230303530352e706e67)
2.通过`push tag`触发，先查找相关文件，然后将特定的插件打包成镜像并推送至指定仓库。
![image](https://gitee.com/beatrueman/images/raw/master/img/202406291116729.png)

![image-20240629120147125](https://gitee.com/beatrueman/images/raw/master/img/202406291201172.png)

![image-20240629125144171](https://gitee.com/beatrueman/images/raw/master/img/202406291251252.png)
![image-20240629125028239](https://gitee.com/beatrueman/images/raw/master/img/202406291250306.png)
3.人工触发，指定插件名和版本号
![51e1fc7ab267c66492ecbcfb43cd23d0](https://gitee.com/beatrueman/images/raw/master/img/202406291116732.png)![image](https://gitee.com/beatrueman/images/raw/master/img/202406291116270.png)

### Ⅴ. Special notes for reviews

这是我第一次参与开源贡献，希望能有所帮助！