### PR TITLE
fix: ext-auth crash bugfix

### DIFF
--- a/plugins/wasm-go/pkg/wrapper/request_wrapper.go
+++ b/plugins/wasm-go/pkg/wrapper/request_wrapper.go
@@ -49,13 +49,17 @@ func GetRequestPath() string {
 	return path
 }
 
-func GetRequestPathWithoutQuery() (string, error) {
+func GetRequestPathWithoutQuery() string {
 	rawPath := GetRequestPath()
+	if rawPath == "" {
+		return ""
+	}
 	path, err := url.Parse(rawPath)
 	if err != nil {
-		return "", err
+		proxywasm.LogErrorf("failed to parse request path '%s': %v", rawPath, err)
+		return ""
 	}
-	return path.Path, nil
+	return path.Path
 }
 
 func GetRequestMethod() string {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

修改 sendlocalresponse 之后 resume 导致 envoy crash 的问题

### Ⅱ. Does this pull request fix one issue?

<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

**endpoint_mode为forward_auth时**

**1）认证成功**

```yaml
apiVersion: extensions.higress.io/v1alpha1
kind: WasmPlugin
metadata:
  name: test
  namespace: higress-system
spec:
  defaultConfig:
    http_service:
      authorization_request:
        allowed_headers:
          - exact: x-user-id
          - prefix: x-custom-
        headers_to_add:
          key1: value1
          key2: value2
        with_request_body: false
      endpoint_mode: forward_auth
      endpoint:
        request_method: POST
        path: /auth
        service_name: ext-auth.static
        service_port: 80
        service_source: ip
  imagePullSecret: aliyun
  url: >-
    oci://registry.cn-hangzhou.aliyuncs.com/wasm-plugin/wasm-plugin:ext-auth-0.0.89
```

curl -kvv -X PUT http://localhost:8082/foo?apikey=9a342114-ba8a-11ec-b1bf-00163e1250b5 -H "foo: bar" -H "Authorization: xxx" -H "Host: foo.bar.com" -H "x-user-id: 111111" -H "x-custom-1: test"

认证成功

![endpoint_mode为forward_auth时认证成功](https://github.com/user-attachments/assets/40156b29-2b78-4c07-874e-5fd8b223dd37)

认证请求Method为配置的request_method，认证请求path为配置的path

![endpoint_mode为forward_auth时认证成功2](https://github.com/user-attachments/assets/6ccc6032-35d8-41cc-af30-b312f200cd67)


**2）认证失败**

curl -kvv -X PUT http://localhost:8082/foo?apikey=9a342114-ba8a-11ec-b1bf-00163e1250b5 -H "foo: bar" -H "Authorization: xxx" -H "Host: foo.bar.com" -H "x-user-id: 111111" -H "x-custom-1: test"

认证失败

![endpoint_mode为forward_auth时认证失败](https://github.com/user-attachments/assets/a8517f5b-1f71-4d7b-bb3a-bfb10f2e709c)

认证请求Method为配置的request_method，认证请求path为配置的path

![endpoint_mode为forward_auth时认证失败2](https://github.com/user-attachments/assets/557b5c27-0fc7-4038-9e22-8955053a0add)

**认证白名单**

```yaml
apiVersion: extensions.higress.io/v1alpha1
kind: WasmPlugin
metadata:
  name: test
  namespace: higress-system
spec:
  defaultConfig:
    http_service:
      authorization_request:
        allowed_headers:
          - exact: x-user-id
          - prefix: x-custom-
        headers_to_add:
          key1: value1
          key2: value2
        with_request_body: false
      endpoint_mode: forward_auth
      endpoint:
        request_method: POST
        path: /auth
        service_name: ext-auth.static
        service_port: 80
        service_source: ip
    match_type: 'whitelist'
    match_list:
        - match_rule_domain: '*.bar.com'
          match_rule_path: '/foo/health'
          match_rule_type: 'exact'
        - match_rule_path: '/foo/metrics'
          match_rule_type: 'exact'
  imagePullSecret: aliyun
  url: >-
    oci://registry.cn-hangzhou.aliyuncs.com/wasm-plugin/wasm-plugin:ext-auth-0.0.89
```

认证服务固定返回500

curl -X PUT http://localhost:8082/foo?apikey=9a342114-ba8a-11ec-b1bf-00163e1250b5 -H "foo: bar" -H "Authorization: xxx" -H "Host: foo.bar.com" -o - -w "\n%{http_code}\n" -s -S

curl -X PUT http://localhost:8082/foo/health?apikey=9a342114-ba8a-11ec-b1bf-00163e1250b5 -H "foo: bar" -H "Authorization: xxx" -H "Host: foo.bar.com" -o - -w "\n%{http_code}\n" -s -S

curl -X PUT http://localhost:8082/foo/metrics?apikey=9a342114-ba8a-11ec-b1bf-00163e1250b5 -H "foo: bar" -H "Authorization: xxx" -o /dev/null -w "%{http_code}\n" -s -S

只有第一次curl进入认证，返回401，其他请求均跳过认证

![认证白名单](https://github.com/user-attachments/assets/5648ec89-6c7f-4f35-9ad8-17cb4b6a9e15)


**认证黑名单**

```yaml
apiVersion: extensions.higress.io/v1alpha1
kind: WasmPlugin
metadata:
  name: test
  namespace: higress-system
spec:
  defaultConfig:
    http_service:
      authorization_request:
        allowed_headers:
          - exact: x-user-id
          - prefix: x-custom-
        headers_to_add:
          key1: value1
          key2: value2
        with_request_body: false
      endpoint_mode: forward_auth
      endpoint:
        request_method: POST
        path: /auth
        service_name: ext-auth.static
        service_port: 80
        service_source: ip
    match_type: 'blacklist'
    match_list:
        - match_rule_domain: '*.bar.com'
          match_rule_path: '/foo/health'
          match_rule_type: 'exact'
        - match_rule_path: '/foo/metrics'
          match_rule_type: 'exact'
  imagePullSecret: aliyun
  url: >-
    oci://registry.cn-hangzhou.aliyuncs.com/wasm-plugin/wasm-plugin:ext-auth-0.0.89
```

认证服务固定返回500

curl -X PUT http://localhost:8082/foo?apikey=9a342114-ba8a-11ec-b1bf-00163e1250b5 -H "foo: bar" -H "Authorization: xxx" -H "Host: foo.bar.com" -o - -w "\n%{http_code}\n" -s -S

curl -X PUT http://localhost:8082/foo/health?apikey=9a342114-ba8a-11ec-b1bf-00163e1250b5 -H "foo: bar" -H "Authorization: xxx" -H "Host: foo.bar.com" -o - -w "\n%{http_code}\n" -s -S

curl -X PUT http://localhost:8082/foo/metrics?apikey=9a342114-ba8a-11ec-b1bf-00163e1250b5 -H "foo: bar" -H "Authorization: xxx" -o /dev/null -w "%{http_code}\n" -s -S

第二、三次curl进入认证，返回401，第一次请求跳过认证

![认证黑名单](https://github.com/user-attachments/assets/456fb818-e962-452e-a767-1e7013359371)

### Ⅴ. Special notes for reviews

