### PR TITLE
fix: baidu api issue

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/ai360.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/ai360.go
@@ -22,7 +22,7 @@ type ai360Provider struct {
 	contextCache *contextCache
 }
 
-func (m *ai360ProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *ai360ProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/azure.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/azure.go
@@ -15,7 +15,7 @@ import (
 type azureProviderInitializer struct {
 }
 
-func (m *azureProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *azureProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.azureServiceUrl == "" {
 		return errors.New("missing azureServiceUrl in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/baichuan.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/baichuan.go
@@ -19,7 +19,7 @@ const (
 type baichuanProviderInitializer struct {
 }
 
-func (m *baichuanProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *baichuanProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/baidu.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/baidu.go
@@ -34,16 +34,15 @@ const (
 
 type baiduProviderInitializer struct{}
 
-func (g *baiduProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (g *baiduProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.baiduAccessKeyAndSecret == nil || len(config.baiduAccessKeyAndSecret) == 0 {
 		return errors.New("no baiduAccessKeyAndSecret found in provider config")
 	}
 	if config.baiduApiTokenServiceName == "" {
 		return errors.New("no baiduApiTokenServiceName found in provider config")
 	}
-	if !config.failover.enabled {
-		config.useGlobalApiToken = true
-	}
+	// baidu use access key and access secret to refresh apiToken regularly, the apiToken should be accessed globally (via all Wasm VMs)
+	config.useGlobalApiToken = true
 	return nil
 }
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -78,7 +78,7 @@ type claudeTextGenDelta struct {
 	StopSequence *string `json:"stop_sequence"`
 }
 
-func (c *claudeProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (c *claudeProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/cloudflare.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/cloudflare.go
@@ -19,7 +19,7 @@ const (
 type cloudflareProviderInitializer struct {
 }
 
-func (c *cloudflareProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (c *cloudflareProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/cohere.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/cohere.go
@@ -18,7 +18,7 @@ const (
 
 type cohereProviderInitializer struct{}
 
-func (m *cohereProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *cohereProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/coze.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/coze.go
@@ -14,7 +14,7 @@ const (
 
 type cozeProviderInitializer struct{}
 
-func (m *cozeProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *cozeProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/deepl.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/deepl.go
@@ -57,7 +57,7 @@ type deeplResponseTranslation struct {
 	Text                   string `json:"text"`
 }
 
-func (d *deeplProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (d *deeplProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.targetLang == "" {
 		return errors.New("missing targetLang in deepl provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/deepseek.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/deepseek.go
@@ -19,7 +19,7 @@ const (
 type deepseekProviderInitializer struct {
 }
 
-func (m *deepseekProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *deepseekProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/doubao.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/doubao.go
@@ -17,7 +17,7 @@ const (
 
 type doubaoProviderInitializer struct{}
 
-func (m *doubaoProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *doubaoProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/failover.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/failover.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
-	
+
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
 	"github.com/alibaba/higress/plugins/wasm-go/pkg/wrapper"
 	"github.com/google/uuid"
@@ -558,7 +558,8 @@ func (c *ProviderConfig) GetApiTokenInUse(ctx wrapper.HttpContext) string {
 func (c *ProviderConfig) SetApiTokenInUse(ctx wrapper.HttpContext, log wrapper.Log) {
 	var apiToken string
 	if c.isFailoverEnabled() || c.useGlobalApiToken {
-		// if enable apiToken failover, only use available apiToken
+		// if enable apiToken failover, only use available apiToken from global apiTokens list
+		// or the apiToken need to be accessed globally (via all Wasm VMs, e.g. baidu),
 		apiToken = c.GetGlobalRandomToken(log)
 	} else {
 		apiToken = c.GetRandomToken()

--- a/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
@@ -28,7 +28,7 @@ const (
 type geminiProviderInitializer struct {
 }
 
-func (g *geminiProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (g *geminiProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/github.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/github.go
@@ -25,7 +25,7 @@ type githubProvider struct {
 	contextCache *contextCache
 }
 
-func (m *githubProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *githubProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/groq.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/groq.go
@@ -18,7 +18,7 @@ const (
 
 type groqProviderInitializer struct{}
 
-func (g *groqProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (g *groqProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan.go
@@ -85,7 +85,7 @@ type hunyuanChatMessage struct {
 	Content string `json:"Content,omitempty"`
 }
 
-func (m *hunyuanProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *hunyuanProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	// 校验hunyuan id 和 key的合法性
 	if len(config.hunyuanAuthId) != hunyuanAuthIdLen || len(config.hunyuanAuthKey) != hunyuanAuthKeyLen {
 		return errors.New("hunyuanAuthId / hunyuanAuthKey is illegal in config file")

--- a/plugins/wasm-go/extensions/ai-proxy/provider/minimax.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/minimax.go
@@ -38,7 +38,7 @@ const (
 type minimaxProviderInitializer struct {
 }
 
-func (m *minimaxProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *minimaxProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	// If using the chat completion Pro API, a group ID must be set.
 	if minimaxApiTypePro == config.minimaxApiType && config.minimaxGroupId == "" {
 		return errors.New(fmt.Sprintf("missing minimaxGroupId in provider config when minimaxApiType is %s", minimaxApiTypePro))

--- a/plugins/wasm-go/extensions/ai-proxy/provider/mistral.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/mistral.go
@@ -15,7 +15,7 @@ const (
 
 type mistralProviderInitializer struct{}
 
-func (m *mistralProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *mistralProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/moonshot.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/moonshot.go
@@ -24,7 +24,7 @@ const (
 type moonshotProviderInitializer struct {
 }
 
-func (m *moonshotProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *moonshotProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.moonshotFileId != "" && config.context != nil {
 		return errors.New("moonshotFileId and context cannot be configured at the same time")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/ollama.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/ollama.go
@@ -19,7 +19,7 @@ const (
 type ollamaProviderInitializer struct {
 }
 
-func (m *ollamaProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *ollamaProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.ollamaServerHost == "" {
 		return errors.New("missing ollamaServerHost in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
@@ -22,7 +22,7 @@ const (
 type openaiProviderInitializer struct {
 }
 
-func (m *openaiProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *openaiProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	return nil
 }
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -76,7 +76,7 @@ const (
 )
 
 type providerInitializer interface {
-	ValidateConfig(ProviderConfig) error
+	ValidateConfig(*ProviderConfig) error
 	CreateProvider(ProviderConfig) (Provider, error)
 }
 
@@ -405,7 +405,7 @@ func (c *ProviderConfig) Validate() error {
 	if !has {
 		return errors.New("unknown provider type: " + c.typ)
 	}
-	if err := initializer.ValidateConfig(*c); err != nil {
+	if err := initializer.ValidateConfig(c); err != nil {
 		return err
 	}
 	return nil

--- a/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
@@ -42,7 +42,7 @@ const (
 type qwenProviderInitializer struct {
 }
 
-func (m *qwenProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *qwenProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if len(config.qwenFileIds) != 0 && config.context != nil {
 		return errors.New("qwenFileIds and context cannot be configured at the same time")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/spark.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/spark.go
@@ -51,7 +51,7 @@ type sparkStreamResponse struct {
 	Created int64  `json:"created"`
 }
 
-func (i *sparkProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (i *sparkProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	return nil
 }
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/stepfun.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/stepfun.go
@@ -17,7 +17,7 @@ const (
 type stepfunProviderInitializer struct {
 }
 
-func (m *stepfunProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *stepfunProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/together_ai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/together_ai.go
@@ -16,7 +16,7 @@ const (
 
 type togetherAIProviderInitializer struct{}
 
-func (m *togetherAIProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *togetherAIProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/yi.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/yi.go
@@ -17,7 +17,7 @@ const (
 type yiProviderInitializer struct {
 }
 
-func (m *yiProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *yiProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/zhipuai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/zhipuai.go
@@ -17,7 +17,7 @@ const (
 
 type zhipuAiProviderInitializer struct{}
 
-func (m *zhipuAiProviderInitializer) ValidateConfig(config ProviderConfig) error {
+func (m *zhipuAiProviderInitializer) ValidateConfig(config *ProviderConfig) error {
 	if config.apiTokens == nil || len(config.apiTokens) == 0 {
 		return errors.New("no apiToken found in provider config")
 	}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
baidu API 和其他 provider 有所不同，需要使用 access key 和 access secret 定期获取 apiToken，并存储在 global 的 apiToken 列表中（让所有 Wasm VM 能够访问到），因此对于 baidu API，需要始终将 useGlobalApiToken 参数设置为 true。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/higress-group/higress-console/issues/409

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

