### PR TITLE
feat: add ratelimit metrics in the ai-token-ratelimit plugin

### DIFF
--- a/plugins/wasm-go/extensions/ai-token-ratelimit/config.go
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"strings"
 
 	"github.com/alibaba/higress/plugins/wasm-go/pkg/wrapper"
@@ -59,6 +60,7 @@ type ClusterKeyRateLimitConfig struct {
 	rejectedCode         uint32          // 当请求超过阈值被拒绝时,返回的HTTP状态码
 	rejectedMsg          string          // 当请求超过阈值被拒绝时,返回的响应体
 	redisClient          wrapper.RedisClient
+	counterMetrics       map[string]proxywasm.MetricCounter // Metrics
 }
 
 type LimitRuleItem struct {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
在ai-token-ratelimit插件里添加限流监控指标

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
发生token限流的时候触发 route_upstream_model_consumer_metric_ai_token_ratelimit 指标
![Image](https://github.com/user-attachments/assets/6054d084-ac2b-4b58-a77b-ea5678d95645)

### Ⅴ. Special notes for reviews

