### PR TITLE
fix: prometheus port

### DIFF
--- a/helm/core/templates/deployment.yaml
+++ b/helm/core/templates/deployment.yaml
@@ -203,6 +203,9 @@ spec:
             value: {{ $val | quote }}
           {{- end }}
           ports:
+          - containerPort: 15020
+            protocol: TCP
+            name: istio-agent-prom
           - containerPort: 15090
             protocol: TCP
             name: http-envoy-prom

--- a/helm/core/templates/deployment.yaml
+++ b/helm/core/templates/deployment.yaml
@@ -205,7 +205,7 @@ spec:
           ports:
           - containerPort: 15020
             protocol: TCP
-            name: istio-agent-prom
+            name: istio-prom
           - containerPort: 15090
             protocol: TCP
             name: http-envoy-prom

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -446,7 +446,7 @@ gateway:
   annotations: {}
 
   podAnnotations:
-    prometheus.io/port: "15090"
+    prometheus.io/port: "15020"
     prometheus.io/scrape: "true"
     prometheus.io/path: "/stats/prometheus"
     sidecar.istio.io/inject: "false"

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -446,7 +446,7 @@ gateway:
   annotations: {}
 
   podAnnotations:
-    prometheus.io/port: "15020"
+    prometheus.io/port: "15090"
     prometheus.io/scrape: "true"
     prometheus.io/path: "/stats/prometheus"
     sidecar.istio.io/inject: "false"


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
当前 higress-gateway 设置的 containerPort 是 15090，和默认的 `prometheus.io/port` 注解设置的端口号（15020）不一致，导致无法正常通过 PodMonitor 来抓取指标。
```yaml
relabelings:
    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
      action: replace
      regex: ([^:]+)(?::\d+)?;(\d+)
      replacement: $1:$2
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes https://github.com/alibaba/higress/issues/993

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

- 1.安装 Prometheus Operator: https://prometheus-operator.dev/docs/user-guides/getting-started/
- 2.创建 PodMonitor 从 higress-gateway 的 `http-envoy-prom` 端口采集指标，端口号根据 `prometheus.io/port` 注解来获取。
```yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: higress-gateway-pod-monitor
spec:
  podMetricsEndpoints:
  - interval: 30s
    port: http-envoy-prom
    path: /stats/prometheus
    relabelings:
    - sourceLabels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
      action: replace
      regex: ([^:]+)(?::\d+)?;(\d+)
      replacement: $1:$2
      targetLabel: __address__
    - action: labelmap
      regex: __meta_kubernetes_pod_label_(.+)
    - sourceLabels: [__meta_kubernetes_namespace]
      action: replace
      targetLabel: kubernetes_namespace
    - sourceLabels: [__meta_kubernetes_pod_name]
      action: replace
      targetLabel: kubernetes_pod_name
  namespaceSelector:
    matchNames:
    - higress-system
  selector:
    matchLabels:
      app: higress-gateway
```

<img width="1263" alt="image" src="https://github.com/alibaba/higress/assets/40051120/88bf4653-a19c-4bf6-acdf-422912c51c50">


### Ⅴ. Special notes for reviews

