### PR TITLE
feat: improve Skywalking and Zipkin integration

### DIFF
--- a/helm/core/templates/_helpers.tpl
+++ b/helm/core/templates/_helpers.tpl
@@ -97,7 +97,7 @@ higress: {{ include "controller.name" . }}
 {{- end }}
 
 {{- define "skywalking.enabled" -}}
-{{- if and .Values.skywalking.enabled .Values.skywalking.service.address }}
+{{- if and .Values.tracing.enable (hasKey .Values.tracing "skywalking") .Values.tracing.skywalking.service }}
 true
 {{- end }}
 {{- end }}

--- a/helm/core/templates/configmap.yaml
+++ b/helm/core/templates/configmap.yaml
@@ -46,10 +46,6 @@
           address: {{ .Values.global.tracer.lightstep.address }}
           # Access Token used to communicate with the Satellite pool
           accessToken: {{ .Values.global.tracer.lightstep.accessToken }}
-      {{- else if eq .Values.global.proxy.tracer "zipkin" }}
-        zipkin:
-          # Address of the Zipkin collector
-          address: {{ .Values.global.tracer.zipkin.address | default (print "zipkin." .Release.Namespace ":9411") }}
       {{- else if eq .Values.global.proxy.tracer "datadog" }}
         datadog:
           # Address of the Datadog Agent
@@ -109,7 +105,11 @@ metadata:
   labels:
     {{- include "gateway.labels" . | nindent 4 }}    
 data:
-
+  higress: |-
+  {{- if .Values.tracing.enable }}
+    tracing:
+{{ toYaml .Values.tracing | trim | indent 6 }}
+  {{- end }}
   # Configuration file for the mesh networks to be used by the Split Horizon EDS.
   meshNetworks: |-
   {{- if .Values.global.meshNetworks }}
@@ -170,8 +170,8 @@ data:
                       "endpoint": {
                         "address": {
                           "socket_address": {
-                            "address": "{{ .Values.skywalking.service.address }}",
-                            "port_value": "{{ .Values.skywalking.service.port }}"
+                            "address": "{{ .Values.tracing.skywalking.service }}",
+                            "port_value": "{{ .Values.tracing.skywalking.port }}"
                           }
                         }
                       }

--- a/helm/core/templates/configmap.yaml
+++ b/helm/core/templates/configmap.yaml
@@ -106,10 +106,13 @@ metadata:
     {{- include "gateway.labels" . | nindent 4 }}    
 data:
   higress: |-
-  {{- if .Values.tracing.enable }}
-    tracing:
-{{ toYaml .Values.tracing | trim | indent 6 }}
-  {{- end }}
+    {{- $existingConfig := lookup "v1" "ConfigMap" .Release.Namespace "higress-config" }}
+    {{- $existingData := index $existingConfig.data "higress" | default "{}" | fromYaml }}
+    {{- $newData := dict }}
+    {{- if .Values.tracing.enable }}
+    {{- $_ := set $newData "tracing" .Values.tracing }}
+    {{- end }}
+    {{- toYaml (merge $existingData $newData) | nindent 4 }}
   # Configuration file for the mesh networks to be used by the Split Horizon EDS.
   meshNetworks: |-
   {{- if .Values.global.meshNetworks }}

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -178,9 +178,9 @@ global:
     # Default port for Pilot agent health checks. A value of 0 will disable health checking.
     statusPort: 15020
 
-    # Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.
+    # Specify which tracer to use. One of: lightstep, datadog, stackdriver.
     # If using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.
-    tracer: "zipkin"
+    tracer: ""
 
     # Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready
     holdApplicationUntilProxyStarts: false
@@ -330,12 +330,8 @@ global:
       maxNumberOfAnnotations: 200
       # The global default max number of attributes per span.
       maxNumberOfAttributes: 200
-    zipkin:
-      # Host:Port for reporting trace data in zipkin format. If not specified, will default to
-      # zipkin service (port 9411) in the same namespace as the other istio components.
-      address: ""
-
   # Use the Mesh Control Protocol (MCP) for configuring Istiod. Requires an MCP source.
+
   useMCP: false
 
   # Observability (o11y) configurations
@@ -667,9 +663,15 @@ pilot:
   podLabels: {}
 
 
-# Skywalking config settings
-skywalking:
-  enabled: false
-  service:
-    address: ~
-    port: 11800
+# Tracing config settings
+tracing:
+  enable: false
+  sampling: 100
+  timeout: 500
+  skywalking:
+   # access_token: ""
+   service: ""
+   port: 11800
+  # zipkin:
+    # service: ""
+    # port: 9411


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Improve SkyWalking and Zipkin integration by configuring higress-config Configmap based on helm values.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/alibaba/higress/issues/478

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

**SkyWalking**
```yaml
tracing:
  enabled: true
  sampling: 100
  timeout: 500
  skywalking:
    # access_token: ""
    service: skywalking-oap-server.op-system.svc.cluster.local
    port: 11800
```
<img width="890" alt="image" src="https://github.com/user-attachments/assets/69d1e5dc-6df8-4973-9486-d23ca651fe20">

**Zipkin**
```yaml
tracing:
  enabled: true
  sampling: 100
  timeout: 500
  zipkin:
    service: zipkin.zipkin.svc.cluster.local
    port: 9411
```
<img width="1592" alt="image" src="https://github.com/user-attachments/assets/b99f66cf-e829-46be-80dd-f80f71b3bff1">


### Ⅴ. Special notes for reviews

