### PR TITLE
fix static cluster of skywalking service

### DIFF
--- a/helm/core/templates/configmap.yaml
+++ b/helm/core/templates/configmap.yaml
@@ -155,44 +155,12 @@ data:
             "transport_api_version": "V3",
             "grpc_service": {
               "envoy_grpc": {
-                "cluster_name": "service_skywalking"
+                "cluster_name": "outbound|{{ .Values.tracing.skywalking.port }}||{{ .Values.tracing.skywalking.service }}"
               }
             }
           }
         }
-      ],
-      "static_resources": {
-        "clusters": [
-          {
-            "name": "service_skywalking",
-            "type": "LOGICAL_DNS",
-            "connect_timeout": "5s",
-            "http2_protocol_options": {
-            },
-            "dns_lookup_family": "V4_ONLY",
-            "lb_policy": "ROUND_ROBIN",
-            "load_assignment": {
-              "cluster_name": "service_skywalking",
-              "endpoints": [
-                {
-                  "lb_endpoints": [
-                    {
-                      "endpoint": {
-                        "address": {
-                          "socket_address": {
-                            "address": "{{ .Values.tracing.skywalking.service }}",
-                            "port_value": "{{ .Values.tracing.skywalking.port }}"
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
+      ]
     }
 ---
 {{- end }}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

The SkyWalking cluster was previously hardcoded as a static cluster, which does not match the service name in the global tracing configuration.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

