### PR TITLE
feat: add ollama embedding to ai-cache

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/embedding/ollama.go
+++ b/plugins/wasm-go/extensions/ai-cache/embedding/ollama.go
@@ -20,10 +20,6 @@ const (
 type ollamaProviderInitializer struct {
 }
 
-//var ollamaConfig OllamaProviderConfig
-
-//type ollamaProviderConfig struct {}
-
 func (c *ollamaProviderInitializer) InitConfig(json gjson.Result) {}
 
 func (c *ollamaProviderInitializer) ValidateConfig() error {
@@ -61,10 +57,10 @@ func (t *ollamaProvider) GetProviderType() string {
 }
 
 type ollamaResponse struct {
-	Model             string      `json:"model"`
-	Embeddings        [][]float64 `json:"embeddings"`
-	TotalDuration    int64     `json:"total_duration"`
-	LoadDuration     int64     `json:"load_duration"`
+	Model           string      `json:"model"`
+	Embeddings      [][]float64 `json:"embeddings"`
+	TotalDuration   int64       `json:"total_duration"`
+	LoadDuration    int64       `json:"load_duration"`
 	PromptEvalCount int64       `json:"prompt_eval_count"`
 }
 
@@ -106,7 +102,6 @@ func (t *ollamaProvider) parseTextEmbedding(responseBody []byte) (*ollamaRespons
 	return &resp, nil
 }
 
-
 func (t *ollamaProvider) GetEmbedding(
 	queryString string,
 	ctx wrapper.HttpContext,
@@ -133,7 +128,6 @@ func (t *ollamaProvider) GetEmbedding(
 				callback(nil, err)
 				return
 			}
-
 
 			resp, err = t.parseTextEmbedding(responseBody)
 			if err != nil {

--- a/plugins/wasm-go/extensions/ai-cache/embedding/ollama.go
+++ b/plugins/wasm-go/extensions/ai-cache/embedding/ollama.go
@@ -1,0 +1,157 @@
+package embedding
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/alibaba/higress/plugins/wasm-go/pkg/wrapper"
+	"github.com/tidwall/gjson"
+	"net/http"
+	"strconv"
+)
+
+const (
+	OLLAMA_DOMAIN             = "localhost"
+	OLLAMA_PORT               = 11434
+	OLLAMA_DEFAULT_MODEL_NAME = "llama3.2"
+	OLLAMA_ENDPOINT           = "/api/embed"
+)
+
+type ollamaProviderInitializer struct {
+}
+
+//var ollamaConfig OllamaProviderConfig
+
+//type ollamaProviderConfig struct {}
+
+func (c *ollamaProviderInitializer) InitConfig(json gjson.Result) {}
+
+func (c *ollamaProviderInitializer) ValidateConfig() error {
+	return nil
+}
+
+type ollamaProvider struct {
+	config ProviderConfig
+	client *wrapper.ClusterClient[wrapper.FQDNCluster]
+}
+
+func (t *ollamaProviderInitializer) CreateProvider(c ProviderConfig) (Provider, error) {
+	if c.servicePort == 0 {
+		c.servicePort = OLLAMA_PORT
+	}
+	if c.serviceHost == "" {
+		c.serviceHost = OLLAMA_DOMAIN
+	}
+	if c.model == "" {
+		c.model = OLLAMA_DEFAULT_MODEL_NAME
+	}
+
+	return &ollamaProvider{
+		config: c,
+		client: wrapper.NewClusterClient(wrapper.FQDNCluster{
+			FQDN: c.serviceName,
+			Host: c.serviceHost,
+			Port: c.servicePort,
+		}),
+	}, nil
+}
+
+func (t *ollamaProvider) GetProviderType() string {
+	return PROVIDER_TYPE_OLLAMA
+}
+
+type ollamaResponse struct {
+	Model             string      `json:"model"`
+	Embeddings        [][]float64 `json:"embeddings"`
+	TotalDuration    int64     `json:"total_duration"`
+	LoadDuration     int64     `json:"load_duration"`
+	PromptEvalCount int64       `json:"prompt_eval_count"`
+}
+
+type ollamaEmbeddingRequest struct {
+	Input string `json:"input"`
+	Model string `json:"model"`
+}
+
+func (t *ollamaProvider) constructParameters(text string, log wrapper.Log) (string, [][2]string, []byte, error) {
+	if text == "" {
+		err := errors.New("queryString text cannot be empty")
+		return "", nil, nil, err
+	}
+
+	data := ollamaEmbeddingRequest{
+		Input: text,
+		Model: t.config.model,
+	}
+
+	requestBody, err := json.Marshal(data)
+	if err != nil {
+		log.Errorf("failed to marshal request data: %v", err)
+		return "", nil, nil, err
+	}
+
+	headers := [][2]string{
+		{"Content-Type", "application/json"},
+	}
+	log.Debugf("constructParameters: %s", string(requestBody))
+
+	return OLLAMA_ENDPOINT, headers, requestBody, err
+}
+
+func (t *ollamaProvider) parseTextEmbedding(responseBody []byte) (*ollamaResponse, error) {
+	var resp ollamaResponse
+	if err := json.Unmarshal(responseBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+	return &resp, nil
+}
+
+
+func (t *ollamaProvider) GetEmbedding(
+	queryString string,
+	ctx wrapper.HttpContext,
+	log wrapper.Log,
+	callback func(emb []float64, err error)) error {
+	embUrl, embHeaders, embRequestBody, err := t.constructParameters(queryString, log)
+	if err != nil {
+		log.Errorf("failed to construct parameters: %v", err)
+		return err
+	}
+
+	var resp *ollamaResponse
+
+	defer func() {
+		if err != nil {
+			callback(nil, err)
+		}
+	}()
+	err = t.client.Post(embUrl, embHeaders, embRequestBody,
+		func(statusCode int, responseHeaders http.Header, responseBody []byte) {
+
+			if statusCode != http.StatusOK {
+				err = errors.New("failed to get embedding due to status code: " + strconv.Itoa(statusCode))
+				callback(nil, err)
+				return
+			}
+
+
+			resp, err = t.parseTextEmbedding(responseBody)
+			if err != nil {
+				err = fmt.Errorf("failed to parse response: %v", err)
+				callback(nil, err)
+				return
+			}
+
+			log.Debugf("get embedding response: %d, %s", statusCode, responseBody)
+
+			if len(resp.Embeddings) == 0 {
+				err = errors.New("no embedding found in response")
+				callback(nil, err)
+				return
+			}
+
+			callback(resp.Embeddings[0], nil)
+
+		}, t.config.timeout)
+	return err
+}

--- a/plugins/wasm-go/extensions/ai-cache/embedding/provider.go
+++ b/plugins/wasm-go/extensions/ai-cache/embedding/provider.go
@@ -12,6 +12,7 @@ const (
 	PROVIDER_TYPE_TEXTIN    = "textin"
 	PROVIDER_TYPE_COHERE    = "cohere"
 	PROVIDER_TYPE_OPENAI    = "openai"
+	PROVIDER_TYPE_OLLAMA    = "ollama"
 )
 
 type providerInitializer interface {
@@ -26,6 +27,7 @@ var (
 		PROVIDER_TYPE_TEXTIN:    &textInProviderInitializer{},
 		PROVIDER_TYPE_COHERE:    &cohereProviderInitializer{},
 		PROVIDER_TYPE_OPENAI:    &openAIProviderInitializer{},
+		PROVIDER_TYPE_OLLAMA:    &ollamaProviderInitializer{},
 	}
 )
 

--- a/plugins/wasm-go/extensions/oidc/go.mod
+++ b/plugins/wasm-go/extensions/oidc/go.mod
@@ -1,6 +1,8 @@
 module github.com/alibaba/higress/plugins/wasm-go/extensions/oidc
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 // toolchain go1.22.5
 

--- a/plugins/wasm-go/extensions/oidc/go.mod
+++ b/plugins/wasm-go/extensions/oidc/go.mod
@@ -1,8 +1,6 @@
 module github.com/alibaba/higress/plugins/wasm-go/extensions/oidc
 
-go 1.21
-
-toolchain go1.21.3
+go 1.20
 
 // toolchain go1.22.5
 


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

AI 缓存插件对接 Ollama

### Ⅱ. Does this pull request fix one issue?

Fix [#1445](https://github.com/alibaba/higress/issues/1445)

### Ⅲ. Why don't you add test cases (unit test/integration test)?

### Ⅳ. Describe how to verify it

**1.环境介绍**

ollama本地部署llama3.2，并且使用ngrok内网穿透，直接调用接口`/api/embed`可以正常使用

![image-20250221120413852](https://gitee.com/beatrueman/images/raw/master/img/202502211204991.png)

**2.编译插件**

`ai-proxy`

```
cd ./higress/plugins/wasm-go/extensions/ai-proxy

tinygo build -o ai.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer proxy_wasm_version_0_2_100" ./
```

`ai-cache`

```
cd ./higress/plugins/wasm-go/extensions/ai-cache

tinygo build -o main.wasm -scheduler=none -target=wasi -gc=custom -tags="custommalloc nottinygc_finalizer proxy_wasm_version_0_2_100" ./
```

**3.Docker部署higress**

 `docker-compose.yaml`

```
services:
  envoy:
    image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway:v2.0.2
    entrypoint: /usr/local/bin/envoy
    command: -c /etc/envoy/envoy.yaml --component-log-level wasm:debug
    networks:
      - wasmtest
    ports:
      - "10002:10002"
    volumes:
      - ./envoy.yaml:/etc/envoy/envoy.yaml
      - ./main.wasm:/etc/envoy/main.wasm
      - ./ai.wasm:/etc/envoy/ai.wasm

networks:
  wasmtest: {}
```

`envoy.yaml`

```
admin:
  address:
    socket_address:
      protocol: TCP
      address: 0.0.0.0
      port_value: 9901
static_resources:
  listeners:
    - name: listener_0
      address:
        socket_address:
          protocol: TCP
          address: 0.0.0.0
          port_value: 10002
      filter_chains:
        - filters:
            - name: envoy.filters.network.http_connection_manager
              typed_config:
                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                scheme_header_transformation:
                  scheme_to_overwrite: https
                stat_prefix: ingress_http
                # Output envoy logs to stdout
                access_log:
                  - name: envoy.access_loggers.stdout
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
                # Modify as required
                route_config:
                  name: local_route
                  virtual_hosts:
                    - name: local_service
                      domains: [ "*" ]
                      routes:
                        - match:
                            prefix: "/"
                          route:
                            cluster: ollama
                            timeout: 300s
                http_filters:
                  - name: wasmtest
                    typed_config:
                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                      value:
                        config:
                          name: wasmtest
                          vm_config:
                            runtime: envoy.wasm.runtime.v8
                            code:
                              local:
                                filename: /etc/envoy/ai.wasm
                          configuration:
                            "@type": "type.googleapis.com/google.protobuf.StringValue"
                            value: |
                              {
                                "provider": {
                                  "type": "ollama",
                                  "apiTokens": [
                                    "sk-"
                                  ],
                                  "ollamaServerHost": "a2b4-112-46-215-209.ngrok-free.app",
                                  "ollamaServerPort": 443,
                                  "ollamaModel": ""
                                }
                              }

                  - name: cache
                    typed_config:
                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                      value:
                        config:
                          name: cache
                          vm_config:
                            runtime: envoy.wasm.runtime.v8
                            code:
                              local:
                                filename: /etc/envoy/main.wasm
                          configuration:
                            "@type": "type.googleapis.com/google.protobuf.StringValue"
                            value: |
                              {
                                "embedding": {
                                  "type": "ollama",
                                  "serviceName": "ollama.dns",
                                  "servicePort": 443,
                                  "serviceHost": "a2b4-112-46-215-209.ngrok-free.app"
                                },
                                "vector": {
                                  "type": "dashvector",
                                  "serviceName": "dashvector.dns",
                                  "collectionID": "test1",
                                  "serviceHost": "your host",
                                  "apiKey": "your key",
                                  "threshold": 0.4
                                },
                                "cache": {
                                  "serviceName": "",
                                  "type": ""
                                }
                              }
                  - name: envoy.filters.http.router
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
  clusters:
    - name: ollama
      connect_timeout: 30s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: ollama
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: a2b4-112-46-215-209.ngrok-free.app
                      port_value: 443
      transport_socket:
        name: envoy.transport_sockets.tls
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
          "sni": "a2b4-112-46-215-209.ngrok-free.app"

    - name: outbound|443||ollama.dns
      connect_timeout: 30s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: outbound|443||ollama.dns
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: a2b4-112-46-215-209.ngrok-free.app
                      port_value: 443
      transport_socket:
        name: envoy.transport_sockets.tls
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
          "sni": "a2b4-112-46-215-209.ngrok-free.app"

    - name: outbound|443||dashvector.dns
      connect_timeout: 30s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: outbound|443||dashvector.dns
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: vrs-*aliyuncs.com
                      port_value: 443
      transport_socket:
        name: envoy.transport_sockets.tls
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
          "sni": "vrs-*aliyuncs.com"
```

**4. 测试**

```
curl "http://localhost:10002/ai/v1/chat/completions"  -H "Content-Type: application/json" -d '{
  "model": "llama3.2",
  "messages": [
    {
      "role": "user",
      "content": "你好"
    }
  ]
}'
```

回显

![image-20250221120952337](https://gitee.com/beatrueman/images/raw/master/img/202502211209387.png)

容器日志

![img_v3_02jn_6196f9fd-47d3-4c04-b265-e3817767e6bg](https://gitee.com/beatrueman/images/raw/master/img/202502211209388.png)

### Ⅳ. Describe how to verify it

感谢老师指导