### PR TITLE
fix: Control gateway-api Listener with global.enableGatewayAPI in Helm

### DIFF
--- a/helm/core/templates/controller-deployment.yaml
+++ b/helm/core/templates/controller-deployment.yaml
@@ -69,10 +69,17 @@ spec:
                 fieldPath: spec.serviceAccountName
           - name: DOMAIN_SUFFIX
             value: {{ .Values.global.proxy.clusterDomain }}
-          - name: PILOT_ENABLE_ALPHA_GATEWAY_API
-            value: "true"
           - name: GATEWAY_NAME
             value: {{ include "gateway.name" . }}
+          {{- if .Values.global.enableGatewayAPI }}
+          - name: PILOT_ENABLE_GATEWAY_API
+            value: "true"
+          - name: PILOT_ENABLE_ALPHA_GATEWAY_API
+            value: "true"
+          {{- else }}
+          - name: PILOT_ENABLE_GATEWAY_API
+            value: "false"
+          {{- end }}
           {{- if .Values.controller.env }}
           {{- range $key, $val := .Values.controller.env }}
           - name: {{ $key }}
@@ -219,16 +226,14 @@ spec:
           - name: HIGRESS_ENABLE_ISTIO_API
             value: "true"
           {{- end }}
-          {{- if .Values.global.enableGatewayAPI }}
           - name: PILOT_ENABLE_GATEWAY_API
-            value: "true"
+            value: "false"
           - name: PILOT_ENABLE_ALPHA_GATEWAY_API
-            value: "true"
+            value: "false"
           - name: PILOT_ENABLE_GATEWAY_API_STATUS
-            value: "true"
+            value: "false"
           - name: PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER
             value: "false"
-          {{- end }}
           {{- if not .Values.global.enableHigressIstio }}
           - name: CUSTOM_CA_CERT_NAME
             value: "higress-ca-root-cert"

--- a/helm/core/templates/controller-deployment.yaml
+++ b/helm/core/templates/controller-deployment.yaml
@@ -71,15 +71,10 @@ spec:
             value: {{ .Values.global.proxy.clusterDomain }}
           - name: GATEWAY_NAME
             value: {{ include "gateway.name" . }}
-          {{- if .Values.global.enableGatewayAPI }}
           - name: PILOT_ENABLE_GATEWAY_API
-            value: "true"
+            value: "{{ .Values.global.enableGatewayAPI }}"
           - name: PILOT_ENABLE_ALPHA_GATEWAY_API
-            value: "true"
-          {{- else }}
-          - name: PILOT_ENABLE_GATEWAY_API
-            value: "false"
-          {{- end }}
+            value: "{{ .Values.global.enableGatewayAPI }}"
           {{- if .Values.controller.env }}
           {{- range $key, $val := .Values.controller.env }}
           - name: {{ $key }}

--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -34,6 +34,7 @@ import (
 	extensions "istio.io/api/extensions/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	istiotype "istio.io/api/type/v1beta1"
+	"istio.io/istio/pilot/pkg/features"
 	istiomodel "istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/util/protoconv"
 	"istio.io/istio/pkg/cluster"
@@ -235,8 +236,9 @@ func (m *IngressConfig) AddLocalCluster(options common.Options) {
 		ingressController = ingressv1.NewController(m.localKubeClient, m.localKubeClient, options, secretController)
 	}
 	m.remoteIngressControllers[options.ClusterId] = ingressController
-
-	m.remoteGatewayControllers[options.ClusterId] = gateway.NewController(m.localKubeClient, options)
+	if features.EnableGatewayAPI {
+		m.remoteGatewayControllers[options.ClusterId] = gateway.NewController(m.localKubeClient, options)
+	}
 }
 
 func (m *IngressConfig) List(typ config.GroupVersionKind, namespace string) []config.Config {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

1）higress-core 中 gateway-api 监听通过 helm 中 `global.enableGatewayAPI` 参数控制

2）默认关闭 istio 中的 gateway-api 处理

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1456 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

