### PR TITLE
fix: default port of static service in ai-cache plugin

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/cache/provider.go
+++ b/plugins/wasm-go/extensions/ai-cache/cache/provider.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/alibaba/higress/plugins/wasm-go/pkg/wrapper"
 	"github.com/tidwall/gjson"
@@ -62,7 +63,12 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 	c.serviceName = json.Get("serviceName").String()
 	c.servicePort = int(json.Get("servicePort").Int())
 	if !json.Get("servicePort").Exists() {
-		c.servicePort = 6379
+		if strings.HasSuffix(c.serviceName, ".static") {
+			// use default logic port which is 80 for static service
+			c.servicePort = 80
+		} else {
+			c.servicePort = 6379
+		}
 	}
 	c.serviceHost = json.Get("serviceHost").String()
 	c.username = json.Get("username").String()


### PR DESCRIPTION
The default port of static service should be 80

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
When using a **static** service like Redis, the default port should be 80 if not specified, not 6379, as using the wrong port may cause warnings like below:

`warning	envoy config external/envoy/source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:128	gRPC config for type.googleapis.com/envoy.config.core.v3.TypedExtensionConfig rejected: Unable to create Wasm HTTP filter higress-system.ai-cache-1.0.0	thread=199`

This fix was used in a previous commit  [#812edf](https://github.com/alibaba/higress/commit/812edf14903cadab8c78a20f078674b05c31778f#diff-430d69382c3da05464dff1d1e0d055b0a173e482b489dc991f371987e9c49982R122), and is the same as in [ai-quota](https://github.com/alibaba/higress/blob/441408c5935e9d8c37f56f0974d49b89c7822a33/plugins/wasm-go/extensions/ai-quota/main.go#L99), [ai-token-ratelimit](https://github.com/alibaba/higress/blob/441408c5935e9d8c37f56f0974d49b89c7822a33/plugins/wasm-go/extensions/ai-token-ratelimit/config.go#L96).



### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->



### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

