### PR TITLE
fix: fix param mapping use %v instead of %s

### DIFF
--- a/plugins/golang-filter/mcp-server/registry/remote.go
+++ b/plugins/golang-filter/mcp-server/registry/remote.go
@@ -122,14 +122,14 @@ func (h *HttpRemoteCallHandle) handleParamMapping(mapInfo *map[string]ParameterM
 	for param, value := range params {
 		if info, ok := paramMapInfo[param]; ok {
 			if info.Position == "Query" {
-				h.Query[info.BackendName] = fmt.Sprintf("%s", value)
+				h.Query[info.BackendName] = fmt.Sprintf("%v", value)
 			} else if info.Position == "Header" {
-				h.Headers[info.BackendName] = []string{fmt.Sprintf("%s", value)}
+				h.Headers[info.BackendName] = []string{fmt.Sprintf("%v", value)}
 			} else {
 				return fmt.Errorf("Unsupport position for args %s, pos is %s", param, info.Position)
 			}
 		} else {
-			h.Query[param] = fmt.Sprintf("%s", value)
+			h.Query[param] = fmt.Sprintf("%v", value)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Fix param mapping in mcp nacos registry, use %v instead of %s for param format

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

