### PR TITLE
fix: Path concatenation issue for authentication requests in Envoy authentication mode

### DIFF
--- a/plugins/wasm-go/extensions/ext-auth/main.go
+++ b/plugins/wasm-go/extensions/ext-auth/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"net/http"
+	"path"
 
 	"ext-auth/config"
 	"ext-auth/util"
@@ -90,7 +91,7 @@ func checkExtAuth(ctx wrapper.HttpContext, cfg config.ExtAuthConfig, body []byte
 	requestPath := httpServiceConfig.Path
 	if httpServiceConfig.EndpointMode == config.EndpointModeEnvoy {
 		requestMethod = ctx.Method()
-		requestPath = httpServiceConfig.PathPrefix + ctx.Path()
+		requestPath = path.Join(httpServiceConfig.PathPrefix, ctx.Path())
 	}
 
 	// Call ext auth server

--- a/plugins/wasm-go/extensions/ext-auth/main.go
+++ b/plugins/wasm-go/extensions/ext-auth/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"net/http"
-	"net/url"
 
 	"ext-auth/config"
 	"ext-auth/util"
@@ -91,7 +90,7 @@ func checkExtAuth(ctx wrapper.HttpContext, cfg config.ExtAuthConfig, body []byte
 	requestPath := httpServiceConfig.Path
 	if httpServiceConfig.EndpointMode == config.EndpointModeEnvoy {
 		requestMethod = ctx.Method()
-		requestPath, _ = url.JoinPath(httpServiceConfig.PathPrefix, ctx.Path())
+		requestPath = httpServiceConfig.PathPrefix + ctx.Path()
 	}
 
 	// Call ext auth server


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
The original request URL is encoded, which causes issues with the concatenation of the authentication request path in Envoy authentication mode.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
原始请求：
![image](https://github.com/user-attachments/assets/e7eec635-df71-4b63-bf2b-e09dee3c20ea)

认证服务获取的请求参数：
![image](https://github.com/user-attachments/assets/9f957fb9-b949-417e-b19e-b9fa9e1b64a9)


### Ⅴ. Special notes for reviews

