### PR TITLE
feat: Support fallback route in ai-proxy plugin

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -75,6 +75,11 @@ func onHttpRequestHeader(ctx wrapper.HttpContext, pluginConfig config.PluginConf
 
 		action, err := handler.OnRequestHeaders(ctx, apiName, log)
 		if err == nil {
+			if contentType, err := proxywasm.GetHttpRequestHeader("Content-Type"); err == nil && contentType != "" {
+				// Always return types.HeaderStopIteration to support fallback routing,
+				// as long as onHttpRequestBody can be called.
+				return types.HeaderStopIteration
+			}
 			return action
 		}
 		_ = util.SendResponse(500, "ai-proxy.proc_req_headers_failed", util.MimeTypeTextPlain, fmt.Sprintf("failed to process request headers: %v", err))


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Support fallback route in ai-proxy plugin by always returning types.HeaderStopIteration in onHttpRequestHeader if the request has a body.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

