### PR TITLE
Support Openai structure output api  (#feat 1214)

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/README.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README.md
@@ -52,6 +52,7 @@ OpenAI 所对应的 `type` 为 `openai`。它特有的配置字段如下:
 | 名称              | 数据类型 | 填写要求 | 默认值 | 描述                                                                          |
 |-------------------|----------|----------|--------|-------------------------------------------------------------------------------|
 | `openaiCustomUrl` | string   | 非必填   | -      | 基于OpenAI协议的自定义后端URL，例如: www.example.com/myai/v1/chat/completions |
+| `responseJsonSchema` | object | 非必填 | - | 预先定义OpenAI响应需满足的Json Schema, 注意目前仅特定的几种模型支持该用法|
 
 
 #### Azure OpenAI

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -31,6 +31,7 @@ type chatCompletionRequest struct {
 	ToolChoice       *toolChoice    `json:"tool_choice,omitempty"`
 	User             string         `json:"user,omitempty"`
 	Stop             []string       `json:"stop,omitempty"`
+	ResponseFormat   map[string]interface{} `json:"response_format,omitempty"`
 }
 
 type streamOptions struct {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
@@ -89,6 +89,10 @@ func (m *openaiProvider) OnRequestBody(ctx wrapper.HttpContext, apiName ApiName,
 	if err := decodeChatCompletionRequest(body, request); err != nil {
 		return types.ActionContinue, err
 	}
+	if m.config.responseJsonSchema != nil {
+		log.Debugf("[ai-proxy] set response format to %s", m.config.responseJsonSchema)
+		request.ResponseFormat = m.config.responseJsonSchema
+	}
 	if request.Stream {
 		// For stream requests, we need to include usage in the response.
 		if request.StreamOptions == nil {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -232,7 +232,13 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 		}
 	}
 	c.targetLang = json.Get("targetLang").String()
-	c.responseJsonSchema = json.Get("responseJsonSchema").Value().(map[string]interface{})
+	
+	if schemaValue, ok := json.Get("responseJsonSchema").Value().(map[string]interface{}); ok {
+		c.responseJsonSchema = schemaValue
+	} else {
+		c.responseJsonSchema = nil 
+	}
+	
 }
 
 func (c *ProviderConfig) Validate() error {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -181,6 +181,9 @@ type ProviderConfig struct {
 	// @Title zh-CN 翻译服务需指定的目标语种
 	// @Description zh-CN 翻译结果的语种，目前仅适用于DeepL服务。
 	targetLang string `required:"false" yaml:"targetLang" json:"targetLang"`
+	// @Title zh-CN  指定服务返回的响应需满足的JSON Schema
+	// @Description zh-CN 目前仅适用于OpenAI部分模型服务。参考：https://platform.openai.com/docs/guides/structured-outputs
+	responseJsonSchema map[string]interface{} `required:"false" yaml:"responseJsonSchema" json:"responseJsonSchema"`
 }
 
 func (c *ProviderConfig) FromJson(json gjson.Result) {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -232,6 +232,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 		}
 	}
 	c.targetLang = json.Get("targetLang").String()
+	c.responseJsonSchema = json.Get("responseJsonSchema").Value().(map[string]interface{})
 }
 
 func (c *ProviderConfig) Validate() error {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
使得AI-Proxy插件支持OpenAI结构化输出接口

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #1214 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
# File generated by hgctl. Modify as required.
Envoy.yaml:
```yaml
admin:
  address:
    socket_address:
      protocol: TCP
      address: 0.0.0.0
      port_value: 9901
static_resources:
  listeners:
    - name: listener_0
      address:
        socket_address:
          protocol: TCP
          address: 0.0.0.0
          port_value: 10000
      filter_chains:
        - filters:
            - name: envoy.filters.network.http_connection_manager
              typed_config:
                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                scheme_header_transformation:
                  scheme_to_overwrite: https
                stat_prefix: ingress_http
                # Output envoy logs to stdout
                access_log:
                  - name: envoy.access_loggers.stdout
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
                # Modify as required
                route_config:
                  name: local_route
                  virtual_hosts:
                    - name: local_service
                      domains: [ "*" ]
                      routes:
                        - match:
                            prefix: "/"
                          route:
                            cluster: moonshot
                            timeout: 300s
                http_filters:
                  - name: wasmtest
                    typed_config:
                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                      value:
                        config:
                          name: wasmtest
                          vm_config:
                            runtime: envoy.wasm.runtime.v8
                            code:
                              local:
                                filename: /etc/envoy/main.wasm
                          configuration:
                            "@type": "type.googleapis.com/google.protobuf.StringValue"
                            value: |
                              {
                                "provider": {
                                  "type": "openai",
                                  "apiTokens": [
                                    "Add you own"
                                  ],
                                  "timeout": 1200000,
                                  "modelMapping": {
                                    "*": "gpt-4o-2024-08-06"
                                  },
                                  "responseJsonSchema": {
                                      "type": "json_schema",
                                      "json_schema": {
                                          "schema": {
                                              "properties": {
                                                  "name": {"title": "Name", "type": "string"},
                                                  "date": {"title": "Date", "type": "string"},
                                                  "participants": {
                                                      "title": "Participants",
                                                      "type": "array",
                                                      "items": {"type": "string"}
                                                  }
                                              },
                                              "required": ["name", "date", "participants"],
                                              "title": "CalendarEvent",
                                              "type": "object",
                                              "additionalProperties": false
                                          },
                                          "name": "CalendarEvent",
                                          "strict": true
                                      }
                                  }
                                }
                              }
                  - name: envoy.filters.http.router
  clusters:
    - name: outbound|443||qwen.dns
      connect_timeout: 30s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: outbound|443||qwen.dns
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: api.openai.com
                      port_value: 443
      transport_socket:
        name: envoy.transport_sockets.tls
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
          "sni": "api.openai.com"
    - name: moonshot
      connect_timeout: 30s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: moonshot
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: api.openai.com
                      port_value: 443
                    # socket_address:
                      # address: mitmproxy    # Assuming mitmproxy is running locally
                      # port_value: 8080
      transport_socket:
        name: envoy.transport_sockets.tls
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
          "sni": "api.openai.com"
```
```bash
curl -X POST "http://***/v1/chat/completions" \
-H "Content-Type: application/json" \
-d '{
  "model": "gpt-4o-2024-08-06",
  "messages": [
    {"role": "user", "content": "Please extract event form this sentence: Alice and Bob are going to a science fair on Friday."}
  ]
}'
```
回答为:
```bash
{
  "id": "chatcmpl-9wyhgw9gSP73346pADecWEXzZdTQC",
  "object": "chat.completion",
  "created": 1723843396,
  "model": "gpt-4o-2024-08-06",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "{\"date\":\"Friday\",\"name\":\"Science Fair\",\"participants\":[\"Alice\",\"Bob\"]}",
        "refusal": null
      },
      "logprobs": null,
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 30,
    "completion_tokens": 17,
    "total_tokens": 47
  },
  "system_fingerprint": "fp_2a322c9ffc"
```
### Ⅴ. Special notes for reviews
1. 是否需要为千问等添加类似接口
2. 是否需要在读取JSON schema时，验证配置
3. 是否需要限定模型（目前只有gpt-4o-2024-08-06支持该配置）
