### PR TITLE
fix: Update the envoy.yaml template used by hgctl

### DIFF
--- a/hgctl/pkg/plugin/test/templates.go
+++ b/hgctl/pkg/plugin/test/templates.go
@@ -114,6 +114,8 @@ static_resources:
                             value: |
 {{ .JSONExample }}
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
     - name: httpbin
       connect_timeout: 30s


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Update the envoy.yaml template used by `hgctl plugin test` command to fix the `Didn't find a registered implementation for 'envoy.filters.http.router' with type URL` error.

See: https://github.com/envoyproxy/envoy/issues/21464

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

