### PR TITLE
fix(typo): use the correct bing name for ai-search.

### DIFF
--- a/plugins/wasm-go/extensions/ai-search/README.md
+++ b/plugins/wasm-go/extensions/ai-search/README.md
@@ -127,7 +127,7 @@ searchFrom:
   cx: "news-search-id"    # 专门搜索Google News内容的搜索引擎ID 
   serviceName: "google-svc.dns"
   servicePort: 443
-- type: being
+- type: bing
   apiKey: "bing-key"
   serviceName: "bing-svc.dns"
   servicePort: 443
@@ -190,8 +190,8 @@ searchFrom:
 ```yaml
 needReference: true
 referenceFormat: "### 数据来源\n%s"
-searchFrom: 
-- type: being
+searchFrom:
+- type: bing
   apiKey: "your-bing-key"
   serviceName: "search-service.dns"
   servicePort: 8080

--- a/plugins/wasm-go/extensions/ai-search/main.go
+++ b/plugins/wasm-go/extensions/ai-search/main.go
@@ -138,10 +138,10 @@ func parseConfig(json gjson.Result, config *Config, log wrapper.Log) error {
 	var internetExists, privateExists, arxivExists bool
 	for _, e := range json.Get("searchFrom").Array() {
 		switch e.Get("type").String() {
-		case "being":
+		case "bing":
 			searchEngine, err := bing.NewBingSearch(&e)
 			if err != nil {
-				return fmt.Errorf("being search engine init failed:%s", err)
+				return fmt.Errorf("bing search engine init failed:%s", err)
 			}
 			config.engine = append(config.engine, searchEngine)
 			internetExists = true


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
The ai-search plugin is using the wrong bing engine name, I tried to fix it again.

### Ⅱ. Does this pull request fix one issue?
None

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

```yaml
needReference: true
referenceFormat: "### 数据来源\n%s"
searchFrom:
- type: bing        // note here.
  apiKey: "your-bing-key"
  serviceName: "search-service.dns"
  servicePort: 8080
```

### Ⅴ. Special notes for reviews

