### PR TITLE
improve the logic for constructing redis key

### DIFF
--- a/plugins/wasm-go/extensions/ai-token-ratelimit/main.go
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/main.go
@@ -39,7 +39,7 @@ func main() {
 }
 
 const (
-	ClusterRateLimitFormat        string = "higress-token-ratelimit:%s:%s:%s:%s"
+	ClusterRateLimitFormat        string = "higress-token-ratelimit:%s:%s:%d:%d:%s:%s" // ruleName, limitType, timewindow, windowsize, key, val
 	RequestPhaseFixedWindowScript string = `
 	local ttl = redis.call('ttl', KEYS[1])
 	if ttl < 0 then
@@ -99,7 +99,7 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config ClusterKeyRateLimitCon
 	}
 
 	// 构建redis限流key和参数
-	limitKey := fmt.Sprintf(ClusterRateLimitFormat, config.ruleName, ruleItem.limitType, ruleItem.key, val)
+	limitKey := fmt.Sprintf(ClusterRateLimitFormat, config.ruleName, ruleItem.limitType, configItem.timeWindow, configItem.count, ruleItem.key, val)
 	keys := []interface{}{limitKey}
 	args := []interface{}{configItem.count, configItem.timeWindow}
 


### PR DESCRIPTION
目前token限流插件存在bug，同一条限流规则，在修改阈值前后，会命中同一个redis key，造成的结果是：之前已经触发限流的规则，在调整阈值后仍然会被限流，直到上次限流的窗口过去。

修改redis key的构建规则，添加timeWindow和windowSize，这样可以保证修改规则可以重新计算限流。