### PR TITLE
chore: load EXTRA_TAGS from plugin .buildrc file to avoid build issue.

### DIFF
--- a/plugins/wasm-go/Makefile
+++ b/plugins/wasm-go/Makefile
@@ -12,14 +12,14 @@ COMMIT_ID := $(shell git rev-parse --short HEAD 2>/dev/null)
 IMAGE_TAG = $(if $(strip $(PLUGIN_VERSION)),${PLUGIN_VERSION},${BUILD_TIME}-${COMMIT_ID})
 IMG ?= ${REGISTRY}${PLUGIN_NAME}:${IMAGE_TAG}
 GOPROXY := $(shell go env GOPROXY)
-EXTRA_TAGS ?=
+EXTRA_TAGS := $(shell [ -f extensions/${PLUGIN_NAME}/.buildrc ] && . extensions/${PLUGIN_NAME}/.buildrc && echo $$EXTRA_TAGS || echo "")
 
 .DEFAULT:
 build:
 	DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=${PLUGIN_NAME} \
 	                            --build-arg BUILDER=${BUILDER}  \
 	                            --build-arg GOPROXY=$(GOPROXY) \
-	                            --build-arg EXTRA_TAGS=$(EXTRA_TAGS) \
+	                            --build-arg EXTRA_TAGS=${EXTRA_TAGS} \
 	                            -t ${IMG} \
 	                            --output extensions/${PLUGIN_NAME} \
 	                            .
@@ -30,7 +30,7 @@ build-image:
 	DOCKER_BUILDKIT=1 docker build --build-arg PLUGIN_NAME=${PLUGIN_NAME} \
 	                            --build-arg BUILDER=${BUILDER}  \
 	                            --build-arg GOPROXY=$(GOPROXY) \
-	                            --build-arg EXTRA_TAGS=$(EXTRA_TAGS) \
+	                            --build-arg EXTRA_TAGS=${EXTRA_TAGS} \
 	                            -t ${IMG} \
 	                            .
 	@echo ""

--- a/plugins/wasm-go/README.md
+++ b/plugins/wasm-go/README.md
@@ -9,6 +9,8 @@
 使用以下命令可以快速构建 wasm-go 插件:
 
 ```bash
+# NOTE: 如果你想在构建插件的时候设置额外的构建参数 EXTRA_TAGS
+# 请更新 extensions/${PLUGIN_NAME} 插件目录对应的 .buildrc 文件
 $ PLUGIN_NAME=request-block make build
 ```
 

--- a/plugins/wasm-go/README_EN.md
+++ b/plugins/wasm-go/README_EN.md
@@ -7,6 +7,8 @@ This SDK is used to develop the WASM Plugins for Higress in Go.
 The wasm-go plugin can be built quickly with the following command:
 
 ```bash
+# NOTE: if you want to set EXTRA_TAGS for the wasm plugin
+# please set them in the .buildrc file under extensions/${PLUGIN_NAME} directory
 $ PLUGIN_NAME=request-block make build
 ```
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
改成约定的从插件目录 .buildrc 文件读取 EXTRA_TAGS，而不是让用户再去手动设置这个变量值

### Ⅱ. Does this pull request fix one issue?
Fixed #1847 


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
本地运行 `PLUGIN_NAME=ai-token-ratelimit make build` , `PLUGIN_NAME=ai-proxy make build` 即可看出来差别。

### Ⅴ. Special notes for reviews

