### PR TITLE
fix: fix tracing configmap template to handle initial installation

### DIFF
--- a/helm/core/templates/_helpers.tpl
+++ b/helm/core/templates/_helpers.tpl
@@ -97,7 +97,7 @@ higress: {{ include "controller.name" . }}
 {{- end }}
 
 {{- define "skywalking.enabled" -}}
-{{- if and .Values.tracing.enable (hasKey .Values.tracing "skywalking") .Values.tracing.skywalking.service }}
+{{- if and (hasKey .Values "tracing") .Values.tracing.enable (hasKey .Values.tracing "skywalking") .Values.tracing.skywalking.service }}
 true
 {{- end }}
 {{- end }}

--- a/helm/core/templates/configmap.yaml
+++ b/helm/core/templates/configmap.yaml
@@ -107,7 +107,10 @@ metadata:
 data:
   higress: |-
     {{- $existingConfig := lookup "v1" "ConfigMap" .Release.Namespace "higress-config" }}
-    {{- $existingData := index $existingConfig.data "higress" | default "{}" | fromYaml }}
+    {{- $existingData := dict }}
+    {{- if $existingConfig }}
+    {{- $existingData = index $existingConfig.data "higress" | default "{}" | fromYaml }}
+    {{- end }}
     {{- $newData := dict }}
     {{- if .Values.tracing.enable }}
     {{- $_ := set $newData "tracing" .Values.tracing }}

--- a/helm/core/templates/configmap.yaml
+++ b/helm/core/templates/configmap.yaml
@@ -112,7 +112,7 @@ data:
     {{- $existingData = index $existingConfig.data "higress" | default "{}" | fromYaml }}
     {{- end }}
     {{- $newData := dict }}
-    {{- if .Values.tracing.enable }}
+    {{- if and (hasKey .Values "tracing") .Values.tracing.enable }}
     {{- $_ := set $newData "tracing" .Values.tracing }}
     {{- end }}
     {{- toYaml (merge $existingData $newData) | nindent 4 }}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

https://github.com/alibaba/higress/actions/runs/10304239283/job/28522475167
```
helm install higress helm/core -n higress-system --create-namespace --set 'controller.tag=fec2e9dfc9571f27e1d97aa4590de97ff27e8235' --set 'gateway.replicas=1' --set 'pilot.tag=sha-59acb61' --set 'gateway.tag=sha-59acb61' --set 'global.local=true'
Error: INSTALLATION FAILED: template: higress-core/templates/configmap.yaml:110:25: executing "higress-core/templates/configmap.yaml" at <index $existingConfig.data "higress">: error calling index: index of untyped nil
make: *** [Makefile.core.mk:184: install-dev] Error 1
```

首次 helm install 的时候 higress-config ConfigMap 不存在，因此会导致这个错误。添加判断逻辑处理该情况。
另外还处理了 tracing 配置完全没有设置的情况。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

