### PR TITLE
feat:add GetContextId func for HttpContext

### DIFF
--- a/plugins/wasm-go/pkg/wrapper/plugin_wrapper.go
+++ b/plugins/wasm-go/pkg/wrapper/plugin_wrapper.go
@@ -73,6 +73,8 @@ type HttpContext interface {
 	SetRequestBodyBufferLimit(byteSize uint32)
 	// Note that this parameter affects the gateway's memory usage! Support setting a maximum buffer size for each response body individually in response phase.
 	SetResponseBodyBufferLimit(byteSize uint32)
+	// Get contextId of HttpContext
+	GetContextId() uint32
 }
 
 type oldParseConfigFunc[PluginConfig any] func(json gjson.Result, config *PluginConfig, log Log) error
@@ -671,6 +673,10 @@ func (ctx *CommonHttpCtx[PluginConfig]) SetRequestBodyBufferLimit(size uint32) {
 func (ctx *CommonHttpCtx[PluginConfig]) SetResponseBodyBufferLimit(size uint32) {
 	ctx.plugin.vm.log.Infof("SetResponseBodyBufferLimit: %d", size)
 	_ = proxywasm.SetProperty([]string{"set_encoder_buffer_limit"}, []byte(strconv.Itoa(int(size))))
+}
+
+func (ctx *CommonHttpCtx[PluginConfig]) GetContextId() uint32 {
+	return ctx.contextID
 }
 
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Expose the contextId property of CommonHttpCtx so that the proxywasm.SetEffectivenessContext function can be called in tickFunc

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

