### PR TITLE
feat: allow failover to distinguish between different endpoint of the same provider

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/failover.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/failover.go
@@ -104,13 +104,14 @@ func (f *failover) Validate() error {
 func (c *ProviderConfig) initVariable() {
 	// Set provider name as prefix to differentiate shared data
 	provider := c.GetType()
-	c.failover.ctxApiTokenInUse = provider + "-apiTokenInUse"
-	c.failover.ctxApiTokenRequestFailureCount = provider + "-apiTokenRequestFailureCount"
-	c.failover.ctxApiTokenRequestSuccessCount = provider + "-apiTokenRequestSuccessCount"
-	c.failover.ctxApiTokens = provider + "-apiTokens"
-	c.failover.ctxUnavailableApiTokens = provider + "-unavailableApiTokens"
-	c.failover.ctxHealthCheckEndpoint = provider + "-requestHostAndPath"
-	c.failover.ctxVmLease = provider + "-vmLease"
+	id := c.GetId()
+	c.failover.ctxApiTokenInUse = provider + "-" + id + "-apiTokenInUse"
+	c.failover.ctxApiTokenRequestFailureCount = provider + "-" + id + "-apiTokenRequestFailureCount"
+	c.failover.ctxApiTokenRequestSuccessCount = provider + "-" + id + "-apiTokenRequestSuccessCount"
+	c.failover.ctxApiTokens = provider + "-" + id + "-apiTokens"
+	c.failover.ctxUnavailableApiTokens = provider + "-" + id + "-unavailableApiTokens"
+	c.failover.ctxHealthCheckEndpoint = provider + "-" + id + "-requestHostAndPath"
+	c.failover.ctxVmLease = provider + "-" + id + "-vmLease"
 }
 
 func parseConfig(json gjson.Result, config *any, log wrapper.Log) error {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

相同的 provider 用户可能会配置不同的 endpoint，该 PR 将 provider 和 id 拼接起来作为 shared data 的 key，使得 failover 可以区分这种情况。

<img width="597" alt="image" src="https://github.com/user-attachments/assets/94b93d77-3983-4d38-bfda-b736df7d77a2" />
<img width="590" alt="image" src="https://github.com/user-attachments/assets/905f4cdc-7bf0-422d-8a2b-21501ced290a" />


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/alibaba/higress/issues/1816

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

