### PR TITLE
fix: Use shallow mode when cloning submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,27 +2,34 @@
 	path = istio/api
 	url = https://github.com/higress-group/api
 	branch = istio-1.19
+	shallow = true
 [submodule "istio/istio"]
 	path = istio/istio
 	url = https://github.com/higress-group/istio
 	branch = istio-1.19
+	shallow = true
 [submodule "istio/client-go"]
 	path = istio/client-go
 	url = https://github.com/higress-group/client-go
 	branch = istio-1.19
+	shallow = true
 [submodule "istio/pkg"]
 	path = istio/pkg
 	url = https://github.com/higress-group/pkg
 	branch = istio-1.19
+	shallow = true
 [submodule "istio/proxy"]
 	path = istio/proxy
 	url = https://github.com/higress-group/proxy
-        branch = istio-1.19
+	branch = istio-1.19
+	shallow = true
 [submodule "envoy/go-control-plane"]
 	path = envoy/go-control-plane
 	url = https://github.com/higress-group/go-control-plane
-        branch = istio-1.19
+	branch = istio-1.19
+	shallow = true
 [submodule "envoy/envoy"]
 	path = envoy/envoy
 	url = https://github.com/higress-group/envoy
-        branch = envoy-1.27
+	branch = envoy-1.27
+	shallow = true


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Use shallow mode when cloning submodules to avoid the following error:

```
error: rpc failed; curl 18 transfer closed with outstanding read data remaining
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

