### PR TITLE
feat: Support configuring a global provider list in ai-proxy plugin

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/README.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README.md
@@ -11,35 +11,38 @@ description: AI 代理插件配置参考
 
 > **注意：**
 
-> 请求路径后缀匹配 `/v1/chat/completions` 时，对应文生文场景，会用 OpenAI 的文生文协议解析请求 Body，再转换为对应 LLM 厂商的文生文协议
+> 请求路径后缀匹配 `/v1/chat/completions` 时，对应文生文场景，会用 OpenAI 的文生文协议解析请求 Body，再转换为对应 LLM
+> 厂商的文生文协议
 
-> 请求路径后缀匹配 `/v1/embeddings` 时，对应文本向量场景，会用 OpenAI 的文本向量协议解析请求 Body，再转换为对应 LLM 厂商的文本向量协议
+> 请求路径后缀匹配 `/v1/embeddings` 时，对应文本向量场景，会用 OpenAI 的文本向量协议解析请求 Body，再转换为对应 LLM
+> 厂商的文本向量协议
 
 ## 运行属性
 
 插件执行阶段：`默认阶段`
 插件执行优先级：`100`
 
-
 ## 配置字段
 
-### 基本配置
+### 基础配置
 
-| 名称         | 数据类型   | 填写要求 | 默认值 | 描述               |
-|------------|--------|------|-----|------------------|
-| `provider` | object | 必填   | -   | 配置目标 AI 服务提供商的信息 |
+| 名称                 | 数据类型            | 填写要求 | 默认值 | 描述                                                                            |
+|--------------------|-----------------|------|-----|-------------------------------------------------------------------------------|
+| `providers`        | array of object | 非必填  | -   | AI 服务提供商列表。建议只在全局粒度进行配置。                                                      |
+| `activeProviderId` | string          | 非必填  | -   | 当前需要启用的 AI 服务提供商标识。支持在全局、域名、路由等粒度进行配置。如果未配置、值为空或值未出现在 `providers` 中，本插件将不会工作。 |
 
-`provider`的配置字段说明如下：
+`providers`内各个元素的配置字段说明如下：
 
-| 名称           | 数据类型        | 填写要求 | 默认值 | 描述                                                                                                                                                                                                                                                           |
-| -------------- | --------------- | -------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                                                  |
-| `type`         | string          | 必填     | -      | AI 服务提供商名称                                                                                                                                                                                                                                              |
-| `apiTokens`    | array of string | 非必填   | -      | 用于在访问 AI 服务时进行认证的令牌。如果配置了多个 token，插件会在请求时随机进行选择。部分服务提供商只支持配置一个 token。                                                                                                                                     |
-| `timeout`      | number          | 非必填   | -      | 访问 AI 服务的超时时间。单位为毫秒。默认值为 120000，即 2 分钟                                                                                                                                                                                                 |
-| `modelMapping` | map of string   | 非必填   | -      | AI 模型映射表，用于将请求中的模型名称映射为服务提供商支持模型名称。<br/>1. 支持前缀匹配。例如用 "gpt-3-*" 匹配所有名称以“gpt-3-”开头的模型；<br/>2. 支持使用 "*" 为键来配置通用兜底映射关系；<br/>3. 如果映射的目标名称为空字符串 ""，则表示保留原模型名称。 |
-| `protocol`     | string          | 非必填   | -      | 插件对外提供的 API 接口契约。目前支持以下取值：openai（默认值，使用 OpenAI 的接口契约）、original（使用目标服务提供商的原始接口契约）                                                                                                                          |
-| `context`      | object          | 非必填   | -      | 配置 AI 对话上下文信息                                                                                                                                                                                                                                         |
-| `customSettings` | array of customSetting | 非必填   | -      | 为AI请求指定覆盖或者填充参数                                                                                                                                                                                                                                 |
+| 名称               | 数据类型                   | 填写要求 | 默认值 | 描述                                                                                                                                                        |
+|------------------|------------------------|------|-----|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`             | string                 | 必填   | -   | AI 服务提供商标识，全局唯一                                                                                                                                           |
+| `type`           | string                 | 必填   | -   | AI 服务提供商名称                                                                                                                                                |
+| `apiTokens`      | array of string        | 非必填  | -   | 用于在访问 AI 服务时进行认证的令牌。如果配置了多个 token，插件会在请求时随机进行选择。部分服务提供商只支持配置一个 token。                                                                                     |
+| `timeout`        | number                 | 非必填  | -   | 访问 AI 服务的超时时间。单位为毫秒。默认值为 120000，即 2 分钟                                                                                                                    |
+| `modelMapping`   | map of string          | 非必填  | -   | AI 模型映射表，用于将请求中的模型名称映射为服务提供商支持模型名称。<br/>1. 支持前缀匹配。例如用 "gpt-3-*" 匹配所有名称以“gpt-3-”开头的模型；<br/>2. 支持使用 "*" 为键来配置通用兜底映射关系；<br/>3. 如果映射的目标名称为空字符串 ""，则表示保留原模型名称。 |
+| `protocol`       | string                 | 非必填  | -   | 插件对外提供的 API 接口契约。目前支持以下取值：openai（默认值，使用 OpenAI 的接口契约）、original（使用目标服务提供商的原始接口契约）                                                                          |
+| `context`        | object                 | 非必填  | -   | 配置 AI 对话上下文信息                                                                                                                                             |
+| `customSettings` | array of customSetting | 非必填  | -   | 为AI请求指定覆盖或者填充参数                                                                                                                                           |
 
 `context`的配置字段说明如下：
 
@@ -49,32 +52,30 @@ description: AI 代理插件配置参考
 | `serviceName` | string | 必填   | -   | URL 所对应的 Higress 后端服务完整名称        |
 | `servicePort` | number | 必填   | -   | URL 所对应的 Higress 后端服务访问端口        |
 
-
 `customSettings`的配置字段说明如下：
 
-| 名称        | 数据类型              | 填写要求 | 默认值 | 描述                                                                                                                         |
-| ----------- | --------------------- | -------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `name`      | string                | 必填     | -      | 想要设置的参数的名称，例如`max_tokens`                                                                                       |
-| `value`     | string/int/float/bool | 必填     | -      | 想要设置的参数的值，例如0                                                                                                    |
-| `mode`      | string                | 非必填   | "auto" | 参数设置的模式，可以设置为"auto"或者"raw"，如果为"auto"则会自动根据协议对参数名做改写，如果为"raw"则不会有任何改写和限制检查 |
-| `overwrite` | bool                  | 非必填   | true   | 如果为false则只在用户没有设置这个参数时填充参数，否则会直接覆盖用户原有的参数设置                                            |
+| 名称          | 数据类型                  | 填写要求 | 默认值    | 描述                                                                        |
+|-------------|-----------------------|------|--------|---------------------------------------------------------------------------|
+| `name`      | string                | 必填   | -      | 想要设置的参数的名称，例如`max_tokens`                                                 |
+| `value`     | string/int/float/bool | 必填   | -      | 想要设置的参数的值，例如0                                                             |
+| `mode`      | string                | 非必填  | "auto" | 参数设置的模式，可以设置为"auto"或者"raw"，如果为"auto"则会自动根据协议对参数名做改写，如果为"raw"则不会有任何改写和限制检查 |
+| `overwrite` | bool                  | 非必填  | true   | 如果为false则只在用户没有设置这个参数时填充参数，否则会直接覆盖用户原有的参数设置                               |
 
-
-custom-setting会遵循如下表格，根据`name`和协议来替换对应的字段，用户需要填写表格中`settingName`列中存在的值。例如用户将`name`设置为`max_tokens`，在openai协议中会替换`max_tokens`，在gemini中会替换`maxOutputTokens`。
+customSettings会遵循如下表格，根据`name`和协议来替换对应的字段，用户需要填写表格中`settingName`列中存在的值。例如用户将
+`name`设置为`max_tokens`，在openai协议中会替换`max_tokens`，在gemini中会替换`maxOutputTokens`。
 `none`表示该协议不支持此参数。如果`name`不在此表格中或者对应协议不支持此参数，同时没有设置raw模式，则配置不会生效。
 
-
 | settingName | openai      | baidu             | spark       | qwen        | gemini          | hunyuan     | claude      | minimax            |
-| ----------- | ----------- | ----------------- | ----------- | ----------- | --------------- | ----------- | ----------- | ------------------ |
+|-------------|-------------|-------------------|-------------|-------------|-----------------|-------------|-------------|--------------------|
 | max_tokens  | max_tokens  | max_output_tokens | max_tokens  | max_tokens  | maxOutputTokens | none        | max_tokens  | tokens_to_generate |
 | temperature | temperature | temperature       | temperature | temperature | temperature     | Temperature | temperature | temperature        |
 | top_p       | top_p       | top_p             | none        | top_p       | topP            | TopP        | top_p       | top_p              |
 | top_k       | none        | none              | top_k       | none        | topK            | none        | top_k       | none               |
 | seed        | seed        | none              | none        | seed        | none            | none        | none        | none               |
 
-如果启用了raw模式，custom-setting会直接用输入的`name`和`value`去更改请求中的json内容，而不对参数名称做任何限制和修改。
-对于大多数协议，custom-setting都会在json内容的根路径修改或者填充参数。对于`qwen`协议，ai-proxy会在json的`parameters`子路径下做配置。对于`gemini`协议，则会在`generation_config`子路径下做配置。
-
+如果启用了raw模式，customSettings会直接用输入的`name`和`value`去更改请求中的json内容，而不对参数名称做任何限制和修改。
+对于大多数协议，customSettings都会在json内容的根路径修改或者填充参数。对于`qwen`协议，ai-proxy会在json的`parameters`
+子路径下做配置。对于`gemini`协议，则会在`generation_config`子路径下做配置。
 
 ### 提供商特有配置
 
@@ -82,11 +83,10 @@ custom-setting会遵循如下表格，根据`name`和协议来替换对应的字
 
 OpenAI 所对应的 `type` 为 `openai`。它特有的配置字段如下:
 
-| 名称              | 数据类型 | 填写要求 | 默认值 | 描述                                                                          |
-|-------------------|----------|----------|--------|-------------------------------------------------------------------------------|
-| `openaiCustomUrl` | string   | 非必填   | -      | 基于OpenAI协议的自定义后端URL，例如: www.example.com/myai/v1/chat/completions |
-| `responseJsonSchema` | object | 非必填 | - | 预先定义OpenAI响应需满足的Json Schema, 注意目前仅特定的几种模型支持该用法|
-
+| 名称                   | 数据类型   | 填写要求 | 默认值 | 描述                                                               |
+|----------------------|--------|------|-----|------------------------------------------------------------------|
+| `openaiCustomUrl`    | string | 非必填  | -   | 基于OpenAI协议的自定义后端URL，例如: www.example.com/myai/v1/chat/completions |
+| `responseJsonSchema` | object | 非必填  | -   | 预先定义OpenAI响应需满足的Json Schema, 注意目前仅特定的几种模型支持该用法                   |
 
 #### Azure OpenAI
 
@@ -112,7 +112,7 @@ Azure OpenAI 所对应的 `type` 为 `azure`。它特有的配置字段如下：
 
 | 名称                 | 数据类型            | 填写要求 | 默认值 | 描述                                                               |
 |--------------------|-----------------|------|-----|------------------------------------------------------------------|
-| `qwenEnableSearch` | boolean         | 非必填  | -   | 是否启用通义千问内置的互联网搜索功能。                          |
+| `qwenEnableSearch` | boolean         | 非必填  | -   | 是否启用通义千问内置的互联网搜索功能。                                              |
 | `qwenFileIds`      | array of string | 非必填  | -   | 通过文件接口上传至Dashscope的文件 ID，其内容将被用做 AI 对话的上下文。不可与 `context` 字段同时配置。 |
 
 #### 百川智能 (Baichuan AI)
@@ -151,34 +151,34 @@ Mistral 所对应的 `type` 为 `mistral`。它并无特有的配置字段。
 
 MiniMax所对应的 `type` 为 `minimax`。它特有的配置字段如下：
 
-| 名称             | 数据类型 | 填写要求                                                     | 默认值 | 描述                                                         |
-| ---------------- | -------- | ------------------------------------------------------------ | ------ | ------------------------------------------------------------ |
-| `minimaxGroupId` | string   | 当使用`abab6.5-chat`, `abab6.5s-chat`, `abab5.5s-chat`, `abab5.5-chat`四种模型时必填 | -      | 当使用`abab6.5-chat`, `abab6.5s-chat`, `abab5.5s-chat`, `abab5.5-chat`四种模型时会使用ChatCompletion Pro，需要设置groupID |
+| 名称               | 数据类型   | 填写要求                                                                       | 默认值 | 描述                                                                                                        |
+|------------------|--------|----------------------------------------------------------------------------|-----|-----------------------------------------------------------------------------------------------------------|
+| `minimaxGroupId` | string | 当使用`abab6.5-chat`, `abab6.5s-chat`, `abab5.5s-chat`, `abab5.5-chat`四种模型时必填 | -   | 当使用`abab6.5-chat`, `abab6.5s-chat`, `abab5.5s-chat`, `abab5.5-chat`四种模型时会使用ChatCompletion Pro，需要设置groupID |
 
 #### Anthropic Claude
 
 Anthropic Claude 所对应的 `type` 为 `claude`。它特有的配置字段如下：
 
-| 名称        | 数据类型   | 填写要求 | 默认值 | 描述                               |
-|-----------|--------|------|-----|----------------------------------|
+| 名称              | 数据类型   | 填写要求 | 默认值 | 描述                               |
+|-----------------|--------|------|-----|----------------------------------|
 | `claudeVersion` | string | 可选   | -   | Claude 服务的 API 版本，默认为 2023-06-01 |
 
 #### Ollama
 
 Ollama 所对应的 `type` 为 `ollama`。它特有的配置字段如下：
 
-| 名称                | 数据类型   | 填写要求 | 默认值 | 描述                                           |
-|-------------------|--------|------|-----|----------------------------------------------|
-| `ollamaServerHost` | string | 必填   | -   | Ollama 服务器的主机地址 |
+| 名称                 | 数据类型   | 填写要求 | 默认值 | 描述                      |
+|--------------------|--------|------|-----|-------------------------|
+| `ollamaServerHost` | string | 必填   | -   | Ollama 服务器的主机地址         |
 | `ollamaServerPort` | number | 必填   | -   | Ollama 服务器的端口号，默认为11434 |
 
 #### 混元
 
 混元所对应的 `type` 为 `hunyuan`。它特有的配置字段如下：
 
-| 名称                | 数据类型   | 填写要求 | 默认值 | 描述                                           |
-|-------------------|--------|------|-----|----------------------------------------------|
-| `hunyuanAuthId` | string | 必填   | -   | 混元用于v3版本认证的id |
+| 名称               | 数据类型   | 填写要求 | 默认值 | 描述             |
+|------------------|--------|------|-----|----------------|
+| `hunyuanAuthId`  | string | 必填   | -   | 混元用于v3版本认证的id  |
 | `hunyuanAuthKey` | string | 必填   | -   | 混元用于v3版本认证的key |
 
 #### 阶跃星辰 (Stepfun)
@@ -189,8 +189,8 @@ Ollama 所对应的 `type` 为 `ollama`。它特有的配置字段如下：
 
 Cloudflare Workers AI 所对应的 `type` 为 `cloudflare`。它特有的配置字段如下：
 
-| 名称                | 数据类型   | 填写要求 | 默认值 | 描述                                                                                                                         |
-|-------------------|--------|------|-----|----------------------------------------------------------------------------------------------------------------------------|
+| 名称                    | 数据类型   | 填写要求 | 默认值 | 描述                                                                                                                         |
+|-----------------------|--------|------|-----|----------------------------------------------------------------------------------------------------------------------------|
 | `cloudflareAccountId` | string | 必填   | -   | [Cloudflare Account ID](https://developers.cloudflare.com/workers-ai/get-started/rest-api/#1-get-api-token-and-account-id) |
 
 #### 星火 (Spark)
@@ -203,17 +203,17 @@ Cloudflare Workers AI 所对应的 `type` 为 `cloudflare`。它特有的配置�
 
 Gemini 所对应的 `type` 为 `gemini`。它特有的配置字段如下：
 
-| 名称                  | 数据类型 | 填写要求 | 默认值 | 描述                                                                                              |
-| --------------------- | -------- | -------- |-----|-------------------------------------------------------------------------------------------------|
-| `geminiSafetySetting` | map of string   | 非必填     | -   | Gemini AI内容过滤和安全级别设定。参考[Safety settings](https://ai.google.dev/gemini-api/docs/safety-settings) |
+| 名称                    | 数据类型          | 填写要求 | 默认值 | 描述                                                                                              |
+|-----------------------|---------------|------|-----|-------------------------------------------------------------------------------------------------|
+| `geminiSafetySetting` | map of string | 非必填  | -   | Gemini AI内容过滤和安全级别设定。参考[Safety settings](https://ai.google.dev/gemini-api/docs/safety-settings) |
 
 #### DeepL
 
 DeepL 所对应的 `type` 为 `deepl`。它特有的配置字段如下：
 
-| 名称         | 数据类型 | 填写要求 | 默认值 | 描述                         |
-| ------------ | -------- | -------- | ------ | ---------------------------- |
-| `targetLang` | string   | 必填     | -      | DeepL 翻译服务需要的目标语种 |
+| 名称           | 数据类型   | 填写要求 | 默认值 | 描述                |
+|--------------|--------|------|-----|-------------------|
+| `targetLang` | string | 必填   | -   | DeepL 翻译服务需要的目标语种 |
 
 #### Cohere
 
@@ -228,11 +228,13 @@ Cohere 所对应的 `type` 为 `cohere`。它并无特有的配置字段。
 **配置信息**
 
 ```yaml
-provider:
-  type: azure
-  apiTokens:
-    - "YOUR_AZURE_OPENAI_API_TOKEN"
-  azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
+activeProviderId: my-azure
+providers:
+  - id: my-azure
+    type: azure
+    apiTokens:
+      - "YOUR_AZURE_OPENAI_API_TOKEN"
+    azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
 ```
 
 **请求示例**
@@ -326,18 +328,20 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: qwen
-  apiTokens:
-    - "YOUR_QWEN_API_TOKEN"
-  modelMapping:
-    'gpt-3': "qwen-turbo"
-    'gpt-35-turbo': "qwen-plus"
-    'gpt-4-turbo': "qwen-max"
-    'gpt-4-*': "qwen-max"
-    'gpt-4o': "qwen-vl-plus"
-    'text-embedding-v1': 'text-embedding-v1'
-    '*': "qwen-turbo"
+activeProviderId: my-qwen
+providers:
+  - id: my-qwen
+    type: qwen
+    apiTokens:
+      - "YOUR_QWEN_API_TOKEN"
+    modelMapping:
+      'gpt-3': "qwen-turbo"
+      'gpt-35-turbo': "qwen-plus"
+      'gpt-4-turbo': "qwen-max"
+      'gpt-4-*': "qwen-max"
+      'gpt-4o': "qwen-vl-plus"
+      'text-embedding-v1': 'text-embedding-v1'
+      '*': "qwen-turbo"
 ```
 
 **AI 对话请求示例**
@@ -393,25 +397,25 @@ URL: http://your-domain/v1/chat/completions
 
 ```json
 {
-    "model": "gpt-4o",
-    "messages": [
+  "model": "gpt-4o",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
         {
-            "role": "user",
-            "content": [
-                {
-                    "type": "image_url",
-                    "image_url": {
-                        "url": "https://dashscope.oss-cn-beijing.aliyuncs.com/images/dog_and_girl.jpeg"
-                    }
-                },
-                {
-                    "type": "text",
-                    "text": "这个图片是哪里？"
-                }
-            ]
+          "type": "image_url",
+          "image_url": {
+            "url": "https://dashscope.oss-cn-beijing.aliyuncs.com/images/dog_and_girl.jpeg"
+          }
+        },
+        {
+          "type": "text",
+          "text": "这个图片是哪里？"
         }
-    ],
-    "temperature": 0.3
+      ]
+    }
+  ],
+  "temperature": 0.3
 }
 ```
 
@@ -419,28 +423,28 @@ URL: http://your-domain/v1/chat/completions
 
 ```json
 {
-    "id": "17c5955d-af9c-9f28-bbde-293a9c9a3515",
-    "choices": [
-        {
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": [
-                    {
-                        "text": "这张照片显示的是一位女士和一只狗在海滩上。由于我无法获取具体的地理位置信息，所以不能确定这是哪个地方的海滩。但是从视觉内容来看，它可能是一个位于沿海地区的沙滩海岸线，并且有海浪拍打着岸边。这样的场景在全球许多美丽的海滨地区都可以找到。如果您需要更精确的信息，请提供更多的背景或细节描述。"
-                    }
-                ]
-            },
-            "finish_reason": "stop"
-        }
-    ],
-    "created": 1723949230,
-    "model": "qwen-vl-plus",
-    "object": "chat.completion",
-    "usage": {
-        "prompt_tokens": 1279,
-        "completion_tokens": 78
+  "id": "17c5955d-af9c-9f28-bbde-293a9c9a3515",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": [
+          {
+            "text": "这张照片显示的是一位女士和一只狗在海滩上。由于我无法获取具体的地理位置信息，所以不能确定这是哪个地方的海滩。但是从视觉内容来看，它可能是一个位于沿海地区的沙滩海岸线，并且有海浪拍打着岸边。这样的场景在全球许多美丽的海滨地区都可以找到。如果您需要更精确的信息，请提供更多的背景或细节描述。"
+          }
+        ]
+      },
+      "finish_reason": "stop"
     }
+  ],
+  "created": 1723949230,
+  "model": "qwen-vl-plus",
+  "object": "chat.completion",
+  "usage": {
+    "prompt_tokens": 1279,
+    "completion_tokens": 78
+  }
 }
 ```
 
@@ -496,16 +500,18 @@ URL: http://your-domain/v1/embeddings
 **配置信息**
 
 ```yaml
-provider:
-  type: qwen
-  apiTokens:
-    - "YOUR_QWEN_API_TOKEN"
-  modelMapping:
-    "*": "qwen-turbo"
-  context:
-    - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
-      serviceName: "file.dns",
-      servicePort: 80
+activeProviderId: my-qwen
+providers:
+  - id: my-qwen
+    type: qwen
+    apiTokens:
+      - "YOUR_QWEN_API_TOKEN"
+    modelMapping:
+      "*": "qwen-turbo"
+    context:
+      - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
+        serviceName: "file.dns",
+        servicePort: 80
 ```
 
 **请求示例**
@@ -556,15 +562,17 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: qwen
-  apiTokens:
-    - "YOUR_QWEN_API_TOKEN"
-  modelMapping:
-    "*": "qwen-long" # 通义千问的文件上下文只能在 qwen-long 模型下使用
-  qwenFileIds:
-  - "file-fe-xxx"
-  - "file-fe-yyy"
+activeProviderId: my-qwen
+providers:
+  - id: my-qwen
+    type: qwen
+    apiTokens:
+      - "YOUR_QWEN_API_TOKEN"
+    modelMapping:
+      "*": "qwen-long" # 通义千问的文件上下文只能在 qwen-long 模型下使用
+    qwenFileIds:
+      - "file-fe-xxx"
+      - "file-fe-yyy"
 ```
 
 **请求示例**
@@ -607,23 +615,27 @@ provider:
 ```
 
 ### 使用original协议代理百炼智能体应用
+
 **配置信息**
 
 ```yaml
-provider:
-  type: qwen
-  apiTokens:
-    - "YOUR_DASHSCOPE_API_TOKEN"
-  protocol: original
+activeProviderId: my-qwen
+providers:
+  - id: my-qwen
+    type: qwen
+    apiTokens:
+      - "YOUR_DASHSCOPE_API_TOKEN"
+    protocol: original
 ```
 
 **请求实例**
+
 ```json
 {
   "input": {
-      "prompt": "介绍一下Dubbo"
+    "prompt": "介绍一下Dubbo"
   },
-  "parameters":  {},
+  "parameters": {},
   "debug": {}
 }
 ```
@@ -632,21 +644,21 @@ provider:
 
 ```json
 {
-    "output": {
-        "finish_reason": "stop",
-        "session_id": "677e7e8fbb874e1b84792b65042e1599",
-        "text": "Apache Dubbo 是一个..."
-    },
-    "usage": {
-        "models": [
-            {
-                "output_tokens": 449,
-                "model_id": "qwen-max",
-                "input_tokens": 282
-            }
-        ]
-    },
-    "request_id": "b59e45e3-5af4-91df-b7c6-9d746fd3297c"
+  "output": {
+    "finish_reason": "stop",
+    "session_id": "677e7e8fbb874e1b84792b65042e1599",
+    "text": "Apache Dubbo 是一个..."
+  },
+  "usage": {
+    "models": [
+      {
+        "output_tokens": 449,
+        "model_id": "qwen-max",
+        "input_tokens": 282
+      }
+    ]
+  },
+  "request_id": "b59e45e3-5af4-91df-b7c6-9d746fd3297c"
 }
 ```
 
@@ -655,13 +667,15 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: doubao
-  apiTokens:
-    - YOUR_DOUBAO_API_KEY
-  modelMapping:
-    '*': YOUR_DOUBAO_ENDPOINT
-  timeout: 1200000
+activeProviderId: my-doubao
+providers:
+  - id: my-doubao
+    type: doubao
+    apiTokens:
+      - YOUR_DOUBAO_API_KEY
+    modelMapping:
+      '*': YOUR_DOUBAO_ENDPOINT
+    timeout: 1200000
 ```
 
 ### 使用月之暗面配合其原生的文件上下文
@@ -671,13 +685,15 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: moonshot
-  apiTokens:
-    - "YOUR_MOONSHOT_API_TOKEN"
-  moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
-  modelMapping:
-    '*': "moonshot-v1-32k"
+activeProviderId: my-moonshot
+providers:
+  - id: my-moonshot
+    type: moonshot
+    apiTokens:
+      - "YOUR_MOONSHOT_API_TOKEN"
+    moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
+    modelMapping:
+      '*': "moonshot-v1-32k"
 ```
 
 **请求示例**
@@ -726,10 +742,12 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: groq
-  apiTokens:
-    - "YOUR_GROQ_API_TOKEN"
+activeProviderId: my-groq
+providers:
+  - id: my-groq
+    type: groq
+    apiTokens:
+      - "YOUR_GROQ_API_TOKEN"
 ```
 
 **请求示例**
@@ -785,11 +803,13 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: claude
-  apiTokens:
-    - "YOUR_CLAUDE_API_TOKEN"
-  version: "2023-06-01"
+activeProviderId: my-claude
+providers:
+  - id: my-claude
+    type: claude
+    apiTokens:
+      - "YOUR_CLAUDE_API_TOKEN"
+    version: "2023-06-01"
 ```
 
 **请求示例**
@@ -832,26 +852,30 @@ provider:
   }
 }
 ```
+
 ### 使用 OpenAI 协议代理混元服务
 
 **配置信息**
 
 ```yaml
-provider:
-  type: "hunyuan"
-  hunyuanAuthKey: "<YOUR AUTH KEY>"
-  apiTokens:
-    - ""
-  hunyuanAuthId: "<YOUR AUTH ID>"
-  timeout: 1200000
-  modelMapping:
-    "*": "hunyuan-lite"
+provider: "my-hunyuan"
+providers:
+  - id: "my-hunyuan"
+    type: "hunyuan"
+    hunyuanAuthKey: "<YOUR AUTH KEY>"
+    apiTokens:
+      - ""
+    hunyuanAuthId: "<YOUR AUTH ID>"
+    timeout: 1200000
+    modelMapping:
+      "*": "hunyuan-lite"
 ```
 
 **请求示例**
-请求脚本：
-```sh
 
+请求脚本：
+
+```shell
 curl --location 'http://<your higress domain>/v1/chat/completions' \
 --header 'Content-Type:  application/json' \
 --data '{
@@ -875,25 +899,25 @@ curl --location 'http://<your higress domain>/v1/chat/completions' \
 
 ```json
 {
-    "id": "fd140c3e-0b69-4b19-849b-d354d32a6162",
-    "choices": [
-        {
-            "index": 0,
-            "delta": {
-                "role": "assistant",
-                "content": "你好！我是一名专业的开发人员。"
-            },
-            "finish_reason": "stop"
-        }
-    ],
-    "created": 1717493117,
-    "model": "hunyuan-lite",
-    "object": "chat.completion",
-    "usage": {
-        "prompt_tokens": 15,
-        "completion_tokens": 9,
-        "total_tokens": 24
+  "id": "fd140c3e-0b69-4b19-849b-d354d32a6162",
+  "choices": [
+    {
+      "index": 0,
+      "delta": {
+        "role": "assistant",
+        "content": "你好！我是一名专业的开发人员。"
+      },
+      "finish_reason": "stop"
     }
+  ],
+  "created": 1717493117,
+  "model": "hunyuan-lite",
+  "object": "chat.completion",
+  "usage": {
+    "prompt_tokens": 15,
+    "completion_tokens": 9,
+    "total_tokens": 24
+  }
 }
 ```
 
@@ -902,27 +926,29 @@ curl --location 'http://<your higress domain>/v1/chat/completions' \
 **配置信息**
 
 ```yaml
-provider:
-  type: baidu
-  apiTokens:
-    - "YOUR_BAIDU_API_TOKEN"
-  modelMapping:
-    'gpt-3': "ERNIE-4.0"
-    '*': "ERNIE-4.0"
+activeProviderId: my-baidu
+providers:
+  - id: my-baidu
+    type: baidu
+    apiTokens:
+      - "YOUR_BAIDU_API_TOKEN"
+    modelMapping:
+      'gpt-3': "ERNIE-4.0"
+      '*': "ERNIE-4.0"
 ```
 
 **请求示例**
 
 ```json
 {
-    "model": "gpt-4-turbo",
-    "messages": [
-        {
-            "role": "user",
-            "content": "你好，你是谁？"
-        }
-    ],
-    "stream": false
+  "model": "gpt-4-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ],
+  "stream": false
 }
 ```
 
@@ -930,25 +956,25 @@ provider:
 
 ```json
 {
-    "id": "as-e90yfg1pk1",
-    "choices": [
-        {
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": "你好，我是文心一言，英文名是ERNIE Bot。我能够与人对话互动，回答问题，协助创作，高效便捷地帮助人们获取信息、知识和灵感。"
-            },
-            "finish_reason": "stop"
-        }
-    ],
-    "created": 1717251488,
-    "model": "ERNIE-4.0",
-    "object": "chat.completion",
-    "usage": {
-        "prompt_tokens": 4,
-        "completion_tokens": 33,
-        "total_tokens": 37
+  "id": "as-e90yfg1pk1",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "你好，我是文心一言，英文名是ERNIE Bot。我能够与人对话互动，回答问题，协助创作，高效便捷地帮助人们获取信息、知识和灵感。"
+      },
+      "finish_reason": "stop"
     }
+  ],
+  "created": 1717251488,
+  "model": "ERNIE-4.0",
+  "object": "chat.completion",
+  "usage": {
+    "prompt_tokens": 4,
+    "completion_tokens": 33,
+    "total_tokens": 37
+  }
 }
 ```
 
@@ -957,29 +983,31 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: minimax
-  apiTokens:
-    - "YOUR_MINIMAX_API_TOKEN"
-  modelMapping:
-    "gpt-3": "abab6.5g-chat"
-    "gpt-4": "abab6.5-chat"
-    "*": "abab6.5g-chat"
-  minimaxGroupId: "YOUR_MINIMAX_GROUP_ID"
+activeProviderId: my-minimax
+providers:
+  - id: my-minimax
+    type: minimax
+    apiTokens:
+      - "YOUR_MINIMAX_API_TOKEN"
+    modelMapping:
+      "gpt-3": "abab6.5g-chat"
+      "gpt-4": "abab6.5-chat"
+      "*": "abab6.5g-chat"
+    minimaxGroupId: "YOUR_MINIMAX_GROUP_ID"
 ```
 
 **请求示例**
 
 ```json
 {
-    "model": "gpt-4-turbo",
-    "messages": [
-        {
-            "role": "user",
-            "content": "你好，你是谁？"
-        }
-    ],
-    "stream": false
+  "model": "gpt-4-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ],
+  "stream": false
 }
 ```
 
@@ -987,31 +1015,31 @@ provider:
 
 ```json
 {
-    "id": "02b2251f8c6c09d68c1743f07c72afd7",
-    "choices": [
-        {
-            "finish_reason": "stop",
-            "index": 0,
-            "message": {
-                "content": "你好！我是MM智能助理，一款由MiniMax自研的大型语言模型。我可以帮助你解答问题，提供信息，进行对话等。有什么可以帮助你的吗？",
-                "role": "assistant"
-            }
-        }
-    ],
-    "created": 1717760544,
-    "model": "abab6.5s-chat",
-    "object": "chat.completion",
-    "usage": {
-        "total_tokens": 106
-    },
-    "input_sensitive": false,
-    "output_sensitive": false,
-    "input_sensitive_type": 0,
-    "output_sensitive_type": 0,
-    "base_resp": {
-        "status_code": 0,
-        "status_msg": ""
+  "id": "02b2251f8c6c09d68c1743f07c72afd7",
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "content": "你好！我是MM智能助理，一款由MiniMax自研的大型语言模型。我可以帮助你解答问题，提供信息，进行对话等。有什么可以帮助你的吗？",
+        "role": "assistant"
+      }
     }
+  ],
+  "created": 1717760544,
+  "model": "abab6.5s-chat",
+  "object": "chat.completion",
+  "usage": {
+    "total_tokens": 106
+  },
+  "input_sensitive": false,
+  "output_sensitive": false,
+  "input_sensitive_type": 0,
+  "output_sensitive_type": 0,
+  "base_resp": {
+    "status_code": 0,
+    "status_msg": ""
+  }
 }
 ```
 
@@ -1020,16 +1048,18 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: ai360
-  apiTokens:
-    - "YOUR_MINIMAX_API_TOKEN"
-  modelMapping:
-    "gpt-4o": "360gpt-turbo-responsibility-8k"
-    "gpt-4": "360gpt2-pro"
-    "gpt-3.5": "360gpt-turbo"
-    "text-embedding-3-small": "embedding_s1_v1.2"
-    "*": "360gpt-pro"
+activeProviderId: my-ai360
+providers:
+  - id: my-ai360
+    type: ai360
+    apiTokens:
+      - "YOUR_AI360_API_TOKEN"
+    modelMapping:
+      "gpt-4o": "360gpt-turbo-responsibility-8k"
+      "gpt-4": "360gpt2-pro"
+      "gpt-3.5": "360gpt-turbo"
+      "text-embedding-3-small": "embedding_s1_v1.2"
+      "*": "360gpt-pro"
 ```
 
 **请求示例**
@@ -1095,8 +1125,10 @@ URL: http://your-domain/v1/embeddings
 
 ```json
 {
-  "input":["你好"],
-  "model":"text-embedding-3-small"
+  "input": [
+    "你好"
+  ],
+  "model": "text-embedding-3-small"
 }
 ```
 
@@ -1134,13 +1166,15 @@ URL: http://your-domain/v1/embeddings
 **配置信息**
 
 ```yaml
-provider:
-  type: cloudflare
-  apiTokens:
-    - "YOUR_WORKERS_AI_API_TOKEN"
-  cloudflareAccountId: "YOUR_CLOUDFLARE_ACCOUNT_ID"
-  modelMapping:
-    "*": "@cf/meta/llama-3-8b-instruct"
+activeProviderId: my-cf
+providers:
+  - id: my-cf
+    type: cloudflare
+    apiTokens:
+      - "YOUR_WORKERS_AI_API_TOKEN"
+    cloudflareAccountId: "YOUR_CLOUDFLARE_ACCOUNT_ID"
+    modelMapping:
+      "*": "@cf/meta/llama-3-8b-instruct"
 ```
 
 **请求示例**
@@ -1185,32 +1219,34 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: spark
-  apiTokens:
-    - "APIKey:APISecret"
-  modelMapping:
-    "gpt-4o": "generalv3.5"
-    "gpt-4": "generalv3"
-    "*": "general"
+activeProviderId: my-spark
+providers:
+  - id: my-spark
+    type: spark
+    apiTokens:
+      - "APIKey:APISecret"
+    modelMapping:
+      "gpt-4o": "generalv3.5"
+      "gpt-4": "generalv3"
+      "*": "general"
 ```
 
 **请求示例**
 
 ```json
 {
-    "model": "gpt-4o",
-    "messages": [
-        {
-            "role": "system",
-            "content": "你是一名专业的开发人员！"
-        },
-        {
-            "role": "user",
-            "content": "你好，你是谁？"
-        }
-    ],
-    "stream": false
+  "model": "gpt-4o",
+  "messages": [
+    {
+      "role": "system",
+      "content": "你是一名专业的开发人员！"
+    },
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ],
+  "stream": false
 }
 ```
 
@@ -1218,24 +1254,24 @@ provider:
 
 ```json
 {
-    "id": "cha000c23c6@dx190ef0b4b96b8f2532",
-    "choices": [
-        {
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": "你好！我是一名专业的开发人员，擅长编程和解决技术问题。有什么我可以帮助你的吗？"
-            }
-        }
-    ],
-    "created": 1721997415,
-    "model": "generalv3.5",
-    "object": "chat.completion",
-    "usage": {
-        "prompt_tokens": 10,
-        "completion_tokens": 19,
-        "total_tokens": 29
+  "id": "cha000c23c6@dx190ef0b4b96b8f2532",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "你好！我是一名专业的开发人员，擅长编程和解决技术问题。有什么我可以帮助你的吗？"
+      }
     }
+  ],
+  "created": 1721997415,
+  "model": "generalv3.5",
+  "object": "chat.completion",
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 19,
+    "total_tokens": 29
+  }
 }
 ```
 
@@ -1244,31 +1280,33 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: gemini
-  apiTokens:
-    - "YOUR_GEMINI_API_TOKEN"
-  modelMapping:
-    "*": "gemini-pro"
-  geminiSafetySetting:
-    "HARM_CATEGORY_SEXUALLY_EXPLICIT" :"BLOCK_NONE"
-    "HARM_CATEGORY_HATE_SPEECH" :"BLOCK_NONE"
-    "HARM_CATEGORY_HARASSMENT" :"BLOCK_NONE"
-    "HARM_CATEGORY_DANGEROUS_CONTENT" :"BLOCK_NONE"
+activeProviderId: my-gemini
+providers:
+  - id: my-gemini
+    type: gemini
+    apiTokens:
+      - "YOUR_GEMINI_API_TOKEN"
+    modelMapping:
+      "*": "gemini-pro"
+    geminiSafetySetting:
+      "HARM_CATEGORY_SEXUALLY_EXPLICIT": "BLOCK_NONE"
+      "HARM_CATEGORY_HATE_SPEECH": "BLOCK_NONE"
+      "HARM_CATEGORY_HARASSMENT": "BLOCK_NONE"
+      "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_NONE"
 ```
 
 **请求示例**
 
 ```json
 {
-    "model": "gpt-3.5",
-    "messages": [
-        {
-            "role": "user",
-            "content": "Who are you?"
-        }
-    ],
-    "stream": false
+  "model": "gpt-3.5",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Who are you?"
+    }
+  ],
+  "stream": false
 }
 ```
 
@@ -1276,25 +1314,25 @@ provider:
 
 ```json
 {
-    "id": "chatcmpl-b010867c-0d3f-40ba-95fd-4e8030551aeb",
-    "choices": [
-        {
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": "I am a large multi-modal model, trained by Google. I am designed to provide information and answer questions to the best of my abilities."
-            },
-            "finish_reason": "stop"
-        }
-    ],
-    "created": 1722756984,
-    "model": "gemini-pro",
-    "object": "chat.completion",
-    "usage": {
-        "prompt_tokens": 5,
-        "completion_tokens": 29,
-        "total_tokens": 34
+  "id": "chatcmpl-b010867c-0d3f-40ba-95fd-4e8030551aeb",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I am a large multi-modal model, trained by Google. I am designed to provide information and answer questions to the best of my abilities."
+      },
+      "finish_reason": "stop"
     }
+  ],
+  "created": 1722756984,
+  "model": "gemini-pro",
+  "object": "chat.completion",
+  "usage": {
+    "prompt_tokens": 5,
+    "completion_tokens": 29,
+    "total_tokens": 34
+  }
 }
 ```
 
@@ -1303,15 +1341,18 @@ provider:
 **配置信息**
 
 ```yaml
-provider:
-  type: deepl
-  apiTokens:
-    - "YOUR_DEEPL_API_TOKEN"
-  targetLang: "ZH"
+activeProviderId: my-deepl
+providers:
+  - id: my-deepl
+    type: deepl
+    apiTokens:
+      - "YOUR_DEEPL_API_TOKEN"
+    targetLang: "ZH"
 ```
 
 **请求示例**
-此处 `model` 表示 DeepL 的服务类型，只能填 `Free` 或 `Pro`。`content` 中设置需要翻译的文本；在 `role: system` 的 `content` 中可以包含可能影响翻译但本身不会被翻译的上下文，例如翻译产品名称时，可以将产品描述作为上下文传递，这种额外的上下文可能会提高翻译的质量。
+此处 `model` 表示 DeepL 的服务类型，只能填 `Free` 或 `Pro`。`content` 中设置需要翻译的文本；在 `role: system` 的 `content`
+中可以包含可能影响翻译但本身不会被翻译的上下文，例如翻译产品名称时，可以将产品描述作为上下文传递，这种额外的上下文可能会提高翻译的质量。
 
 ```json
 {
@@ -1332,16 +1373,25 @@ provider:
 ```
 
 **响应示例**
+
 ```json
 {
   "choices": [
     {
       "index": 0,
-      "message": { "name": "EN", "role": "assistant", "content": "坐庄" }
+      "message": {
+        "name": "EN",
+        "role": "assistant",
+        "content": "坐庄"
+      }
     },
     {
       "index": 1,
-      "message": { "name": "EN", "role": "assistant", "content": "中国银行" }
+      "message": {
+        "name": "EN",
+        "role": "assistant",
+        "content": "中国银行"
+      }
     }
   ],
   "created": 1722747752,
@@ -1365,13 +1415,15 @@ metadata:
   namespace: higress-system
 spec:
   matchRules:
-  - config:
-      provider:
-        type: groq
-        apiTokens: 
-          - "YOUR_API_TOKEN"
-    ingress:
-    - groq
+    - config:
+        activeProviderId: my-groq
+        providers:
+          - id: my-groq
+            type: groq
+            apiTokens:
+              - "YOUR_API_TOKEN"
+      ingress:
+        - groq
   url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:1.0.0
 ---
 apiVersion: networking.k8s.io/v1
@@ -1389,16 +1441,16 @@ metadata:
 spec:
   ingressClassName: higress
   rules:
-  - host: <YOUR-DOMAIN> 
-    http:
-      paths:
-      - backend:
-          resource:
-            apiGroup: networking.higress.io
-            kind: McpBridge
-            name: default
-        path: /
-        pathType: Prefix
+    - host: <YOUR-DOMAIN>
+      http:
+        paths:
+          - backend:
+              resource:
+                apiGroup: networking.higress.io
+                kind: McpBridge
+                name: default
+            path: /
+            pathType: Prefix
 ---
 apiVersion: networking.higress.io/v1
 kind: McpBridge
@@ -1407,10 +1459,10 @@ metadata:
   namespace: higress-system
 spec:
   registries:
-  - domain: api.groq.com
-    name: groq
-    port: 443
-    type: dns
+    - domain: api.groq.com
+      name: groq
+      port: 443
+      type: dns
 ```
 
 访问示例：
@@ -1447,7 +1499,7 @@ services:
       - ./envoy.yaml:/etc/envoy/envoy.yaml
       - ./plugin.wasm:/etc/envoy/plugin.wasm
 networks:
-  higress-net: {}
+  higress-net: { }
 ```
 
 `envoy.yaml` 配置文件：
@@ -1509,12 +1561,16 @@ static_resources:
                             "@type": "type.googleapis.com/google.protobuf.StringValue"
                             value: | # 插件配置
                               {
-                                "provider": {
-                                  "type": "claude",                                
-                                  "apiTokens": [
-                                    "YOUR_API_TOKEN"
-                                  ]                  
-                                }
+                                "activeProviderId": "my-claude",
+                                "providers": [
+                                  {
+                                    "id": "my-claude",
+                                    "type": "claude",
+                                    "apiTokens": [
+                                      "YOUR_API_TOKEN"
+                                    ]
+                                  }
+                                ]
                               }
                   - name: envoy.filters.http.router
   clusters:

--- a/plugins/wasm-go/extensions/ai-proxy/README.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README.md
@@ -11,38 +11,35 @@ description: AI 代理插件配置参考
 
 > **注意：**
 
-> 请求路径后缀匹配 `/v1/chat/completions` 时，对应文生文场景，会用 OpenAI 的文生文协议解析请求 Body，再转换为对应 LLM
-> 厂商的文生文协议
+> 请求路径后缀匹配 `/v1/chat/completions` 时，对应文生文场景，会用 OpenAI 的文生文协议解析请求 Body，再转换为对应 LLM 厂商的文生文协议
 
-> 请求路径后缀匹配 `/v1/embeddings` 时，对应文本向量场景，会用 OpenAI 的文本向量协议解析请求 Body，再转换为对应 LLM
-> 厂商的文本向量协议
+> 请求路径后缀匹配 `/v1/embeddings` 时，对应文本向量场景，会用 OpenAI 的文本向量协议解析请求 Body，再转换为对应 LLM 厂商的文本向量协议
 
 ## 运行属性
 
 插件执行阶段：`默认阶段`
 插件执行优先级：`100`
 
+
 ## 配置字段
 
-### 基础配置
+### 基本配置
 
-| 名称                 | 数据类型            | 填写要求 | 默认值 | 描述                                                                            |
-|--------------------|-----------------|------|-----|-------------------------------------------------------------------------------|
-| `providers`        | array of object | 非必填  | -   | AI 服务提供商列表。建议只在全局粒度进行配置。                                                      |
-| `activeProviderId` | string          | 非必填  | -   | 当前需要启用的 AI 服务提供商标识。支持在全局、域名、路由等粒度进行配置。如果未配置、值为空或值未出现在 `providers` 中，本插件将不会工作。 |
+| 名称         | 数据类型   | 填写要求 | 默认值 | 描述               |
+|------------|--------|------|-----|------------------|
+| `provider` | object | 必填   | -   | 配置目标 AI 服务提供商的信息 |
 
-`providers`内各个元素的配置字段说明如下：
+`provider`的配置字段说明如下：
 
-| 名称               | 数据类型                   | 填写要求 | 默认值 | 描述                                                                                                                                                        |
-|------------------|------------------------|------|-----|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `id`             | string                 | 必填   | -   | AI 服务提供商标识，全局唯一                                                                                                                                           |
-| `type`           | string                 | 必填   | -   | AI 服务提供商名称                                                                                                                                                |
-| `apiTokens`      | array of string        | 非必填  | -   | 用于在访问 AI 服务时进行认证的令牌。如果配置了多个 token，插件会在请求时随机进行选择。部分服务提供商只支持配置一个 token。                                                                                     |
-| `timeout`        | number                 | 非必填  | -   | 访问 AI 服务的超时时间。单位为毫秒。默认值为 120000，即 2 分钟                                                                                                                    |
-| `modelMapping`   | map of string          | 非必填  | -   | AI 模型映射表，用于将请求中的模型名称映射为服务提供商支持模型名称。<br/>1. 支持前缀匹配。例如用 "gpt-3-*" 匹配所有名称以“gpt-3-”开头的模型；<br/>2. 支持使用 "*" 为键来配置通用兜底映射关系；<br/>3. 如果映射的目标名称为空字符串 ""，则表示保留原模型名称。 |
-| `protocol`       | string                 | 非必填  | -   | 插件对外提供的 API 接口契约。目前支持以下取值：openai（默认值，使用 OpenAI 的接口契约）、original（使用目标服务提供商的原始接口契约）                                                                          |
-| `context`        | object                 | 非必填  | -   | 配置 AI 对话上下文信息                                                                                                                                             |
-| `customSettings` | array of customSetting | 非必填  | -   | 为AI请求指定覆盖或者填充参数                                                                                                                                           |
+| 名称           | 数据类型        | 填写要求 | 默认值 | 描述                                                                                                                                                                                                                                                           |
+| -------------- | --------------- | -------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                                                  |
+| `type`         | string          | 必填     | -      | AI 服务提供商名称                                                                                                                                                                                                                                              |
+| `apiTokens`    | array of string | 非必填   | -      | 用于在访问 AI 服务时进行认证的令牌。如果配置了多个 token，插件会在请求时随机进行选择。部分服务提供商只支持配置一个 token。                                                                                                                                     |
+| `timeout`      | number          | 非必填   | -      | 访问 AI 服务的超时时间。单位为毫秒。默认值为 120000，即 2 分钟                                                                                                                                                                                                 |
+| `modelMapping` | map of string   | 非必填   | -      | AI 模型映射表，用于将请求中的模型名称映射为服务提供商支持模型名称。<br/>1. 支持前缀匹配。例如用 "gpt-3-*" 匹配所有名称以“gpt-3-”开头的模型；<br/>2. 支持使用 "*" 为键来配置通用兜底映射关系；<br/>3. 如果映射的目标名称为空字符串 ""，则表示保留原模型名称。 |
+| `protocol`     | string          | 非必填   | -      | 插件对外提供的 API 接口契约。目前支持以下取值：openai（默认值，使用 OpenAI 的接口契约）、original（使用目标服务提供商的原始接口契约）                                                                                                                          |
+| `context`      | object          | 非必填   | -      | 配置 AI 对话上下文信息                                                                                                                                                                                                                                         |
+| `customSettings` | array of customSetting | 非必填   | -      | 为AI请求指定覆盖或者填充参数                                                                                                                                                                                                                                 |
 
 `context`的配置字段说明如下：
 
@@ -52,30 +49,32 @@ description: AI 代理插件配置参考
 | `serviceName` | string | 必填   | -   | URL 所对应的 Higress 后端服务完整名称        |
 | `servicePort` | number | 必填   | -   | URL 所对应的 Higress 后端服务访问端口        |
 
+
 `customSettings`的配置字段说明如下：
 
-| 名称          | 数据类型                  | 填写要求 | 默认值    | 描述                                                                        |
-|-------------|-----------------------|------|--------|---------------------------------------------------------------------------|
-| `name`      | string                | 必填   | -      | 想要设置的参数的名称，例如`max_tokens`                                                 |
-| `value`     | string/int/float/bool | 必填   | -      | 想要设置的参数的值，例如0                                                             |
-| `mode`      | string                | 非必填  | "auto" | 参数设置的模式，可以设置为"auto"或者"raw"，如果为"auto"则会自动根据协议对参数名做改写，如果为"raw"则不会有任何改写和限制检查 |
-| `overwrite` | bool                  | 非必填  | true   | 如果为false则只在用户没有设置这个参数时填充参数，否则会直接覆盖用户原有的参数设置                               |
+| 名称        | 数据类型              | 填写要求 | 默认值 | 描述                                                                                                                         |
+| ----------- | --------------------- | -------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | string                | 必填     | -      | 想要设置的参数的名称，例如`max_tokens`                                                                                       |
+| `value`     | string/int/float/bool | 必填     | -      | 想要设置的参数的值，例如0                                                                                                    |
+| `mode`      | string                | 非必填   | "auto" | 参数设置的模式，可以设置为"auto"或者"raw"，如果为"auto"则会自动根据协议对参数名做改写，如果为"raw"则不会有任何改写和限制检查 |
+| `overwrite` | bool                  | 非必填   | true   | 如果为false则只在用户没有设置这个参数时填充参数，否则会直接覆盖用户原有的参数设置                                            |
 
-customSettings会遵循如下表格，根据`name`和协议来替换对应的字段，用户需要填写表格中`settingName`列中存在的值。例如用户将
-`name`设置为`max_tokens`，在openai协议中会替换`max_tokens`，在gemini中会替换`maxOutputTokens`。
+
+custom-setting会遵循如下表格，根据`name`和协议来替换对应的字段，用户需要填写表格中`settingName`列中存在的值。例如用户将`name`设置为`max_tokens`，在openai协议中会替换`max_tokens`，在gemini中会替换`maxOutputTokens`。
 `none`表示该协议不支持此参数。如果`name`不在此表格中或者对应协议不支持此参数，同时没有设置raw模式，则配置不会生效。
 
+
 | settingName | openai      | baidu             | spark       | qwen        | gemini          | hunyuan     | claude      | minimax            |
-|-------------|-------------|-------------------|-------------|-------------|-----------------|-------------|-------------|--------------------|
+| ----------- | ----------- | ----------------- | ----------- | ----------- | --------------- | ----------- | ----------- | ------------------ |
 | max_tokens  | max_tokens  | max_output_tokens | max_tokens  | max_tokens  | maxOutputTokens | none        | max_tokens  | tokens_to_generate |
 | temperature | temperature | temperature       | temperature | temperature | temperature     | Temperature | temperature | temperature        |
 | top_p       | top_p       | top_p             | none        | top_p       | topP            | TopP        | top_p       | top_p              |
 | top_k       | none        | none              | top_k       | none        | topK            | none        | top_k       | none               |
 | seed        | seed        | none              | none        | seed        | none            | none        | none        | none               |
 
-如果启用了raw模式，customSettings会直接用输入的`name`和`value`去更改请求中的json内容，而不对参数名称做任何限制和修改。
-对于大多数协议，customSettings都会在json内容的根路径修改或者填充参数。对于`qwen`协议，ai-proxy会在json的`parameters`
-子路径下做配置。对于`gemini`协议，则会在`generation_config`子路径下做配置。
+如果启用了raw模式，custom-setting会直接用输入的`name`和`value`去更改请求中的json内容，而不对参数名称做任何限制和修改。
+对于大多数协议，custom-setting都会在json内容的根路径修改或者填充参数。对于`qwen`协议，ai-proxy会在json的`parameters`子路径下做配置。对于`gemini`协议，则会在`generation_config`子路径下做配置。
+
 
 ### 提供商特有配置
 
@@ -83,10 +82,11 @@ customSettings会遵循如下表格，根据`name`和协议来替换对应的字
 
 OpenAI 所对应的 `type` 为 `openai`。它特有的配置字段如下:
 
-| 名称                   | 数据类型   | 填写要求 | 默认值 | 描述                                                               |
-|----------------------|--------|------|-----|------------------------------------------------------------------|
-| `openaiCustomUrl`    | string | 非必填  | -   | 基于OpenAI协议的自定义后端URL，例如: www.example.com/myai/v1/chat/completions |
-| `responseJsonSchema` | object | 非必填  | -   | 预先定义OpenAI响应需满足的Json Schema, 注意目前仅特定的几种模型支持该用法                   |
+| 名称              | 数据类型 | 填写要求 | 默认值 | 描述                                                                          |
+|-------------------|----------|----------|--------|-------------------------------------------------------------------------------|
+| `openaiCustomUrl` | string   | 非必填   | -      | 基于OpenAI协议的自定义后端URL，例如: www.example.com/myai/v1/chat/completions |
+| `responseJsonSchema` | object | 非必填 | - | 预先定义OpenAI响应需满足的Json Schema, 注意目前仅特定的几种模型支持该用法|
+
 
 #### Azure OpenAI
 
@@ -112,7 +112,7 @@ Azure OpenAI 所对应的 `type` 为 `azure`。它特有的配置字段如下：
 
 | 名称                 | 数据类型            | 填写要求 | 默认值 | 描述                                                               |
 |--------------------|-----------------|------|-----|------------------------------------------------------------------|
-| `qwenEnableSearch` | boolean         | 非必填  | -   | 是否启用通义千问内置的互联网搜索功能。                                              |
+| `qwenEnableSearch` | boolean         | 非必填  | -   | 是否启用通义千问内置的互联网搜索功能。                          |
 | `qwenFileIds`      | array of string | 非必填  | -   | 通过文件接口上传至Dashscope的文件 ID，其内容将被用做 AI 对话的上下文。不可与 `context` 字段同时配置。 |
 
 #### 百川智能 (Baichuan AI)
@@ -151,34 +151,34 @@ Mistral 所对应的 `type` 为 `mistral`。它并无特有的配置字段。
 
 MiniMax所对应的 `type` 为 `minimax`。它特有的配置字段如下：
 
-| 名称               | 数据类型   | 填写要求                                                                       | 默认值 | 描述                                                                                                        |
-|------------------|--------|----------------------------------------------------------------------------|-----|-----------------------------------------------------------------------------------------------------------|
-| `minimaxGroupId` | string | 当使用`abab6.5-chat`, `abab6.5s-chat`, `abab5.5s-chat`, `abab5.5-chat`四种模型时必填 | -   | 当使用`abab6.5-chat`, `abab6.5s-chat`, `abab5.5s-chat`, `abab5.5-chat`四种模型时会使用ChatCompletion Pro，需要设置groupID |
+| 名称             | 数据类型 | 填写要求                                                     | 默认值 | 描述                                                         |
+| ---------------- | -------- | ------------------------------------------------------------ | ------ | ------------------------------------------------------------ |
+| `minimaxGroupId` | string   | 当使用`abab6.5-chat`, `abab6.5s-chat`, `abab5.5s-chat`, `abab5.5-chat`四种模型时必填 | -      | 当使用`abab6.5-chat`, `abab6.5s-chat`, `abab5.5s-chat`, `abab5.5-chat`四种模型时会使用ChatCompletion Pro，需要设置groupID |
 
 #### Anthropic Claude
 
 Anthropic Claude 所对应的 `type` 为 `claude`。它特有的配置字段如下：
 
-| 名称              | 数据类型   | 填写要求 | 默认值 | 描述                               |
-|-----------------|--------|------|-----|----------------------------------|
+| 名称        | 数据类型   | 填写要求 | 默认值 | 描述                               |
+|-----------|--------|------|-----|----------------------------------|
 | `claudeVersion` | string | 可选   | -   | Claude 服务的 API 版本，默认为 2023-06-01 |
 
 #### Ollama
 
 Ollama 所对应的 `type` 为 `ollama`。它特有的配置字段如下：
 
-| 名称                 | 数据类型   | 填写要求 | 默认值 | 描述                      |
-|--------------------|--------|------|-----|-------------------------|
-| `ollamaServerHost` | string | 必填   | -   | Ollama 服务器的主机地址         |
+| 名称                | 数据类型   | 填写要求 | 默认值 | 描述                                           |
+|-------------------|--------|------|-----|----------------------------------------------|
+| `ollamaServerHost` | string | 必填   | -   | Ollama 服务器的主机地址 |
 | `ollamaServerPort` | number | 必填   | -   | Ollama 服务器的端口号，默认为11434 |
 
 #### 混元
 
 混元所对应的 `type` 为 `hunyuan`。它特有的配置字段如下：
 
-| 名称               | 数据类型   | 填写要求 | 默认值 | 描述             |
-|------------------|--------|------|-----|----------------|
-| `hunyuanAuthId`  | string | 必填   | -   | 混元用于v3版本认证的id  |
+| 名称                | 数据类型   | 填写要求 | 默认值 | 描述                                           |
+|-------------------|--------|------|-----|----------------------------------------------|
+| `hunyuanAuthId` | string | 必填   | -   | 混元用于v3版本认证的id |
 | `hunyuanAuthKey` | string | 必填   | -   | 混元用于v3版本认证的key |
 
 #### 阶跃星辰 (Stepfun)
@@ -189,8 +189,8 @@ Ollama 所对应的 `type` 为 `ollama`。它特有的配置字段如下：
 
 Cloudflare Workers AI 所对应的 `type` 为 `cloudflare`。它特有的配置字段如下：
 
-| 名称                    | 数据类型   | 填写要求 | 默认值 | 描述                                                                                                                         |
-|-----------------------|--------|------|-----|----------------------------------------------------------------------------------------------------------------------------|
+| 名称                | 数据类型   | 填写要求 | 默认值 | 描述                                                                                                                         |
+|-------------------|--------|------|-----|----------------------------------------------------------------------------------------------------------------------------|
 | `cloudflareAccountId` | string | 必填   | -   | [Cloudflare Account ID](https://developers.cloudflare.com/workers-ai/get-started/rest-api/#1-get-api-token-and-account-id) |
 
 #### 星火 (Spark)
@@ -203,17 +203,17 @@ Cloudflare Workers AI 所对应的 `type` 为 `cloudflare`。它特有的配置�
 
 Gemini 所对应的 `type` 为 `gemini`。它特有的配置字段如下：
 
-| 名称                    | 数据类型          | 填写要求 | 默认值 | 描述                                                                                              |
-|-----------------------|---------------|------|-----|-------------------------------------------------------------------------------------------------|
-| `geminiSafetySetting` | map of string | 非必填  | -   | Gemini AI内容过滤和安全级别设定。参考[Safety settings](https://ai.google.dev/gemini-api/docs/safety-settings) |
+| 名称                  | 数据类型 | 填写要求 | 默认值 | 描述                                                                                              |
+| --------------------- | -------- | -------- |-----|-------------------------------------------------------------------------------------------------|
+| `geminiSafetySetting` | map of string   | 非必填     | -   | Gemini AI内容过滤和安全级别设定。参考[Safety settings](https://ai.google.dev/gemini-api/docs/safety-settings) |
 
 #### DeepL
 
 DeepL 所对应的 `type` 为 `deepl`。它特有的配置字段如下：
 
-| 名称           | 数据类型   | 填写要求 | 默认值 | 描述                |
-|--------------|--------|------|-----|-------------------|
-| `targetLang` | string | 必填   | -   | DeepL 翻译服务需要的目标语种 |
+| 名称         | 数据类型 | 填写要求 | 默认值 | 描述                         |
+| ------------ | -------- | -------- | ------ | ---------------------------- |
+| `targetLang` | string   | 必填     | -      | DeepL 翻译服务需要的目标语种 |
 
 #### Cohere
 
@@ -228,13 +228,11 @@ Cohere 所对应的 `type` 为 `cohere`。它并无特有的配置字段。
 **配置信息**
 
 ```yaml
-activeProviderId: my-azure
-providers:
-  - id: my-azure
-    type: azure
-    apiTokens:
-      - "YOUR_AZURE_OPENAI_API_TOKEN"
-    azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
+provider:
+  type: azure
+  apiTokens:
+    - "YOUR_AZURE_OPENAI_API_TOKEN"
+  azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
 ```
 
 **请求示例**
@@ -328,20 +326,18 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-qwen
-providers:
-  - id: my-qwen
-    type: qwen
-    apiTokens:
-      - "YOUR_QWEN_API_TOKEN"
-    modelMapping:
-      'gpt-3': "qwen-turbo"
-      'gpt-35-turbo': "qwen-plus"
-      'gpt-4-turbo': "qwen-max"
-      'gpt-4-*': "qwen-max"
-      'gpt-4o': "qwen-vl-plus"
-      'text-embedding-v1': 'text-embedding-v1'
-      '*': "qwen-turbo"
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_QWEN_API_TOKEN"
+  modelMapping:
+    'gpt-3': "qwen-turbo"
+    'gpt-35-turbo': "qwen-plus"
+    'gpt-4-turbo': "qwen-max"
+    'gpt-4-*': "qwen-max"
+    'gpt-4o': "qwen-vl-plus"
+    'text-embedding-v1': 'text-embedding-v1'
+    '*': "qwen-turbo"
 ```
 
 **AI 对话请求示例**
@@ -397,25 +393,25 @@ URL: http://your-domain/v1/chat/completions
 
 ```json
 {
-  "model": "gpt-4o",
-  "messages": [
-    {
-      "role": "user",
-      "content": [
+    "model": "gpt-4o",
+    "messages": [
         {
-          "type": "image_url",
-          "image_url": {
-            "url": "https://dashscope.oss-cn-beijing.aliyuncs.com/images/dog_and_girl.jpeg"
-          }
-        },
-        {
-          "type": "text",
-          "text": "这个图片是哪里？"
+            "role": "user",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "https://dashscope.oss-cn-beijing.aliyuncs.com/images/dog_and_girl.jpeg"
+                    }
+                },
+                {
+                    "type": "text",
+                    "text": "这个图片是哪里？"
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "temperature": 0.3
+    ],
+    "temperature": 0.3
 }
 ```
 
@@ -423,28 +419,28 @@ URL: http://your-domain/v1/chat/completions
 
 ```json
 {
-  "id": "17c5955d-af9c-9f28-bbde-293a9c9a3515",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": [
-          {
-            "text": "这张照片显示的是一位女士和一只狗在海滩上。由于我无法获取具体的地理位置信息，所以不能确定这是哪个地方的海滩。但是从视觉内容来看，它可能是一个位于沿海地区的沙滩海岸线，并且有海浪拍打着岸边。这样的场景在全球许多美丽的海滨地区都可以找到。如果您需要更精确的信息，请提供更多的背景或细节描述。"
-          }
-        ]
-      },
-      "finish_reason": "stop"
+    "id": "17c5955d-af9c-9f28-bbde-293a9c9a3515",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "text": "这张照片显示的是一位女士和一只狗在海滩上。由于我无法获取具体的地理位置信息，所以不能确定这是哪个地方的海滩。但是从视觉内容来看，它可能是一个位于沿海地区的沙滩海岸线，并且有海浪拍打着岸边。这样的场景在全球许多美丽的海滨地区都可以找到。如果您需要更精确的信息，请提供更多的背景或细节描述。"
+                    }
+                ]
+            },
+            "finish_reason": "stop"
+        }
+    ],
+    "created": 1723949230,
+    "model": "qwen-vl-plus",
+    "object": "chat.completion",
+    "usage": {
+        "prompt_tokens": 1279,
+        "completion_tokens": 78
     }
-  ],
-  "created": 1723949230,
-  "model": "qwen-vl-plus",
-  "object": "chat.completion",
-  "usage": {
-    "prompt_tokens": 1279,
-    "completion_tokens": 78
-  }
 }
 ```
 
@@ -500,18 +496,16 @@ URL: http://your-domain/v1/embeddings
 **配置信息**
 
 ```yaml
-activeProviderId: my-qwen
-providers:
-  - id: my-qwen
-    type: qwen
-    apiTokens:
-      - "YOUR_QWEN_API_TOKEN"
-    modelMapping:
-      "*": "qwen-turbo"
-    context:
-      - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
-        serviceName: "file.dns",
-        servicePort: 80
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_QWEN_API_TOKEN"
+  modelMapping:
+    "*": "qwen-turbo"
+  context:
+    - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
+      serviceName: "file.dns",
+      servicePort: 80
 ```
 
 **请求示例**
@@ -562,17 +556,15 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-qwen
-providers:
-  - id: my-qwen
-    type: qwen
-    apiTokens:
-      - "YOUR_QWEN_API_TOKEN"
-    modelMapping:
-      "*": "qwen-long" # 通义千问的文件上下文只能在 qwen-long 模型下使用
-    qwenFileIds:
-      - "file-fe-xxx"
-      - "file-fe-yyy"
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_QWEN_API_TOKEN"
+  modelMapping:
+    "*": "qwen-long" # 通义千问的文件上下文只能在 qwen-long 模型下使用
+  qwenFileIds:
+  - "file-fe-xxx"
+  - "file-fe-yyy"
 ```
 
 **请求示例**
@@ -619,23 +611,20 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-qwen
-providers:
-  - id: my-qwen
-    type: qwen
-    apiTokens:
-      - "YOUR_DASHSCOPE_API_TOKEN"
-    protocol: original
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_DASHSCOPE_API_TOKEN"
+  protocol: original
 ```
 
 **请求实例**
-
 ```json
 {
   "input": {
-    "prompt": "介绍一下Dubbo"
+      "prompt": "介绍一下Dubbo"
   },
-  "parameters": {},
+  "parameters":  {},
   "debug": {}
 }
 ```
@@ -644,21 +633,21 @@ providers:
 
 ```json
 {
-  "output": {
-    "finish_reason": "stop",
-    "session_id": "677e7e8fbb874e1b84792b65042e1599",
-    "text": "Apache Dubbo 是一个..."
-  },
-  "usage": {
-    "models": [
-      {
-        "output_tokens": 449,
-        "model_id": "qwen-max",
-        "input_tokens": 282
-      }
-    ]
-  },
-  "request_id": "b59e45e3-5af4-91df-b7c6-9d746fd3297c"
+    "output": {
+        "finish_reason": "stop",
+        "session_id": "677e7e8fbb874e1b84792b65042e1599",
+        "text": "Apache Dubbo 是一个..."
+    },
+    "usage": {
+        "models": [
+            {
+                "output_tokens": 449,
+                "model_id": "qwen-max",
+                "input_tokens": 282
+            }
+        ]
+    },
+    "request_id": "b59e45e3-5af4-91df-b7c6-9d746fd3297c"
 }
 ```
 
@@ -667,15 +656,13 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-doubao
-providers:
-  - id: my-doubao
-    type: doubao
-    apiTokens:
-      - YOUR_DOUBAO_API_KEY
-    modelMapping:
-      '*': YOUR_DOUBAO_ENDPOINT
-    timeout: 1200000
+provider:
+  type: doubao
+  apiTokens:
+    - YOUR_DOUBAO_API_KEY
+  modelMapping:
+    '*': YOUR_DOUBAO_ENDPOINT
+  timeout: 1200000
 ```
 
 ### 使用月之暗面配合其原生的文件上下文
@@ -685,15 +672,13 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-moonshot
-providers:
-  - id: my-moonshot
-    type: moonshot
-    apiTokens:
-      - "YOUR_MOONSHOT_API_TOKEN"
-    moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
-    modelMapping:
-      '*': "moonshot-v1-32k"
+provider:
+  type: moonshot
+  apiTokens:
+    - "YOUR_MOONSHOT_API_TOKEN"
+  moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
+  modelMapping:
+    '*': "moonshot-v1-32k"
 ```
 
 **请求示例**
@@ -742,12 +727,10 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-groq
-providers:
-  - id: my-groq
-    type: groq
-    apiTokens:
-      - "YOUR_GROQ_API_TOKEN"
+provider:
+  type: groq
+  apiTokens:
+    - "YOUR_GROQ_API_TOKEN"
 ```
 
 **请求示例**
@@ -803,13 +786,11 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-claude
-providers:
-  - id: my-claude
-    type: claude
-    apiTokens:
-      - "YOUR_CLAUDE_API_TOKEN"
-    version: "2023-06-01"
+provider:
+  type: claude
+  apiTokens:
+    - "YOUR_CLAUDE_API_TOKEN"
+  version: "2023-06-01"
 ```
 
 **请求示例**
@@ -858,17 +839,15 @@ providers:
 **配置信息**
 
 ```yaml
-provider: "my-hunyuan"
-providers:
-  - id: "my-hunyuan"
-    type: "hunyuan"
-    hunyuanAuthKey: "<YOUR AUTH KEY>"
-    apiTokens:
-      - ""
-    hunyuanAuthId: "<YOUR AUTH ID>"
-    timeout: 1200000
-    modelMapping:
-      "*": "hunyuan-lite"
+provider:
+  type: "hunyuan"
+  hunyuanAuthKey: "<YOUR AUTH KEY>"
+  apiTokens:
+    - ""
+  hunyuanAuthId: "<YOUR AUTH ID>"
+  timeout: 1200000
+  modelMapping:
+    "*": "hunyuan-lite"
 ```
 
 **请求示例**
@@ -899,25 +878,25 @@ curl --location 'http://<your higress domain>/v1/chat/completions' \
 
 ```json
 {
-  "id": "fd140c3e-0b69-4b19-849b-d354d32a6162",
-  "choices": [
-    {
-      "index": 0,
-      "delta": {
-        "role": "assistant",
-        "content": "你好！我是一名专业的开发人员。"
-      },
-      "finish_reason": "stop"
+    "id": "fd140c3e-0b69-4b19-849b-d354d32a6162",
+    "choices": [
+        {
+            "index": 0,
+            "delta": {
+                "role": "assistant",
+                "content": "你好！我是一名专业的开发人员。"
+            },
+            "finish_reason": "stop"
+        }
+    ],
+    "created": 1717493117,
+    "model": "hunyuan-lite",
+    "object": "chat.completion",
+    "usage": {
+        "prompt_tokens": 15,
+        "completion_tokens": 9,
+        "total_tokens": 24
     }
-  ],
-  "created": 1717493117,
-  "model": "hunyuan-lite",
-  "object": "chat.completion",
-  "usage": {
-    "prompt_tokens": 15,
-    "completion_tokens": 9,
-    "total_tokens": 24
-  }
 }
 ```
 
@@ -926,29 +905,27 @@ curl --location 'http://<your higress domain>/v1/chat/completions' \
 **配置信息**
 
 ```yaml
-activeProviderId: my-baidu
-providers:
-  - id: my-baidu
-    type: baidu
-    apiTokens:
-      - "YOUR_BAIDU_API_TOKEN"
-    modelMapping:
-      'gpt-3': "ERNIE-4.0"
-      '*': "ERNIE-4.0"
+provider:
+  type: baidu
+  apiTokens:
+    - "YOUR_BAIDU_API_TOKEN"
+  modelMapping:
+    'gpt-3': "ERNIE-4.0"
+    '*': "ERNIE-4.0"
 ```
 
 **请求示例**
 
 ```json
 {
-  "model": "gpt-4-turbo",
-  "messages": [
-    {
-      "role": "user",
-      "content": "你好，你是谁？"
-    }
-  ],
-  "stream": false
+    "model": "gpt-4-turbo",
+    "messages": [
+        {
+            "role": "user",
+            "content": "你好，你是谁？"
+        }
+    ],
+    "stream": false
 }
 ```
 
@@ -956,25 +933,25 @@ providers:
 
 ```json
 {
-  "id": "as-e90yfg1pk1",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "你好，我是文心一言，英文名是ERNIE Bot。我能够与人对话互动，回答问题，协助创作，高效便捷地帮助人们获取信息、知识和灵感。"
-      },
-      "finish_reason": "stop"
+    "id": "as-e90yfg1pk1",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "你好，我是文心一言，英文名是ERNIE Bot。我能够与人对话互动，回答问题，协助创作，高效便捷地帮助人们获取信息、知识和灵感。"
+            },
+            "finish_reason": "stop"
+        }
+    ],
+    "created": 1717251488,
+    "model": "ERNIE-4.0",
+    "object": "chat.completion",
+    "usage": {
+        "prompt_tokens": 4,
+        "completion_tokens": 33,
+        "total_tokens": 37
     }
-  ],
-  "created": 1717251488,
-  "model": "ERNIE-4.0",
-  "object": "chat.completion",
-  "usage": {
-    "prompt_tokens": 4,
-    "completion_tokens": 33,
-    "total_tokens": 37
-  }
 }
 ```
 
@@ -983,31 +960,29 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-minimax
-providers:
-  - id: my-minimax
-    type: minimax
-    apiTokens:
-      - "YOUR_MINIMAX_API_TOKEN"
-    modelMapping:
-      "gpt-3": "abab6.5g-chat"
-      "gpt-4": "abab6.5-chat"
-      "*": "abab6.5g-chat"
-    minimaxGroupId: "YOUR_MINIMAX_GROUP_ID"
+provider:
+  type: minimax
+  apiTokens:
+    - "YOUR_MINIMAX_API_TOKEN"
+  modelMapping:
+    "gpt-3": "abab6.5g-chat"
+    "gpt-4": "abab6.5-chat"
+    "*": "abab6.5g-chat"
+  minimaxGroupId: "YOUR_MINIMAX_GROUP_ID"
 ```
 
 **请求示例**
 
 ```json
 {
-  "model": "gpt-4-turbo",
-  "messages": [
-    {
-      "role": "user",
-      "content": "你好，你是谁？"
-    }
-  ],
-  "stream": false
+    "model": "gpt-4-turbo",
+    "messages": [
+        {
+            "role": "user",
+            "content": "你好，你是谁？"
+        }
+    ],
+    "stream": false
 }
 ```
 
@@ -1015,31 +990,31 @@ providers:
 
 ```json
 {
-  "id": "02b2251f8c6c09d68c1743f07c72afd7",
-  "choices": [
-    {
-      "finish_reason": "stop",
-      "index": 0,
-      "message": {
-        "content": "你好！我是MM智能助理，一款由MiniMax自研的大型语言模型。我可以帮助你解答问题，提供信息，进行对话等。有什么可以帮助你的吗？",
-        "role": "assistant"
-      }
+    "id": "02b2251f8c6c09d68c1743f07c72afd7",
+    "choices": [
+        {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+                "content": "你好！我是MM智能助理，一款由MiniMax自研的大型语言模型。我可以帮助你解答问题，提供信息，进行对话等。有什么可以帮助你的吗？",
+                "role": "assistant"
+            }
+        }
+    ],
+    "created": 1717760544,
+    "model": "abab6.5s-chat",
+    "object": "chat.completion",
+    "usage": {
+        "total_tokens": 106
+    },
+    "input_sensitive": false,
+    "output_sensitive": false,
+    "input_sensitive_type": 0,
+    "output_sensitive_type": 0,
+    "base_resp": {
+        "status_code": 0,
+        "status_msg": ""
     }
-  ],
-  "created": 1717760544,
-  "model": "abab6.5s-chat",
-  "object": "chat.completion",
-  "usage": {
-    "total_tokens": 106
-  },
-  "input_sensitive": false,
-  "output_sensitive": false,
-  "input_sensitive_type": 0,
-  "output_sensitive_type": 0,
-  "base_resp": {
-    "status_code": 0,
-    "status_msg": ""
-  }
 }
 ```
 
@@ -1048,18 +1023,16 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-ai360
-providers:
-  - id: my-ai360
-    type: ai360
-    apiTokens:
-      - "YOUR_AI360_API_TOKEN"
-    modelMapping:
-      "gpt-4o": "360gpt-turbo-responsibility-8k"
-      "gpt-4": "360gpt2-pro"
-      "gpt-3.5": "360gpt-turbo"
-      "text-embedding-3-small": "embedding_s1_v1.2"
-      "*": "360gpt-pro"
+provider:
+  type: ai360
+  apiTokens:
+    - "YOUR_MINIMAX_API_TOKEN"
+  modelMapping:
+    "gpt-4o": "360gpt-turbo-responsibility-8k"
+    "gpt-4": "360gpt2-pro"
+    "gpt-3.5": "360gpt-turbo"
+    "text-embedding-3-small": "embedding_s1_v1.2"
+    "*": "360gpt-pro"
 ```
 
 **请求示例**
@@ -1125,10 +1098,8 @@ URL: http://your-domain/v1/embeddings
 
 ```json
 {
-  "input": [
-    "你好"
-  ],
-  "model": "text-embedding-3-small"
+  "input":["你好"],
+  "model":"text-embedding-3-small"
 }
 ```
 
@@ -1166,15 +1137,13 @@ URL: http://your-domain/v1/embeddings
 **配置信息**
 
 ```yaml
-activeProviderId: my-cf
-providers:
-  - id: my-cf
-    type: cloudflare
-    apiTokens:
-      - "YOUR_WORKERS_AI_API_TOKEN"
-    cloudflareAccountId: "YOUR_CLOUDFLARE_ACCOUNT_ID"
-    modelMapping:
-      "*": "@cf/meta/llama-3-8b-instruct"
+provider:
+  type: cloudflare
+  apiTokens:
+    - "YOUR_WORKERS_AI_API_TOKEN"
+  cloudflareAccountId: "YOUR_CLOUDFLARE_ACCOUNT_ID"
+  modelMapping:
+    "*": "@cf/meta/llama-3-8b-instruct"
 ```
 
 **请求示例**
@@ -1219,34 +1188,32 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-spark
-providers:
-  - id: my-spark
-    type: spark
-    apiTokens:
-      - "APIKey:APISecret"
-    modelMapping:
-      "gpt-4o": "generalv3.5"
-      "gpt-4": "generalv3"
-      "*": "general"
+provider:
+  type: spark
+  apiTokens:
+    - "APIKey:APISecret"
+  modelMapping:
+    "gpt-4o": "generalv3.5"
+    "gpt-4": "generalv3"
+    "*": "general"
 ```
 
 **请求示例**
 
 ```json
 {
-  "model": "gpt-4o",
-  "messages": [
-    {
-      "role": "system",
-      "content": "你是一名专业的开发人员！"
-    },
-    {
-      "role": "user",
-      "content": "你好，你是谁？"
-    }
-  ],
-  "stream": false
+    "model": "gpt-4o",
+    "messages": [
+        {
+            "role": "system",
+            "content": "你是一名专业的开发人员！"
+        },
+        {
+            "role": "user",
+            "content": "你好，你是谁？"
+        }
+    ],
+    "stream": false
 }
 ```
 
@@ -1254,24 +1221,24 @@ providers:
 
 ```json
 {
-  "id": "cha000c23c6@dx190ef0b4b96b8f2532",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "你好！我是一名专业的开发人员，擅长编程和解决技术问题。有什么我可以帮助你的吗？"
-      }
+    "id": "cha000c23c6@dx190ef0b4b96b8f2532",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "你好！我是一名专业的开发人员，擅长编程和解决技术问题。有什么我可以帮助你的吗？"
+            }
+        }
+    ],
+    "created": 1721997415,
+    "model": "generalv3.5",
+    "object": "chat.completion",
+    "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 19,
+        "total_tokens": 29
     }
-  ],
-  "created": 1721997415,
-  "model": "generalv3.5",
-  "object": "chat.completion",
-  "usage": {
-    "prompt_tokens": 10,
-    "completion_tokens": 19,
-    "total_tokens": 29
-  }
 }
 ```
 
@@ -1280,33 +1247,31 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-gemini
-providers:
-  - id: my-gemini
-    type: gemini
-    apiTokens:
-      - "YOUR_GEMINI_API_TOKEN"
-    modelMapping:
-      "*": "gemini-pro"
-    geminiSafetySetting:
-      "HARM_CATEGORY_SEXUALLY_EXPLICIT": "BLOCK_NONE"
-      "HARM_CATEGORY_HATE_SPEECH": "BLOCK_NONE"
-      "HARM_CATEGORY_HARASSMENT": "BLOCK_NONE"
-      "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_NONE"
+provider:
+  type: gemini
+  apiTokens:
+    - "YOUR_GEMINI_API_TOKEN"
+  modelMapping:
+    "*": "gemini-pro"
+  geminiSafetySetting:
+    "HARM_CATEGORY_SEXUALLY_EXPLICIT" :"BLOCK_NONE"
+    "HARM_CATEGORY_HATE_SPEECH" :"BLOCK_NONE"
+    "HARM_CATEGORY_HARASSMENT" :"BLOCK_NONE"
+    "HARM_CATEGORY_DANGEROUS_CONTENT" :"BLOCK_NONE"
 ```
 
 **请求示例**
 
 ```json
 {
-  "model": "gpt-3.5",
-  "messages": [
-    {
-      "role": "user",
-      "content": "Who are you?"
-    }
-  ],
-  "stream": false
+    "model": "gpt-3.5",
+    "messages": [
+        {
+            "role": "user",
+            "content": "Who are you?"
+        }
+    ],
+    "stream": false
 }
 ```
 
@@ -1314,25 +1279,25 @@ providers:
 
 ```json
 {
-  "id": "chatcmpl-b010867c-0d3f-40ba-95fd-4e8030551aeb",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "I am a large multi-modal model, trained by Google. I am designed to provide information and answer questions to the best of my abilities."
-      },
-      "finish_reason": "stop"
+    "id": "chatcmpl-b010867c-0d3f-40ba-95fd-4e8030551aeb",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "I am a large multi-modal model, trained by Google. I am designed to provide information and answer questions to the best of my abilities."
+            },
+            "finish_reason": "stop"
+        }
+    ],
+    "created": 1722756984,
+    "model": "gemini-pro",
+    "object": "chat.completion",
+    "usage": {
+        "prompt_tokens": 5,
+        "completion_tokens": 29,
+        "total_tokens": 34
     }
-  ],
-  "created": 1722756984,
-  "model": "gemini-pro",
-  "object": "chat.completion",
-  "usage": {
-    "prompt_tokens": 5,
-    "completion_tokens": 29,
-    "total_tokens": 34
-  }
 }
 ```
 
@@ -1341,18 +1306,15 @@ providers:
 **配置信息**
 
 ```yaml
-activeProviderId: my-deepl
-providers:
-  - id: my-deepl
-    type: deepl
-    apiTokens:
-      - "YOUR_DEEPL_API_TOKEN"
-    targetLang: "ZH"
+provider:
+  type: deepl
+  apiTokens:
+    - "YOUR_DEEPL_API_TOKEN"
+  targetLang: "ZH"
 ```
 
 **请求示例**
-此处 `model` 表示 DeepL 的服务类型，只能填 `Free` 或 `Pro`。`content` 中设置需要翻译的文本；在 `role: system` 的 `content`
-中可以包含可能影响翻译但本身不会被翻译的上下文，例如翻译产品名称时，可以将产品描述作为上下文传递，这种额外的上下文可能会提高翻译的质量。
+此处 `model` 表示 DeepL 的服务类型，只能填 `Free` 或 `Pro`。`content` 中设置需要翻译的文本；在 `role: system` 的 `content` 中可以包含可能影响翻译但本身不会被翻译的上下文，例如翻译产品名称时，可以将产品描述作为上下文传递，这种额外的上下文可能会提高翻译的质量。
 
 ```json
 {
@@ -1373,25 +1335,16 @@ providers:
 ```
 
 **响应示例**
-
 ```json
 {
   "choices": [
     {
       "index": 0,
-      "message": {
-        "name": "EN",
-        "role": "assistant",
-        "content": "坐庄"
-      }
+      "message": { "name": "EN", "role": "assistant", "content": "坐庄" }
     },
     {
       "index": 1,
-      "message": {
-        "name": "EN",
-        "role": "assistant",
-        "content": "中国银行"
-      }
+      "message": { "name": "EN", "role": "assistant", "content": "中国银行" }
     }
   ],
   "created": 1722747752,
@@ -1415,15 +1368,13 @@ metadata:
   namespace: higress-system
 spec:
   matchRules:
-    - config:
-        activeProviderId: my-groq
-        providers:
-          - id: my-groq
-            type: groq
-            apiTokens:
-              - "YOUR_API_TOKEN"
-      ingress:
-        - groq
+  - config:
+      provider:
+        type: groq
+        apiTokens: 
+          - "YOUR_API_TOKEN"
+    ingress:
+    - groq
   url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:1.0.0
 ---
 apiVersion: networking.k8s.io/v1
@@ -1441,16 +1392,16 @@ metadata:
 spec:
   ingressClassName: higress
   rules:
-    - host: <YOUR-DOMAIN>
-      http:
-        paths:
-          - backend:
-              resource:
-                apiGroup: networking.higress.io
-                kind: McpBridge
-                name: default
-            path: /
-            pathType: Prefix
+  - host: <YOUR-DOMAIN> 
+    http:
+      paths:
+      - backend:
+          resource:
+            apiGroup: networking.higress.io
+            kind: McpBridge
+            name: default
+        path: /
+        pathType: Prefix
 ---
 apiVersion: networking.higress.io/v1
 kind: McpBridge
@@ -1459,10 +1410,10 @@ metadata:
   namespace: higress-system
 spec:
   registries:
-    - domain: api.groq.com
-      name: groq
-      port: 443
-      type: dns
+  - domain: api.groq.com
+    name: groq
+    port: 443
+    type: dns
 ```
 
 访问示例：
@@ -1499,7 +1450,7 @@ services:
       - ./envoy.yaml:/etc/envoy/envoy.yaml
       - ./plugin.wasm:/etc/envoy/plugin.wasm
 networks:
-  higress-net: { }
+  higress-net: {}
 ```
 
 `envoy.yaml` 配置文件：
@@ -1561,16 +1512,12 @@ static_resources:
                             "@type": "type.googleapis.com/google.protobuf.StringValue"
                             value: | # 插件配置
                               {
-                                "activeProviderId": "my-claude",
-                                "providers": [
-                                  {
-                                    "id": "my-claude",
-                                    "type": "claude",
-                                    "apiTokens": [
-                                      "YOUR_API_TOKEN"
-                                    ]
-                                  }
-                                ]
+                                "provider": {
+                                  "type": "claude",                                
+                                  "apiTokens": [
+                                    "YOUR_API_TOKEN"
+                                  ]                  
+                                }
                               }
                   - name: envoy.filters.http.router
   clusters:

--- a/plugins/wasm-go/extensions/ai-proxy/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README_EN.md
@@ -25,7 +25,8 @@ Plugin execution priority: `100`
 
 | Name       | Data Type   | Requirement | Default | Description               |
 |------------|--------|------|-----|------------------|
-| `provider` | object | Required   | -   | Configures information for the target AI service provider |
+| `providers` | object | Optional   | -   | Configures information for the target AI service provider |
+| `activeProviderId` | string          | Optional  | -   | 当前需要启用的 AI 服务提供商标识。支持在全局、域名、路由等粒度进行配置。如果未配置、值为空或值未出现在 `providers` 中，本插件将不会工作。 |
 
 **Details for the `provider` configuration fields:**
 
@@ -139,9 +140,9 @@ For 360 Brain, the corresponding `type` is `ai360`. It has no unique configurati
 
 For Mistral, the corresponding `type` is `mistral`. It has no unique configuration fields.
 
-#### Minimax
+#### MiniMax
 
-For Minimax, the corresponding `type` is `minimax`. Its unique configuration field is:
+For MiniMax, the corresponding `type` is `minimax`. Its unique configuration field is:
 
 | Name             | Data Type | Filling Requirements | Default Value | Description                                                                                                 |
 | ---------------- | -------- | --------------------- |---------------|------------------------------------------------------------------------------------------------------------|
@@ -216,11 +217,13 @@ Using the basic Azure OpenAI service without configuring any context.
 **Configuration Information**
 
 ```yaml
-provider:
-  type: azure
-  apiTokens:
-    - "YOUR_AZURE_OPENAI_API_TOKEN"
-  azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
+activeProviderId: my-azure
+providers:
+  - id: my-azure
+    type: azure
+    apiTokens:
+      - "YOUR_AZURE_OPENAI_API_TOKEN"
+    azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
 ```
 
 **Request Example**
@@ -314,18 +317,20 @@ Using Qwen service and configuring the mapping relationship between OpenAI large
 **Configuration Information**
 
 ```yaml
-provider:
-  type: qwen
-  apiTokens:
-    - "YOUR_QWEN_API_TOKEN"
-  modelMapping:
-    'gpt-3': "qwen-turbo"
-    'gpt-35-turbo': "qwen-plus"
-    'gpt-4-turbo': "qwen-max"
-    'gpt-4-*': "qwen-max"
-    'gpt-4o': "qwen-vl-plus"
-    'text-embedding-v1': 'text-embedding-v1'
-    '*': "qwen-turbo"
+activeProviderId: my-qwen
+providers:
+  - id: my-qwen
+    type: qwen
+    apiTokens:
+      - "YOUR_QWEN_API_TOKEN"
+    modelMapping:
+      'gpt-3': "qwen-turbo"
+      'gpt-35-turbo': "qwen-plus"
+      'gpt-4-turbo': "qwen-max"
+      'gpt-4-*': "qwen-max"
+      'gpt-4o': "qwen-vl-plus"
+      'text-embedding-v1': 'text-embedding-v1'
+      '*': "qwen-turbo"
 ```
 
 **AI Conversation Request Example**
@@ -484,16 +489,18 @@ Using Qwen service while configuring pure text context information.
 **Configuration Information**
 
 ```yaml
-provider:
-  type: qwen
-  apiTokens:
-    - "YOUR_QWEN_API_TOKEN"
-  modelMapping:
-    "*": "qwen-turbo"
-  context:
-    - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
-      serviceName: "file.dns",
-      servicePort: 80
+activeProviderId: my-qwen
+providers:
+  - id: my-qwen
+    type: qwen
+    apiTokens:
+      - "YOUR_QWEN_API_TOKEN"
+    modelMapping:
+      "*": "qwen-turbo"
+    context:
+      - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
+        serviceName: "file.dns",
+        servicePort: 80
 ```
 
 **Request Example**
@@ -544,15 +551,17 @@ Uploading files to Qwen in advance to use them as context when utilizing its AI 
 **Configuration Information**
 
 ```yaml
-provider:
-  type: qwen
-  apiTokens:
-    - "YOUR_QWEN_API_TOKEN"
-  modelMapping:
-    "*": "qwen-long" # Qwen's file context can only be used in the qwen-long model
-  qwenFileIds:
-  - "file-fe-xxx"
-  - "file-fe-yyy"
+activeProviderId: my-qwen
+providers:
+  - id: my-qwen
+    type: qwen
+    apiTokens:
+      - "YOUR_QWEN_API_TOKEN"
+    modelMapping:
+      "*": "qwen-long" # 通义千问的文件上下文只能在 qwen-long 模型下使用
+    qwenFileIds:
+      - "file-fe-xxx"
+      - "file-fe-yyy"
 ```
 
 **Request Example**
@@ -593,6 +602,69 @@ provider:
   "request_id": "187e99ba-5b64-9ffe-8f69-01dafbaf6ed7"
 }
 ```
+
+### Forwards requests to AliCloud Bailian with the "original" protocol
+
+**Configuration Information**
+
+```yaml
+activeProviderId: my-qwen
+providers:
+  - id: my-qwen
+    type: qwen
+    apiTokens:
+      - "YOUR_DASHSCOPE_API_TOKEN"
+    protocol: original
+```
+
+**Example Request**
+
+```json
+{
+  "input": {
+    "prompt": "What is Dubbo?"
+  },
+  "parameters": {},
+  "debug": {}
+}
+```
+
+**Example Response**
+
+```json
+{
+  "output": {
+    "finish_reason": "stop",
+    "session_id": "677e7e8fbb874e1b84792b65042e1599",
+    "text": "Apache Dubbo is a..."
+  },
+  "usage": {
+    "models": [
+      {
+        "output_tokens": 449,
+        "model_id": "qwen-max",
+        "input_tokens": 282
+      }
+    ]
+  },
+  "request_id": "b59e45e3-5af4-91df-b7c6-9d746fd3297c"
+}
+```
+
+### Using OpenAI Protocol Proxy for Doubao Service
+
+```yaml
+activeProviderId: my-doubao
+providers:
+- id: my-doubao
+  type: doubao
+  apiTokens:
+    - YOUR_DOUBAO_API_KEY
+  modelMapping:
+    '*': YOUR_DOUBAO_ENDPOINT
+  timeout: 1200000
+```
+
 ### Utilizing Moonshot with its Native File Context
 
 Upload files to Moonshot in advance and use its AI services based on file content.
@@ -600,13 +672,15 @@ Upload files to Moonshot in advance and use its AI services based on file conten
 **Configuration Information**
 
 ```yaml
-provider:
-  type: moonshot
-  apiTokens:
-    - "YOUR_MOONSHOT_API_TOKEN"
-  moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
-  modelMapping:
-    '*': "moonshot-v1-32k"
+activeProviderId: my-moonshot
+providers:
+  - id: my-moonshot
+    type: moonshot
+    apiTokens:
+      - "YOUR_MOONSHOT_API_TOKEN"
+    moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
+    modelMapping:
+      '*': "moonshot-v1-32k"
 ```
 
 **Example Request**
@@ -655,10 +729,12 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: groq
-  apiTokens:
-    - "YOUR_GROQ_API_TOKEN"
+activeProviderId: my-groq
+providers:
+  - id: my-groq
+    type: groq
+    apiTokens:
+      - "YOUR_GROQ_API_TOKEN"
 ```
 
 **Example Request**
@@ -714,11 +790,13 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: claude
-  apiTokens:
-    - "YOUR_CLAUDE_API_TOKEN"
-  version: "2023-06-01"
+activeProviderId: my-claude
+providers:
+  - id: my-claude
+    type: claude
+    apiTokens:
+      - "YOUR_CLAUDE_API_TOKEN"
+    version: "2023-06-01"
 ```
 
 **Example Request**
@@ -767,23 +845,24 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: "hunyuan"
-  hunyuanAuthKey: "<YOUR AUTH KEY>"
-  apiTokens:
-    - ""
-  hunyuanAuthId: "<YOUR AUTH ID>"
-  timeout: 1200000
-  modelMapping:
-    "*": "hunyuan-lite"
+provider: "my-hunyuan"
+providers:
+  - id: "my-hunyuan"
+    type: "hunyuan"
+    hunyuanAuthKey: "<YOUR AUTH KEY>"
+    apiTokens:
+      - ""
+    hunyuanAuthId: "<YOUR AUTH ID>"
+    timeout: 1200000
+    modelMapping:
+      "*": "hunyuan-lite"
 ```
 
 **Example Request**
 
 Request script:
 
-```sh
-
+```shell
 curl --location 'http://<your higress domain>/v1/chat/completions' \
 --header 'Content-Type:  application/json' \
 --data '{
@@ -834,13 +913,15 @@ curl --location 'http://<your higress domain>/v1/chat/completions' \
 **Configuration Information**
 
 ```yaml
-provider:
-  type: baidu
-  apiTokens:
-    - "YOUR_BAIDU_API_TOKEN"
-  modelMapping:
-    'gpt-3': "ERNIE-4.0"
-    '*': "ERNIE-4.0"
+activeProviderId: my-baidu
+providers:
+  - id: my-baidu
+    type: baidu
+    apiTokens:
+      - "YOUR_BAIDU_API_TOKEN"
+    modelMapping:
+      'gpt-3': "ERNIE-4.0"
+      '*': "ERNIE-4.0"
 ```
 
 **Request Example**
@@ -889,15 +970,17 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: minimax
-  apiTokens:
-    - "YOUR_MINIMAX_API_TOKEN"
-  modelMapping:
-    "gpt-3": "abab6.5g-chat"
-    "gpt-4": "abab6.5-chat"
-    "*": "abab6.5g-chat"
-  minimaxGroupId: "YOUR_MINIMAX_GROUP_ID"
+activeProviderId: my-minimax
+providers:
+  - id: my-minimax
+    type: minimax
+    apiTokens:
+      - "YOUR_MINIMAX_API_TOKEN"
+    modelMapping:
+      "gpt-3": "abab6.5g-chat"
+      "gpt-4": "abab6.5-chat"
+      "*": "abab6.5g-chat"
+    minimaxGroupId: "YOUR_MINIMAX_GROUP_ID"
 ```
 
 **Request Example**
@@ -952,16 +1035,18 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: ai360
-  apiTokens:
-    - "YOUR_MINIMAX_API_TOKEN"
-  modelMapping:
-    "gpt-4o": "360gpt-turbo-responsibility-8k"
-    "gpt-4": "360gpt2-pro"
-    "gpt-3.5": "360gpt-turbo"
-    "text-embedding-3-small": "embedding_s1_v1.2"
-    "*": "360gpt-pro"
+activeProviderId: my-ai360
+providers:
+  - id: my-ai360
+    type: ai360
+    apiTokens:
+      - "YOUR_AI360_API_TOKEN"
+    modelMapping:
+      "gpt-4o": "360gpt-turbo-responsibility-8k"
+      "gpt-4": "360gpt2-pro"
+      "gpt-3.5": "360gpt-turbo"
+      "text-embedding-3-small": "embedding_s1_v1.2"
+      "*": "360gpt-pro"
 ```
 
 **Request Example**
@@ -1066,13 +1151,15 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: cloudflare
-  apiTokens:
-    - "YOUR_WORKERS_AI_API_TOKEN"
-  cloudflareAccountId: "YOUR_CLOUDFLARE_ACCOUNT_ID"
-  modelMapping:
-    "*": "@cf/meta/llama-3-8b-instruct"
+activeProviderId: my-cf
+providers:
+  - id: my-cf
+    type: cloudflare
+    apiTokens:
+      - "YOUR_WORKERS_AI_API_TOKEN"
+    cloudflareAccountId: "YOUR_CLOUDFLARE_ACCOUNT_ID"
+    modelMapping:
+      "*": "@cf/meta/llama-3-8b-instruct"
 ```
 
 **Request Example**
@@ -1117,14 +1204,16 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: spark
-  apiTokens:
-    - "APIKey:APISecret"
-  modelMapping:
-    "gpt-4o": "generalv3.5"
-    "gpt-4": "generalv3"
-    "*": "general"
+activeProviderId: my-spark
+providers:
+  - id: my-spark
+    type: spark
+    apiTokens:
+      - "APIKey:APISecret"
+    modelMapping:
+      "gpt-4o": "generalv3.5"
+      "gpt-4": "generalv3"
+      "*": "general"
 ```
 
 **Request Example**
@@ -1176,31 +1265,33 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: gemini
-  apiTokens:
-    - "YOUR_GEMINI_API_TOKEN"
-  modelMapping:
-    "*": "gemini-pro"
-  geminiSafetySetting:
-    "HARM_CATEGORY_SEXUALLY_EXPLICIT" :"BLOCK_NONE"
-    "HARM_CATEGORY_HATE_SPEECH" :"BLOCK_NONE"
-    "HARM_CATEGORY_HARASSMENT" :"BLOCK_NONE"
-    "HARM_CATEGORY_DANGEROUS_CONTENT" :"BLOCK_NONE"
+activeProviderId: my-gemini
+providers:
+  - id: my-gemini
+    type: gemini
+    apiTokens:
+      - "YOUR_GEMINI_API_TOKEN"
+    modelMapping:
+      "*": "gemini-pro"
+    geminiSafetySetting:
+      "HARM_CATEGORY_SEXUALLY_EXPLICIT": "BLOCK_NONE"
+      "HARM_CATEGORY_HATE_SPEECH": "BLOCK_NONE"
+      "HARM_CATEGORY_HARASSMENT": "BLOCK_NONE"
+      "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_NONE"
 ```
 
 **Request Example**
 
 ```json
 {
-    "model": "gpt-3.5",
-    "messages": [
-        {
-            "role": "user",
-            "content": "Who are you?"
-        }
-    ],
-    "stream": false
+  "model": "gpt-3.5",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Who are you?"
+    }
+  ],
+  "stream": false
 }
 ```
 
@@ -1208,25 +1299,25 @@ provider:
 
 ```json
 {
-    "id": "chatcmpl-b010867c-0d3f-40ba-95fd-4e8030551aeb",
-    "choices": [
-        {
-            "index": 0,
-            "message": {
-                "role": "assistant",
-                "content": "I am a large multi-modal model, trained by Google. I am designed to provide information and answer questions to the best of my abilities."
-            },
-            "finish_reason": "stop"
-        }
-    ],
-    "created": 1722756984,
-    "model": "gemini-pro",
-    "object": "chat.completion",
-    "usage": {
-        "prompt_tokens": 5,
-        "completion_tokens": 29,
-        "total_tokens": 34
+  "id": "chatcmpl-b010867c-0d3f-40ba-95fd-4e8030551aeb",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I am a large multi-modal model, trained by Google. I am designed to provide information and answer questions to the best of my abilities."
+      },
+      "finish_reason": "stop"
     }
+  ],
+  "created": 1722756984,
+  "model": "gemini-pro",
+  "object": "chat.completion",
+  "usage": {
+    "prompt_tokens": 5,
+    "completion_tokens": 29,
+    "total_tokens": 34
+  }
 }
 ```
 
@@ -1235,11 +1326,13 @@ provider:
 **Configuration Information**
 
 ```yaml
-provider:
-  type: deepl
-  apiTokens:
-    - "YOUR_DEEPL_API_TOKEN"
-  targetLang: "ZH"
+activeProviderId: my-deepl
+providers:
+  - id: my-deepl
+    type: deepl
+    apiTokens:
+      - "YOUR_DEEPL_API_TOKEN"
+    targetLang: "ZH"
 ```
 
 **Request Example**
@@ -1264,6 +1357,7 @@ Here, `model` denotes the service tier of DeepL and can only be either `Free` or
 ```
 
 **Response Example**
+
 ```json
 {
   "choices": [
@@ -1297,13 +1391,15 @@ metadata:
   namespace: higress-system
 spec:
   matchRules:
-  - config:
-      provider:
-        type: groq
-        apiTokens:
-          - "YOUR_API_TOKEN"
-    ingress:
-    - groq
+    - config:
+        activeProviderId: my-groq
+        providers:
+          - id: my-groq
+            type: groq
+            apiTokens:
+              - "YOUR_API_TOKEN"
+      ingress:
+        - groq
   url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:1.0.0
 ---
 apiVersion: networking.k8s.io/v1
@@ -1321,16 +1417,16 @@ metadata:
 spec:
   ingressClassName: higress
   rules:
-  - host: <YOUR-DOMAIN>
-    http:
-      paths:
-      - backend:
-          resource:
-            apiGroup: networking.higress.io
-            kind: McpBridge
-            name: default
-        path: /
-        pathType: Prefix
+    - host: <YOUR-DOMAIN>
+      http:
+        paths:
+          - backend:
+              resource:
+                apiGroup: networking.higress.io
+                kind: McpBridge
+                name: default
+            path: /
+            pathType: Prefix
 ---
 apiVersion: networking.higress.io/v1
 kind: McpBridge
@@ -1339,10 +1435,10 @@ metadata:
   namespace: higress-system
 spec:
   registries:
-  - domain: api.groq.com
-    name: groq
-    port: 443
-    type: dns
+    - domain: api.groq.com
+      name: groq
+      port: 443
+      type: dns
 ```
 
 Access Example:
@@ -1379,7 +1475,7 @@ services:
       - ./envoy.yaml:/etc/envoy/envoy.yaml
       - ./plugin.wasm:/etc/envoy/plugin.wasm
 networks:
-  higress-net: {}
+  higress-net: { }
 ```
 
 `envoy.yaml` configuration file:
@@ -1407,12 +1503,12 @@ static_resources:
                 scheme_header_transformation:
                   scheme_to_overwrite: https
                 stat_prefix: ingress_http
-                # Outputs envoy logs to stdout
+                # Output envoy logs to stdout
                 access_log:
                   - name: envoy.access_loggers.stdout
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
-                # Modify as needed
+                # Modify as required
                 route_config:
                   name: local_route
                   virtual_hosts:
@@ -1441,12 +1537,16 @@ static_resources:
                             "@type": "type.googleapis.com/google.protobuf.StringValue"
                             value: | # Plugin configuration
                               {
-                                "provider": {
-                                  "type": "claude",
-                                  "apiTokens": [
-                                    "YOUR_API_TOKEN"
-                                  ]
-                                }
+                                "activeProviderId": "my-claude",
+                                "providers": [
+                                  {
+                                    "id": "my-claude",
+                                    "type": "claude",
+                                    "apiTokens": [
+                                      "YOUR_API_TOKEN"
+                                    ]
+                                  }
+                                ]
                               }
                   - name: envoy.filters.http.router
   clusters:

--- a/plugins/wasm-go/extensions/ai-proxy/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README_EN.md
@@ -25,8 +25,7 @@ Plugin execution priority: `100`
 
 | Name       | Data Type   | Requirement | Default | Description               |
 |------------|--------|------|-----|------------------|
-| `providers` | object | Optional   | -   | Configures information for the target AI service provider |
-| `activeProviderId` | string          | Optional  | -   | 当前需要启用的 AI 服务提供商标识。支持在全局、域名、路由等粒度进行配置。如果未配置、值为空或值未出现在 `providers` 中，本插件将不会工作。 |
+| `provider` | object | Required   | -   | Configures information for the target AI service provider |
 
 **Details for the `provider` configuration fields:**
 
@@ -217,13 +216,11 @@ Using the basic Azure OpenAI service without configuring any context.
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-azure
-providers:
-  - id: my-azure
-    type: azure
-    apiTokens:
-      - "YOUR_AZURE_OPENAI_API_TOKEN"
-    azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
+provider:
+  type: azure
+  apiTokens:
+    - "YOUR_AZURE_OPENAI_API_TOKEN"
+  azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
 ```
 
 **Request Example**
@@ -317,20 +314,18 @@ Using Qwen service and configuring the mapping relationship between OpenAI large
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-qwen
-providers:
-  - id: my-qwen
-    type: qwen
-    apiTokens:
-      - "YOUR_QWEN_API_TOKEN"
-    modelMapping:
-      'gpt-3': "qwen-turbo"
-      'gpt-35-turbo': "qwen-plus"
-      'gpt-4-turbo': "qwen-max"
-      'gpt-4-*': "qwen-max"
-      'gpt-4o': "qwen-vl-plus"
-      'text-embedding-v1': 'text-embedding-v1'
-      '*': "qwen-turbo"
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_QWEN_API_TOKEN"
+  modelMapping:
+    'gpt-3': "qwen-turbo"
+    'gpt-35-turbo': "qwen-plus"
+    'gpt-4-turbo': "qwen-max"
+    'gpt-4-*': "qwen-max"
+    'gpt-4o': "qwen-vl-plus"
+    'text-embedding-v1': 'text-embedding-v1'
+    '*': "qwen-turbo"
 ```
 
 **AI Conversation Request Example**
@@ -489,18 +484,16 @@ Using Qwen service while configuring pure text context information.
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-qwen
-providers:
-  - id: my-qwen
-    type: qwen
-    apiTokens:
-      - "YOUR_QWEN_API_TOKEN"
-    modelMapping:
-      "*": "qwen-turbo"
-    context:
-      - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
-        serviceName: "file.dns",
-        servicePort: 80
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_QWEN_API_TOKEN"
+  modelMapping:
+    "*": "qwen-turbo"
+  context:
+    - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
+      serviceName: "file.dns",
+      servicePort: 80
 ```
 
 **Request Example**
@@ -551,17 +544,15 @@ Uploading files to Qwen in advance to use them as context when utilizing its AI 
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-qwen
-providers:
-  - id: my-qwen
-    type: qwen
-    apiTokens:
-      - "YOUR_QWEN_API_TOKEN"
-    modelMapping:
-      "*": "qwen-long" # 通义千问的文件上下文只能在 qwen-long 模型下使用
-    qwenFileIds:
-      - "file-fe-xxx"
-      - "file-fe-yyy"
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_QWEN_API_TOKEN"
+  modelMapping:
+    "*": "qwen-long" # Qwen's file context can only be used in the qwen-long model
+  qwenFileIds:
+  - "file-fe-xxx"
+  - "file-fe-yyy"
 ```
 
 **Request Example**
@@ -672,15 +663,13 @@ Upload files to Moonshot in advance and use its AI services based on file conten
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-moonshot
-providers:
-  - id: my-moonshot
-    type: moonshot
-    apiTokens:
-      - "YOUR_MOONSHOT_API_TOKEN"
-    moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
-    modelMapping:
-      '*': "moonshot-v1-32k"
+provider:
+  type: moonshot
+  apiTokens:
+    - "YOUR_MOONSHOT_API_TOKEN"
+  moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
+  modelMapping:
+    '*': "moonshot-v1-32k"
 ```
 
 **Example Request**
@@ -729,12 +718,10 @@ providers:
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-groq
-providers:
-  - id: my-groq
-    type: groq
-    apiTokens:
-      - "YOUR_GROQ_API_TOKEN"
+provider:
+  type: groq
+  apiTokens:
+    - "YOUR_GROQ_API_TOKEN"
 ```
 
 **Example Request**
@@ -790,13 +777,11 @@ providers:
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-claude
-providers:
-  - id: my-claude
-    type: claude
-    apiTokens:
-      - "YOUR_CLAUDE_API_TOKEN"
-    version: "2023-06-01"
+provider:
+  type: claude
+  apiTokens:
+    - "YOUR_CLAUDE_API_TOKEN"
+  version: "2023-06-01"
 ```
 
 **Example Request**
@@ -845,17 +830,15 @@ providers:
 **Configuration Information**
 
 ```yaml
-provider: "my-hunyuan"
-providers:
-  - id: "my-hunyuan"
-    type: "hunyuan"
-    hunyuanAuthKey: "<YOUR AUTH KEY>"
-    apiTokens:
-      - ""
-    hunyuanAuthId: "<YOUR AUTH ID>"
-    timeout: 1200000
-    modelMapping:
-      "*": "hunyuan-lite"
+provider:
+  type: "hunyuan"
+  hunyuanAuthKey: "<YOUR AUTH KEY>"
+  apiTokens:
+    - ""
+  hunyuanAuthId: "<YOUR AUTH ID>"
+  timeout: 1200000
+  modelMapping:
+    "*": "hunyuan-lite"
 ```
 
 **Example Request**
@@ -913,15 +896,13 @@ curl --location 'http://<your higress domain>/v1/chat/completions' \
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-baidu
-providers:
-  - id: my-baidu
-    type: baidu
-    apiTokens:
-      - "YOUR_BAIDU_API_TOKEN"
-    modelMapping:
-      'gpt-3': "ERNIE-4.0"
-      '*': "ERNIE-4.0"
+provider:
+  type: baidu
+  apiTokens:
+    - "YOUR_BAIDU_API_TOKEN"
+  modelMapping:
+    'gpt-3': "ERNIE-4.0"
+    '*': "ERNIE-4.0"
 ```
 
 **Request Example**
@@ -970,17 +951,15 @@ providers:
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-minimax
-providers:
-  - id: my-minimax
-    type: minimax
-    apiTokens:
-      - "YOUR_MINIMAX_API_TOKEN"
-    modelMapping:
-      "gpt-3": "abab6.5g-chat"
-      "gpt-4": "abab6.5-chat"
-      "*": "abab6.5g-chat"
-    minimaxGroupId: "YOUR_MINIMAX_GROUP_ID"
+provider:
+  type: minimax
+  apiTokens:
+    - "YOUR_MINIMAX_API_TOKEN"
+  modelMapping:
+    "gpt-3": "abab6.5g-chat"
+    "gpt-4": "abab6.5-chat"
+    "*": "abab6.5g-chat"
+  minimaxGroupId: "YOUR_MINIMAX_GROUP_ID"
 ```
 
 **Request Example**
@@ -1035,18 +1014,16 @@ providers:
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-ai360
-providers:
-  - id: my-ai360
-    type: ai360
-    apiTokens:
-      - "YOUR_AI360_API_TOKEN"
-    modelMapping:
-      "gpt-4o": "360gpt-turbo-responsibility-8k"
-      "gpt-4": "360gpt2-pro"
-      "gpt-3.5": "360gpt-turbo"
-      "text-embedding-3-small": "embedding_s1_v1.2"
-      "*": "360gpt-pro"
+provider:
+  type: ai360
+  apiTokens:
+    - "YOUR_AI360_API_TOKEN"
+  modelMapping:
+    "gpt-4o": "360gpt-turbo-responsibility-8k"
+    "gpt-4": "360gpt2-pro"
+    "gpt-3.5": "360gpt-turbo"
+    "text-embedding-3-small": "embedding_s1_v1.2"
+    "*": "360gpt-pro"
 ```
 
 **Request Example**
@@ -1151,15 +1128,13 @@ providers:
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-cf
-providers:
-  - id: my-cf
-    type: cloudflare
-    apiTokens:
-      - "YOUR_WORKERS_AI_API_TOKEN"
-    cloudflareAccountId: "YOUR_CLOUDFLARE_ACCOUNT_ID"
-    modelMapping:
-      "*": "@cf/meta/llama-3-8b-instruct"
+provider:
+  type: cloudflare
+  apiTokens:
+    - "YOUR_WORKERS_AI_API_TOKEN"
+  cloudflareAccountId: "YOUR_CLOUDFLARE_ACCOUNT_ID"
+  modelMapping:
+    "*": "@cf/meta/llama-3-8b-instruct"
 ```
 
 **Request Example**
@@ -1204,16 +1179,14 @@ providers:
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-spark
-providers:
-  - id: my-spark
-    type: spark
-    apiTokens:
-      - "APIKey:APISecret"
-    modelMapping:
-      "gpt-4o": "generalv3.5"
-      "gpt-4": "generalv3"
-      "*": "general"
+provider:
+  type: spark
+  apiTokens:
+    - "APIKey:APISecret"
+  modelMapping:
+    "gpt-4o": "generalv3.5"
+    "gpt-4": "generalv3"
+    "*": "general"
 ```
 
 **Request Example**
@@ -1265,33 +1238,31 @@ providers:
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-gemini
-providers:
-  - id: my-gemini
-    type: gemini
-    apiTokens:
-      - "YOUR_GEMINI_API_TOKEN"
-    modelMapping:
-      "*": "gemini-pro"
-    geminiSafetySetting:
-      "HARM_CATEGORY_SEXUALLY_EXPLICIT": "BLOCK_NONE"
-      "HARM_CATEGORY_HATE_SPEECH": "BLOCK_NONE"
-      "HARM_CATEGORY_HARASSMENT": "BLOCK_NONE"
-      "HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_NONE"
+provider:
+  type: gemini
+  apiTokens:
+    - "YOUR_GEMINI_API_TOKEN"
+  modelMapping:
+    "*": "gemini-pro"
+  geminiSafetySetting:
+    "HARM_CATEGORY_SEXUALLY_EXPLICIT" :"BLOCK_NONE"
+    "HARM_CATEGORY_HATE_SPEECH" :"BLOCK_NONE"
+    "HARM_CATEGORY_HARASSMENT" :"BLOCK_NONE"
+    "HARM_CATEGORY_DANGEROUS_CONTENT" :"BLOCK_NONE"
 ```
 
 **Request Example**
 
 ```json
 {
-  "model": "gpt-3.5",
-  "messages": [
-    {
-      "role": "user",
-      "content": "Who are you?"
-    }
-  ],
-  "stream": false
+    "model": "gpt-3.5",
+    "messages": [
+        {
+            "role": "user",
+            "content": "Who are you?"
+        }
+    ],
+    "stream": false
 }
 ```
 
@@ -1299,25 +1270,25 @@ providers:
 
 ```json
 {
-  "id": "chatcmpl-b010867c-0d3f-40ba-95fd-4e8030551aeb",
-  "choices": [
-    {
-      "index": 0,
-      "message": {
-        "role": "assistant",
-        "content": "I am a large multi-modal model, trained by Google. I am designed to provide information and answer questions to the best of my abilities."
-      },
-      "finish_reason": "stop"
+    "id": "chatcmpl-b010867c-0d3f-40ba-95fd-4e8030551aeb",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "I am a large multi-modal model, trained by Google. I am designed to provide information and answer questions to the best of my abilities."
+            },
+            "finish_reason": "stop"
+        }
+    ],
+    "created": 1722756984,
+    "model": "gemini-pro",
+    "object": "chat.completion",
+    "usage": {
+        "prompt_tokens": 5,
+        "completion_tokens": 29,
+        "total_tokens": 34
     }
-  ],
-  "created": 1722756984,
-  "model": "gemini-pro",
-  "object": "chat.completion",
-  "usage": {
-    "prompt_tokens": 5,
-    "completion_tokens": 29,
-    "total_tokens": 34
-  }
 }
 ```
 
@@ -1326,13 +1297,11 @@ providers:
 **Configuration Information**
 
 ```yaml
-activeProviderId: my-deepl
-providers:
-  - id: my-deepl
-    type: deepl
-    apiTokens:
-      - "YOUR_DEEPL_API_TOKEN"
-    targetLang: "ZH"
+provider:
+  type: deepl
+  apiTokens:
+    - "YOUR_DEEPL_API_TOKEN"
+  targetLang: "ZH"
 ```
 
 **Request Example**
@@ -1391,15 +1360,13 @@ metadata:
   namespace: higress-system
 spec:
   matchRules:
-    - config:
-        activeProviderId: my-groq
-        providers:
-          - id: my-groq
-            type: groq
-            apiTokens:
-              - "YOUR_API_TOKEN"
-      ingress:
-        - groq
+  - config:
+      provider:
+        type: groq
+        apiTokens:
+          - "YOUR_API_TOKEN"
+    ingress:
+    - groq
   url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/ai-proxy:1.0.0
 ---
 apiVersion: networking.k8s.io/v1
@@ -1417,16 +1384,16 @@ metadata:
 spec:
   ingressClassName: higress
   rules:
-    - host: <YOUR-DOMAIN>
-      http:
-        paths:
-          - backend:
-              resource:
-                apiGroup: networking.higress.io
-                kind: McpBridge
-                name: default
-            path: /
-            pathType: Prefix
+  - host: <YOUR-DOMAIN>
+    http:
+      paths:
+      - backend:
+          resource:
+            apiGroup: networking.higress.io
+            kind: McpBridge
+            name: default
+        path: /
+        pathType: Prefix
 ---
 apiVersion: networking.higress.io/v1
 kind: McpBridge
@@ -1435,10 +1402,10 @@ metadata:
   namespace: higress-system
 spec:
   registries:
-    - domain: api.groq.com
-      name: groq
-      port: 443
-      type: dns
+  - domain: api.groq.com
+    name: groq
+    port: 443
+    type: dns
 ```
 
 Access Example:
@@ -1475,7 +1442,7 @@ services:
       - ./envoy.yaml:/etc/envoy/envoy.yaml
       - ./plugin.wasm:/etc/envoy/plugin.wasm
 networks:
-  higress-net: { }
+  higress-net: {}
 ```
 
 `envoy.yaml` configuration file:
@@ -1503,12 +1470,12 @@ static_resources:
                 scheme_header_transformation:
                   scheme_to_overwrite: https
                 stat_prefix: ingress_http
-                # Output envoy logs to stdout
+                # Outputs envoy logs to stdout
                 access_log:
                   - name: envoy.access_loggers.stdout
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
-                # Modify as required
+                # Modify as needed
                 route_config:
                   name: local_route
                   virtual_hosts:
@@ -1537,16 +1504,12 @@ static_resources:
                             "@type": "type.googleapis.com/google.protobuf.StringValue"
                             value: | # Plugin configuration
                               {
-                                "activeProviderId": "my-claude",
-                                "providers": [
-                                  {
-                                    "id": "my-claude",
-                                    "type": "claude",
-                                    "apiTokens": [
-                                      "YOUR_API_TOKEN"
-                                    ]
-                                  }
-                                ]
+                                "provider": {
+                                  "type": "claude",
+                                  "apiTokens": [
+                                    "YOUR_API_TOKEN"
+                                  ]
+                                }
                               }
                   - name: envoy.filters.http.router
   clusters:

--- a/plugins/wasm-go/extensions/ai-proxy/envoy.yaml
+++ b/plugins/wasm-go/extensions/ai-proxy/envoy.yaml
@@ -56,21 +56,24 @@ static_resources:
                             "@type": "type.googleapis.com/google.protobuf.StringValue"
                             value: |
                               {
-                                "provider": {
-                                  "type": "moonshot",
-                                  "domain": "api.moonshot.cn",
-                                  "apiTokens": [
-                                    "****",
-                                    "****"
-                                  ],
-                                  "timeout": 1200000,
-                                  "modelMapping": {
-                                    "gpt-3": "moonshot-v1-8k",
-                                    "gpt-35-turbo": "moonshot-v1-32k",
-                                    "gpt-4-turbo": "moonshot-v1-128k",
-                                    "*": "moonshot-v1-8k"
-                                  },
-                                }
+                                "activeProviderId": "moonshot",
+                                "providers": [
+                                  {
+                                    "type": "moonshot",
+                                    "domain": "api.moonshot.cn",
+                                    "apiTokens": [
+                                      "****",
+                                      "****"
+                                    ],
+                                    "timeout": 1200000,
+                                    "modelMapping": {
+                                      "gpt-3": "moonshot-v1-8k",
+                                      "gpt-35-turbo": "moonshot-v1-32k",
+                                      "gpt-4-turbo": "moonshot-v1-128k",
+                                      "*": "moonshot-v1-8k"
+                                    },
+                                  }
+                                ]
                               }
                   - name: envoy.filters.http.router
   clusters:

--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -20,7 +20,7 @@ import (
 const (
 	pluginName = "ai-proxy"
 
-	ctxKeyApiName = "apiKey"
+	ctxKeyApiName = "apiName"
 
 	defaultMaxBodyBytes uint32 = 10 * 1024 * 1024
 )
@@ -28,7 +28,7 @@ const (
 func main() {
 	wrapper.SetCtx(
 		pluginName,
-		wrapper.ParseConfigBy(parseConfig),
+		wrapper.ParseOverrideConfigBy(parseGlobalConfig, parseOverrideRuleConfig),
 		wrapper.ProcessRequestHeadersBy(onHttpRequestHeader),
 		wrapper.ProcessRequestBodyBy(onHttpRequestBody),
 		wrapper.ProcessResponseHeadersBy(onHttpResponseHeaders),
@@ -37,8 +37,23 @@ func main() {
 	)
 }
 
-func parseConfig(json gjson.Result, pluginConfig *config.PluginConfig, log wrapper.Log) error {
-	// log.Debugf("loading config: %s", json.String())
+func parseGlobalConfig(json gjson.Result, pluginConfig *config.PluginConfig, log wrapper.Log) error {
+	//log.Debugf("loading global config: %s", json.String())
+
+	pluginConfig.FromJson(json)
+	if err := pluginConfig.Validate(); err != nil {
+		return err
+	}
+	if err := pluginConfig.Complete(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseOverrideRuleConfig(json gjson.Result, global config.PluginConfig, pluginConfig *config.PluginConfig, log wrapper.Log) error {
+	//log.Debugf("loading override rule config: %s", json.String())
+
+	*pluginConfig = global
 
 	pluginConfig.FromJson(json)
 	if err := pluginConfig.Validate(); err != nil {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -126,7 +126,10 @@ type ResponseBodyHandler interface {
 }
 
 type ProviderConfig struct {
-	// @Title zh-CN AI服务提供商
+	// @Title zh-CN ID
+	// @Description zh-CN AI服务提供商标识
+	id string `required:"true" yaml:"id" json:"id"`
+	// @Title zh-CN 类型
 	// @Description zh-CN AI服务提供商类型
 	typ string `required:"true" yaml:"type" json:"type"`
 	// @Title zh-CN API Tokens
@@ -197,7 +200,20 @@ type ProviderConfig struct {
 	customSettings []CustomSetting
 }
 
+func (c *ProviderConfig) GetId() string {
+	return c.id
+}
+
+func (c *ProviderConfig) GetType() string {
+	return c.typ
+}
+
+func (c *ProviderConfig) GetProtocol() string {
+	return c.protocol
+}
+
 func (c *ProviderConfig) FromJson(json gjson.Result) {
+	c.id = json.Get("id").String()
 	c.typ = json.Get("type").String()
 	c.apiTokens = make([]string, 0)
 	for _, token := range json.Get("apiTokens").Array() {
@@ -322,6 +338,10 @@ func (c *ProviderConfig) IsOriginal() bool {
 	return c.protocol == protocolOriginal
 }
 
+func (c *ProviderConfig) ReplaceByCustomSettings(body []byte) ([]byte, error) {
+	return ReplaceByCustomSettings(body, c.customSettings)
+}
+
 func CreateProvider(pc ProviderConfig) (Provider, error) {
 	initializer, has := providerInitializers[pc.typ]
 	if !has {
@@ -365,8 +385,4 @@ func doGetMappedModel(model string, modelMapping map[string]string, log wrapper.
 	}
 
 	return ""
-}
-
-func (c ProviderConfig) ReplaceByCustomSettings(body []byte) ([]byte, error) {
-	return ReplaceByCustomSettings(body, c.customSettings)
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Support configuring a global provider list in ai-proxy plugin. Meanwhile, the old-style configurations are also supported.

**New config style:**

```yaml
provider: my-azure
providers:
  - id: my-azure
    type: azure
    apiTokens:
      - "YOUR_AZURE_OPENAI_API_TOKEN"
    azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
  - id: my-qwen
    type: qwen
    apiTokens:
      - "YOUR_QWEN_API_TOKEN"
    modelMapping:
      'gpt-3': "qwen-turbo"
      'gpt-35-turbo': "qwen-plus"
      'gpt-4-turbo': "qwen-max"
      'gpt-4-*': "qwen-max"
      'gpt-4o': "qwen-vl-plus"
      'text-embedding-v1': 'text-embedding-v1'
      '*': "qwen-turbo"
```

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

