### PR TITLE
modify log-format, then every plugin log is associated with access log

### DIFF
--- a/plugins/wasm-go/pkg/wrapper/log_wrapper.go
+++ b/plugins/wasm-go/pkg/wrapper/log_wrapper.go
@@ -36,8 +36,12 @@ type Log struct {
 }
 
 func (l Log) log(level LogLevel, msg string) {
-	requestID, _ := proxywasm.GetProperty([]string{"x_request_id"})
-	msg = fmt.Sprintf("[%s] [%s] %s", l.pluginName, string(requestID), msg)
+	requestIDRaw, _ := proxywasm.GetProperty([]string{"x_request_id"})
+	requestID := string(requestIDRaw)
+	if requestID == "" {
+		requestID = "nil"
+	}
+	msg = fmt.Sprintf("[%s] [%s] %s", l.pluginName, requestID, msg)
 	switch level {
 	case LogLevelTrace:
 		proxywasm.LogTrace(msg)
@@ -55,7 +59,12 @@ func (l Log) log(level LogLevel, msg string) {
 }
 
 func (l Log) logFormat(level LogLevel, format string, args ...interface{}) {
-	format = fmt.Sprintf("[%s] %s", l.pluginName, format)
+	requestIDRaw, _ := proxywasm.GetProperty([]string{"x_request_id"})
+	requestID := string(requestIDRaw)
+	if requestID == "" {
+		requestID = "nil"
+	}
+	format = fmt.Sprintf("[%s] [%s] %s", l.pluginName, requestID, format)
 	switch level {
 	case LogLevelTrace:
 		proxywasm.LogTracef(format, args...)

--- a/plugins/wasm-go/pkg/wrapper/log_wrapper.go
+++ b/plugins/wasm-go/pkg/wrapper/log_wrapper.go
@@ -36,7 +36,8 @@ type Log struct {
 }
 
 func (l Log) log(level LogLevel, msg string) {
-	msg = fmt.Sprintf("[%s] %s", l.pluginName, msg)
+	requestID, _ := proxywasm.GetProperty([]string{"x_request_id"})
+	msg = fmt.Sprintf("[%s] [%s] %s", l.pluginName, string(requestID), msg)
 	switch level {
 	case LogLevelTrace:
 		proxywasm.LogTrace(msg)

--- a/plugins/wasm-go/pkg/wrapper/plugin_wrapper.go
+++ b/plugins/wasm-go/pkg/wrapper/plugin_wrapper.go
@@ -370,6 +370,8 @@ func (ctx *CommonHttpCtx[PluginConfig]) SetResponseBodyBufferLimit(size uint32) 
 }
 
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	requestID, _ := proxywasm.GetHttpRequestHeader("x-request-id")
+	_ = proxywasm.SetProperty([]string{"x_request_id"}, []byte(requestID))
 	config, err := ctx.plugin.GetMatchConfig()
 	if err != nil {
 		ctx.plugin.vm.log.Errorf("get match config failed, err:%v", err)


### PR DESCRIPTION
修改log wrapper记录日志时的format，使得每条插件的日志能够与网关访问日志关联起来，便于排查问题