### PR TITLE
feat: Make higress-core and higress-gateway as the default container

### DIFF
--- a/helm/core/templates/controller-deployment.yaml
+++ b/helm/core/templates/controller-deployment.yaml
@@ -32,6 +32,64 @@ spec:
       securityContext:
         {{- toYaml .Values.controller.podSecurityContext | nindent 8 }}
       containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.controller.securityContext | nindent 12 }}
+          image: "{{ .Values.controller.hub | default .Values.global.hub }}/{{ .Values.controller.image | default "higress" }}:{{ .Values.controller.tag | default .Chart.AppVersion }}"
+          args:
+          - "serve"
+          - --gatewaySelectorKey=higress
+          - --gatewaySelectorValue={{ .Release.Namespace }}-{{ include "gateway.name" . }}
+          - --gatewayHttpPort={{ .Values.gateway.httpPort }}
+          - --gatewayHttpsPort={{ .Values.gateway.httpsPort }}
+          {{- if not .Values.global.enableStatus }}
+          - --enableStatus={{ .Values.global.enableStatus }}
+          {{- end }}
+          - --ingressClass={{ .Values.global.ingressClass }}
+          {{- if .Values.global.watchNamespace }}
+          - --watchNamespace={{ .Values.global.watchNamespace }}
+          {{- end }}
+          - --enableAutomaticHttps={{ .Values.controller.automaticHttps.enabled }}
+          - --automaticHttpsEmail={{ .Values.controller.automaticHttps.email }}
+          env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: spec.serviceAccountName
+          - name: DOMAIN_SUFFIX
+            value: {{ .Values.global.proxy.clusterDomain }}
+          {{- if .Values.controller.env }}
+          {{- range $key, $val := .Values.controller.env }}
+          - name: {{ $key }}
+            value: "{{ $val }}"
+          {{- end }}
+          {{- end }}
+          ports:
+            {{- range $idx, $port := .Values.controller.ports }}
+            - name: {{ $port.name }}
+              containerPort: {{ $port.port }}
+              protocol: {{ $port.protocol }}
+            {{- end }}
+          readinessProbe:
+            {{- toYaml .Values.controller.probe | nindent 12 }}
+          {{- if not (or .Values.global.local .Values.global.kind) }}
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          - name: log
+            mountPath: /var/log
 {{- if not .Values.global.enableHigressIstio }}
         - name: discovery
           image: "{{ .Values.pilot.hub | default .Values.global.hub }}/{{ .Values.pilot.image | default "pilot" }}:{{ .Values.pilot.tag | default .Chart.AppVersion }}"
@@ -194,64 +252,6 @@ spec:
             mountPath: /cacerts
           {{- end }}
 {{- end }}
-        - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.controller.securityContext | nindent 12 }}
-          image: "{{ .Values.controller.hub | default .Values.global.hub }}/{{ .Values.controller.image | default "higress" }}:{{ .Values.controller.tag | default .Chart.AppVersion }}"
-          args:
-          - "serve"
-          - --gatewaySelectorKey=higress
-          - --gatewaySelectorValue={{ .Release.Namespace }}-{{ include "gateway.name" . }}
-          - --gatewayHttpPort={{ .Values.gateway.httpPort }}
-          - --gatewayHttpsPort={{ .Values.gateway.httpsPort }}
-          {{- if not .Values.global.enableStatus }}
-          - --enableStatus={{ .Values.global.enableStatus }}
-          {{- end }}
-          - --ingressClass={{ .Values.global.ingressClass }}
-          {{- if .Values.global.watchNamespace }}
-          - --watchNamespace={{ .Values.global.watchNamespace }}
-          {{- end }}
-          - --enableAutomaticHttps={{ .Values.controller.automaticHttps.enabled }}
-          - --automaticHttpsEmail={{ .Values.controller.automaticHttps.email }}
-          env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
-          - name: SERVICE_ACCOUNT
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: spec.serviceAccountName
-          - name: DOMAIN_SUFFIX
-            value: {{ .Values.global.proxy.clusterDomain }}
-          {{- if .Values.controller.env }}
-          {{- range $key, $val := .Values.controller.env }}
-          - name: {{ $key }}
-            value: "{{ $val }}"
-          {{- end }}
-          {{- end }}
-          ports:
-            {{- range $idx, $port := .Values.controller.ports }}
-            - name: {{ $port.name }}
-              containerPort: {{ $port.port }}
-              protocol: {{ $port.protocol }}
-            {{- end }}
-          readinessProbe:
-            {{- toYaml .Values.controller.probe | nindent 12 }}
-          {{- if not (or .Values.global.local .Values.global.kind) }}
-          resources:
-            {{- toYaml .Values.controller.resources | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-          - name: log
-            mountPath: /var/log
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/core/templates/deployment.yaml
+++ b/helm/core/templates/deployment.yaml
@@ -72,40 +72,6 @@ spec:
           value: "0"
       {{- end }}
       containers:
-        {{- if $o11y.enabled }}
-          {{- $config := $o11y.promtail }}
-        - name: promtail
-          image: {{ $config.image.repository }}:{{ $config.image.tag }}
-          imagePullPolicy: IfNotPresent
-          args:
-            - -config.file=/etc/promtail/promtail.yaml
-          env:
-            - name: 'HOSTNAME'
-              valueFrom:
-                fieldRef:
-                  fieldPath: 'spec.nodeName'
-          ports:
-            - containerPort: {{ $config.port }}
-              name: http-metrics
-              protocol: TCP
-          readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /ready
-              port: {{ $config.port }}
-              scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          volumeMounts:
-            - name: promtail-config
-              mountPath: "/etc/promtail"
-            - name: log
-              mountPath: /var/log/proxy
-            - name: tmp
-              mountPath: /tmp
-        {{- end }}
         - name: higress-gateway
           image: "{{ .Values.gateway.hub | default .Values.global.hub }}/{{ .Values.gateway.image | default "gateway" }}:{{ .Values.gateway.tag | default .Chart.AppVersion }}"
           args:
@@ -264,6 +230,40 @@ spec:
           - mountPath: /var/log/proxy
             name: log
           {{- end }}
+        {{- if $o11y.enabled }}
+          {{- $config := $o11y.promtail }}
+        - name: promtail
+          image: {{ $config.image.repository }}:{{ $config.image.tag }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - -config.file=/etc/promtail/promtail.yaml
+          env:
+            - name: 'HOSTNAME'
+              valueFrom:
+                fieldRef:
+                  fieldPath: 'spec.nodeName'
+          ports:
+            - containerPort: {{ $config.port }}
+              name: http-metrics
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: {{ $config.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: promtail-config
+              mountPath: "/etc/promtail"
+            - name: log
+              mountPath: /var/log/proxy
+            - name: tmp
+              mountPath: /tmp
+        {{- end }}
       {{- if .Values.gateway.hostNetwork }}
       hostNetwork: {{ .Values.gateway.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Make higress-core and higress-gateway as the default container, so it would be easier for users to run `kubectl logs` and `kubectl exec` commands.

![image](https://github.com/user-attachments/assets/c6181b43-8e83-4cb2-8cb6-a27f7c63c794)

![image](https://github.com/user-attachments/assets/2016e6e2-9f57-488b-a2bc-76c7383596ae)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

Q: Why don't I use the `kubectl.kubernetes.io/default-container` mentioned here (https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/2227-kubectl-default-container/README.md)?

A: Although we get almost the same result after adding this annotation, the first line output, `Defaulted container "higress-core" out of: higress-core, discovery` will disappear, making users more difficult to know all the container names.