### PR TITLE
fix: Wasm-rust plugin crashed when header name or value is not a valid UTF8 string

### DIFF
--- a/plugins/wasm-rust/src/plugin_wrapper.rs
+++ b/plugins/wasm-rust/src/plugin_wrapper.rs
@@ -14,12 +14,11 @@
 
 use crate::rule_matcher::SharedRuleMatcher;
 use multimap::MultiMap;
+use proxy_wasm::hostcalls::log;
 use proxy_wasm::traits::{Context, HttpContext, RootContext};
+use proxy_wasm::types::LogLevel;
 use proxy_wasm::types::{Action, Bytes, DataAction, HeaderAction};
 use serde::de::DeserializeOwned;
-use proxy_wasm::hostcalls::log;
-use proxy_wasm::types::LogLevel;
-
 
 pub trait RootContextWrapper<PluginConfig>: RootContext
 where
@@ -155,8 +154,13 @@ where
                 Err(_) => {
                     log(
                         LogLevel::Warn,
-                        format!("request http header contains non-ASCII characters header: {}", k ).as_str(),
-                    ).unwrap();
+                        format!(
+                            "request http header contains non-ASCII characters header: {}",
+                            k
+                        )
+                        .as_str(),
+                    )
+                    .unwrap();
                 }
             }
         }
@@ -210,8 +214,13 @@ where
                 Err(_) => {
                     log(
                         LogLevel::Warn,
-                        format!("response http header contains non-ASCII characters header: {}", k ).as_str(),
-                    ).unwrap();
+                        format!(
+                            "response http header contains non-ASCII characters header: {}",
+                            k
+                        )
+                        .as_str(),
+                    )
+                    .unwrap();
                 }
             }
         }


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
优化 wasm rust sdk 中 PluginHttpWrapper req_header 获取方方式，避免因为不规范的 http header 导致 plugin panic，并且打印不规范的 header 日志。已在生产环境验证

### Ⅱ. Does this pull request fix one issue?
fixes #1280 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews

