### PR TITLE
Standardize the data structure returned by the AI security security a…

### DIFF
--- a/plugins/wasm-go/extensions/ai-security-guard/README.md
+++ b/plugins/wasm-go/extensions/ai-security-guard/README.md
@@ -29,7 +29,6 @@ description: 阿里云内容安全检测
 | `responseStreamContentJsonPath` | string | optional | `choices.0.delta.content` | 指定要检测内容在流式响应body中的jsonpath |
 | `denyCode` | int | optional | 200 | 指定内容非法时的响应状态码 |
 | `denyMessage` | string | optional | openai格式的流失/非流式响应，回答内容为阿里云内容安全的建议回答 | 指定内容非法时的响应内容 |
-| `responseModelName` | string | optional | ai_art_detection | 指定内容非法时返回的响应内容中的模型名 |
 
 ## 配置示例
 ### 前提条件
@@ -123,10 +122,10 @@ curl http://localhost/v1/chat/completions \
 
 ```json
 {
-    "id": "chatcmpl-123",
+    "id": "chatcmpl-AAy3hK1dE4ODaegbGOMoC9VY4Sizv",
     "object": "chat.completion",
     "created": 1677652288,
-    "model": "ai_art_detection",
+    "model": "gpt-4o-mini",
     "system_fingerprint": "fp_44709d6fcb",
     "choices": [
         {

--- a/plugins/wasm-go/extensions/ai-security-guard/README.md
+++ b/plugins/wasm-go/extensions/ai-security-guard/README.md
@@ -29,7 +29,7 @@ description: 阿里云内容安全检测
 | `responseStreamContentJsonPath` | string | optional | `choices.0.delta.content` | 指定要检测内容在流式响应body中的jsonpath |
 | `denyCode` | int | optional | 200 | 指定内容非法时的响应状态码 |
 | `denyMessage` | string | optional | openai格式的流失/非流式响应，回答内容为阿里云内容安全的建议回答 | 指定内容非法时的响应内容 |
-
+| `responseModelName` | string | optional | ai_art_detection | 指定内容非法时返回的响应内容中的模型名 |
 
 ## 配置示例
 ### 前提条件
@@ -126,7 +126,7 @@ curl http://localhost/v1/chat/completions \
     "id": "chatcmpl-123",
     "object": "chat.completion",
     "created": 1677652288,
-    "model": "gpt-4o-mini",
+    "model": "ai_art_detection",
     "system_fingerprint": "fp_44709d6fcb",
     "choices": [
         {

--- a/plugins/wasm-go/extensions/ai-security-guard/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-security-guard/README_EN.md
@@ -31,6 +31,7 @@ Plugin Priority: `300`
 | `denyCode` | int | optional | 200 | Response status code when the specified content is illegal |
 | `denyMessage` | string | optional | Drainage/non-streaming response in openai format, the answer content is the suggested answer from Alibaba Cloud content security
  | Response content when the specified content is illegal |
+| `responseModelName` | string | optional | ai_art_detection | Specifies the model name in the response content when the content is illegal |
 
 
 ## Examples of configuration

--- a/plugins/wasm-go/extensions/ai-security-guard/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-security-guard/README_EN.md
@@ -31,7 +31,6 @@ Plugin Priority: `300`
 | `denyCode` | int | optional | 200 | Response status code when the specified content is illegal |
 | `denyMessage` | string | optional | Drainage/non-streaming response in openai format, the answer content is the suggested answer from Alibaba Cloud content security
  | Response content when the specified content is illegal |
-| `responseModelName` | string | optional | ai_art_detection | Specifies the model name in the response content when the content is illegal |
 
 
 ## Examples of configuration

--- a/plugins/wasm-go/extensions/ai-security-guard/main.go
+++ b/plugins/wasm-go/extensions/ai-security-guard/main.go
@@ -166,11 +166,6 @@ func parseConfig(json gjson.Result, config *AISecurityConfig, log wrapper.Log) e
 		Host: serviceHost,
 	})
 	config.metrics = make(map[string]proxywasm.MetricCounter)
-	if obj := json.Get("responseModelName"); obj.Exists() {
-		config.responseModelName = obj.String()
-	} else {
-		config.responseModelName = "ai_art_detection" // 设置默认模型名为阿里云 AI 内容安全服务名
-	}
 	return nil
 }
 

--- a/plugins/wasm-go/extensions/ai-security-guard/main.go
+++ b/plugins/wasm-go/extensions/ai-security-guard/main.go
@@ -180,9 +180,11 @@ func generateRandomID() string {
 
 func onHttpRequestHeaders(ctx wrapper.HttpContext, config AISecurityConfig, log wrapper.Log) types.Action {
 	if !config.checkRequest {
+		log.Debugf("request checking is disabled")
 		ctx.DontReadRequestBody()
 	}
 	if !config.checkResponse {
+		log.Debugf("response checking is disabled")
 		ctx.DontReadResponseBody()
 	}
 	return types.ActionContinue
@@ -353,6 +355,7 @@ func onHttpResponseBody(ctx wrapper.HttpContext, config AISecurityConfig, body [
 			},
 		)
 		if err != nil {
+			log.Errorf("failed call the safe check service: %v", err)
 			return types.ActionContinue
 		}
 		return types.ActionPause


### PR DESCRIPTION
…nd add the ability to customize model name

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
规范接口返回结构，包括：随机 id，匹配 model 入参、规范流式输出结束标记 data: [DONE]

### Ⅱ. Does this pull request fix one issue?
No.


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Easy to understand

### Ⅳ. Describe how to verify it
开启 AI 内容安全插件后，利用敏感数据请求，观察返回的结构体 id 由 chatcmpl-123 变为随机；model 由 gpt-4o-mini 变成请求体里面传入的 model 模型名；最后增加了流式输出结束标记 data: [DONE]。

### Ⅴ. Special notes for reviews

