### PR TITLE
add textin embedding for ai-cache

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/embedding/provider.go
+++ b/plugins/wasm-go/extensions/ai-cache/embedding/provider.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	PROVIDER_TYPE_DASHSCOPE = "dashscope"
+	PROVIDER_TYPE_TEXTIN    = "textin"
 )
 
 type providerInitializer interface {
@@ -19,6 +20,7 @@ type providerInitializer interface {
 var (
 	providerInitializers = map[string]providerInitializer{
 		PROVIDER_TYPE_DASHSCOPE: &dashScopeProviderInitializer{},
+		PROVIDER_TYPE_TEXTIN:    &textInProviderInitializer{},
 	}
 )
 
@@ -38,6 +40,15 @@ type ProviderConfig struct {
 	// @Title zh-CN 文本特征提取服务 API Key
 	// @Description zh-CN 文本特征提取服务 API Key
 	apiKey string
+	//@Title zh-CN TextIn x-ti-app-id
+	// @Description zh-CN 仅适用于 TextIn 服务。参考 https://www.textin.com/document/acge_text_embedding
+	textinAppId string
+	//@Title zh-CN TextIn x-ti-secret-code
+	// @Description zh-CN 仅适用于 TextIn 服务。参考 https://www.textin.com/document/acge_text_embedding
+	textinSecretCode string
+	//@Title zh-CN TextIn request matryoshka_dim
+	// @Description zh-CN 仅适用于 TextIn 服务, 指定返回的向量维度。参考 https://www.textin.com/document/acge_text_embedding
+	textinMatryoshkaDim int
 	// @Title zh-CN 文本特征提取服务超时时间
 	// @Description zh-CN 文本特征提取服务超时时间
 	timeout uint32
@@ -52,6 +63,9 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 	c.serviceHost = json.Get("serviceHost").String()
 	c.servicePort = json.Get("servicePort").Int()
 	c.apiKey = json.Get("apiKey").String()
+	c.textinAppId = json.Get("textinAppId").String()
+	c.textinSecretCode = json.Get("textinSecretCode").String()
+	c.textinMatryoshkaDim = int(json.Get("textinMatryoshkaDim").Int())
 	c.timeout = uint32(json.Get("timeout").Int())
 	c.model = json.Get("model").String()
 	if c.timeout == 0 {
@@ -62,9 +76,6 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 func (c *ProviderConfig) Validate() error {
 	if c.serviceName == "" {
 		return errors.New("embedding service name is required")
-	}
-	if c.apiKey == "" {
-		return errors.New("embedding service API key is required")
 	}
 	if c.typ == "" {
 		return errors.New("embedding service type is required")

--- a/plugins/wasm-go/extensions/ai-cache/embedding/textin.go
+++ b/plugins/wasm-go/extensions/ai-cache/embedding/textin.go
@@ -1,0 +1,161 @@
+package embedding
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/alibaba/higress/plugins/wasm-go/pkg/wrapper"
+)
+
+const (
+	TEXTIN_DOMAIN             = "api.textin.com"
+	TEXTIN_PORT               = 443
+	TEXTIN_DEFAULT_MODEL_NAME = "acge-text-embedding"
+	TEXTIN_ENDPOINT           = "/ai/service/v1/acge_embedding"
+)
+
+type textInProviderInitializer struct {
+}
+
+func (t *textInProviderInitializer) ValidateConfig(config ProviderConfig) error {
+	if config.textinAppId == "" {
+		return errors.New("embedding service TextIn App ID is required")
+	}
+	if config.textinSecretCode == "" {
+		return errors.New("embedding service TextIn Secret Code is required")
+	}
+	if config.textinMatryoshkaDim == 0 {
+		return errors.New("embedding service TextIn Matryoshka Dim is required")
+	}
+	return nil
+}
+
+func (t *textInProviderInitializer) CreateProvider(c ProviderConfig) (Provider, error) {
+	if c.servicePort == 0 {
+		c.servicePort = TEXTIN_PORT
+	}
+	if c.serviceHost == "" {
+		c.serviceHost = TEXTIN_DOMAIN
+	}
+	return &TIProvider{
+		config: c,
+		client: wrapper.NewClusterClient(wrapper.FQDNCluster{
+			FQDN: c.serviceName,
+			Host: c.serviceHost,
+			Port: int64(c.servicePort),
+		}),
+	}, nil
+}
+
+func (t *TIProvider) GetProviderType() string {
+	return PROVIDER_TYPE_TEXTIN
+}
+
+type TextInResponse struct {
+	Code     int          `json:"code"`
+	Message  string       `json:"message"`
+	Duration float64      `json:"duration"`
+	Result   TextInResult `json:"result"`
+}
+
+type TextInResult struct {
+	Embeddings    [][]float64 `json:"embedding"` 
+	MatryoshkaDim int         `json:"matryoshka_dim"`
+}
+
+type TextInEmbeddingRequest struct {
+	Input         []string `json:"input"`
+	MatryoshkaDim int      `json:"matryoshka_dim"`
+}
+
+type TIProvider struct {
+	config ProviderConfig
+	client wrapper.HttpClient
+}
+
+func (t *TIProvider) constructParameters(texts []string, log wrapper.Log) (string, [][2]string, []byte, error) {
+
+	data := TextInEmbeddingRequest{
+		Input:         texts,
+		MatryoshkaDim: t.config.textinMatryoshkaDim,
+	}
+
+	requestBody, err := json.Marshal(data)
+	if err != nil {
+		log.Errorf("failed to marshal request data: %v", err)
+		return "", nil, nil, err
+	}
+
+	if t.config.textinAppId == "" {
+		err := errors.New("textinAppId is empty")
+		log.Errorf("failed to construct headers: %v", err)
+		return "", nil, nil, err
+	}
+	if t.config.textinSecretCode == "" {
+		err := errors.New("textinSecretCode is empty")
+		log.Errorf("failed to construct headers: %v", err)
+		return "", nil, nil, err
+	}
+
+	headers := [][2]string{
+		{"x-ti-app-id", t.config.textinAppId},
+		{"x-ti-secret-code", t.config.textinSecretCode},
+		{"Content-Type", "application/json"},
+	}
+
+	return TEXTIN_ENDPOINT, headers, requestBody, err
+}
+
+func (t *TIProvider) parseTextEmbedding(responseBody []byte) (*TextInResponse, error) {
+	var resp TextInResponse
+	err := json.Unmarshal(responseBody, &resp)
+	if err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func (t *TIProvider) GetEmbedding(
+	queryString string,
+	ctx wrapper.HttpContext,
+	log wrapper.Log,
+	callback func(emb []float64, err error)) error {
+	embUrl, embHeaders, embRequestBody, err := t.constructParameters([]string{queryString}, log)
+	if err != nil {
+		log.Errorf("failed to construct parameters: %v", err)
+		return err
+	}
+
+	var resp *TextInResponse
+	err = t.client.Post(embUrl, embHeaders, embRequestBody,
+		func(statusCode int, responseHeaders http.Header, responseBody []byte) {
+
+			if statusCode != http.StatusOK {
+				err = errors.New("failed to get embedding due to status code: " + strconv.Itoa(statusCode))
+				callback(nil, err)
+				return
+			}
+
+			log.Debugf("get embedding response: %d, %s", statusCode, responseBody)
+
+			resp, err = t.parseTextEmbedding(responseBody)
+			if err != nil {
+				err = fmt.Errorf("failed to parse response: %v", err)
+				callback(nil, err)
+				return
+			}
+
+			if len(resp.Result.Embeddings) == 0 {
+				err = errors.New("no embedding found in response")
+				callback(nil, err)
+				return
+			}
+
+			callback(resp.Result.Embeddings[0], nil)
+
+		}, t.config.timeout)
+	return err
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fix #1447 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
docker-compose.yaml
```yaml
services:
  envoy:
    image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway:v2.0.2
    entrypoint: /usr/local/bin/envoy
    command: -c /etc/envoy/envoy.yaml --component-log-level wasm:debug
    networks:
    - wasmtest
    ports:
    - "10000:10000"
    volumes:
    - ./envoy.yaml:/etc/envoy/envoy.yaml
    - ./main.wasm:/etc/envoy/main.wasm
    - ../ai-proxy/ai.wasm:/etc/envoy/ai.wasm

networks:
  wasmtest: {}
```
envoy.yaml
```yaml
admin:
  address:
    socket_address:
      protocol: TCP
      address: 0.0.0.0
      port_value: 9901
static_resources:
  listeners:
    - name: listener_0
      address:
        socket_address:
          protocol: TCP
          address: 0.0.0.0
          port_value: 10000
      filter_chains:
        - filters:
            - name: envoy.filters.network.http_connection_manager
              typed_config:
                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                scheme_header_transformation:
                  scheme_to_overwrite: https
                stat_prefix: ingress_http
                # Output envoy logs to stdout
                access_log:
                  - name: envoy.access_loggers.stdout
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
                # Modify as required
                route_config:
                  name: local_route
                  virtual_hosts:
                    - name: local_service
                      domains: [ "*" ]
                      routes:
                        - match:
                            prefix: "/"
                          route:
                            cluster: deepseek
                            timeout: 300s
                http_filters:
                  - name: wasmtest
                    typed_config:
                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                      value:
                        config:
                          name: wasmtest
                          vm_config:
                            runtime: envoy.wasm.runtime.v8
                            code:
                              local:
                                filename: /etc/envoy/ai.wasm
                          configuration:
                            "@type": "type.googleapis.com/google.protobuf.StringValue"
                            value: |
                              {
                                "provider": {
                                  "type": "deepseek",
                                  "apiTokens": [
                                    "sk-"
                                  ]
                                }
                              }

                  - name: cache
                    typed_config:
                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                      value:
                        config:
                          name: cache
                          vm_config:
                            runtime: envoy.wasm.runtime.v8
                            code:
                              local:
                                filename: /etc/envoy/main.wasm
                          configuration:
                            "@type": "type.googleapis.com/google.protobuf.StringValue"
                            value: |
                              {
                                "embedding": {
                                  "type": "textin",
                                  "serviceName": "textin.dns",
                                  "textinAppId": "your id",
                                  "textinSecretCode": "your SecretCode",
                                  "textinMatryoshkaDim": 1792
                                },
                                "vector": {
                                  "type": "dashvector",
                                  "serviceName": "dashvector.dns",
                                  "collectionID": "test1",
                                  "serviceHost": "your host",
                                  "apiKey": "your key",
                                  "threshold": 0.4
                                },
                                "cache": { # 不使用cache
                                  "serviceName": "",
                                  "type": ""
                                }
                              }
                  - name: envoy.filters.http.router
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
  clusters:
   - name: deepseek
     connect_timeout: 30s
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: deepseek
       endpoints:
         - lb_endpoints:
             - endpoint:
                 address:
                   socket_address:
                     address: api.deepseek.com
                     port_value: 443
     transport_socket:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         "sni": "api.deepseek.com"

   - name: outbound|443||textin.dns
     connect_timeout: 30s
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: outbound|443||textin.dns
       endpoints:
         - lb_endpoints:
             - endpoint:
                 address:
                   socket_address:
                     address: api.textin.com
                     port_value: 443
     transport_socket:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         "sni": "api.textin.com"

   - name: outbound|443||dashvector.dns
     connect_timeout: 30s
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: outbound|443||dashvector.dns
       endpoints:
         - lb_endpoints:
             - endpoint:
                 address:
                   socket_address:
                     address: vrs-*aliyuncs.com
                     port_value: 443
     transport_socket:
       name: envoy.transport_sockets.tls
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
         "sni": "vrs-*aliyuncs.com"
```
![image](https://github.com/user-attachments/assets/55889191-2bb8-449d-b3e2-50d64865e159)

### Ⅴ. Special notes for reviews
感谢各位老师的帮助
