### PR TITLE
When the service source type is nacos3, if mcpserver is turned off, then the discovery mechanism of nacos2 will be enabled

### DIFF
--- a/registry/nacos/mcpserver/watcher.go
+++ b/registry/nacos/mcpserver/watcher.go
@@ -111,9 +111,10 @@ func NewWatcher(cache memory.Cache, opts ...WatcherOption) (provider.Watcher, er
 		opt(w)
 	}
 
-	if w.NacosNamespace == "" {
-		w.NacosNamespace = w.NacosNamespaceId
-	}
+	// The nacos mcp server uses these restricted namespaces and groups, and may be adjusted in the future.
+	w.NacosNamespace = "nacos-default-mcp"
+	w.NacosNamespaceId = w.NacosNamespace
+	w.NacosGroups = []string("mcp-server")
 
 	mcpServerLog.Infof("new nacos mcp server watcher with config Name:%s", w.Name)
 
@@ -174,32 +175,6 @@ func WithNacosAccessKey(nacosAccessKey string) WatcherOption {
 func WithNacosSecretKey(nacosSecretKey string) WatcherOption {
 	return func(w *watcher) {
 		w.NacosSecretKey = nacosSecretKey
-	}
-}
-
-func WithNacosNamespaceId(nacosNamespaceId string) WatcherOption {
-	return func(w *watcher) {
-		if nacosNamespaceId == "" {
-			w.NacosNamespaceId = "nacos-default-mcp"
-		} else {
-			w.NacosNamespaceId = nacosNamespaceId
-		}
-	}
-}
-
-func WithNacosNamespace(nacosNamespace string) WatcherOption {
-	return func(w *watcher) {
-		w.NacosNamespace = nacosNamespace
-	}
-}
-
-func WithNacosGroups(nacosGroups []string) WatcherOption {
-	return func(w *watcher) {
-		if len(nacosGroups) == 0 {
-			w.NacosGroups = []string{"mcp-server"}
-		} else {
-			w.NacosGroups = nacosGroups
-		}
 	}
 }
 

--- a/registry/reconcile/reconcile.go
+++ b/registry/reconcile/reconcile.go
@@ -187,25 +187,40 @@ func (r *Reconciler) generateWatcherFromRegistryConfig(registry *apiv1.RegistryC
 			nacosv2.WithAuthOption(authOption),
 		)
 	case string(Nacos3):
-		watcher, err = mcpserver.NewWatcher(
-			r.Cache,
-			mcpserver.WithType(registry.Type),
-			mcpserver.WithName(registry.Name),
-			mcpserver.WithNacosAddressServer(registry.NacosAddressServer),
-			mcpserver.WithDomain(registry.Domain),
-			mcpserver.WithPort(registry.Port),
-			mcpserver.WithNacosAccessKey(registry.NacosAccessKey),
-			mcpserver.WithNacosSecretKey(registry.NacosSecretKey),
-			mcpserver.WithNacosNamespaceId(registry.NacosNamespaceId),
-			mcpserver.WithNacosNamespace(registry.NacosNamespace),
-			mcpserver.WithNacosGroups(registry.NacosGroups),
-			mcpserver.WithNacosRefreshInterval(registry.NacosRefreshInterval),
-			mcpserver.WithMcpExportDomains(registry.McpServerExportDomains),
-			mcpserver.WithMcpBaseUrl(registry.McpServerBaseUrl),
-			mcpserver.WithEnableMcpServer(registry.EnableMCPServer),
-			mcpserver.WithClusterId(r.clusterId),
-			mcpserver.WithNamespace(r.namespace),
-		)
+		if registry.EnableMCPServer.GetValue() {
+			watcher, err = mcpserver.NewWatcher(
+				r.Cache,
+				mcpserver.WithType(registry.Type),
+				mcpserver.WithName(registry.Name),
+				mcpserver.WithNacosAddressServer(registry.NacosAddressServer),
+				mcpserver.WithDomain(registry.Domain),
+				mcpserver.WithPort(registry.Port),
+				mcpserver.WithNacosAccessKey(registry.NacosAccessKey),
+				mcpserver.WithNacosSecretKey(registry.NacosSecretKey),
+				mcpserver.WithNacosRefreshInterval(registry.NacosRefreshInterval),
+				mcpserver.WithMcpExportDomains(registry.McpServerExportDomains),
+				mcpserver.WithMcpBaseUrl(registry.McpServerBaseUrl),
+				mcpserver.WithEnableMcpServer(registry.EnableMCPServer),
+				mcpserver.WithClusterId(r.clusterId),
+				mcpserver.WithNamespace(r.namespace),
+			)
+		} else {
+			watcher, err = nacosv2.NewWatcher(
+				r.Cache,
+				nacosv2.WithType(registry.Type),
+				nacosv2.WithName(registry.Name),
+				nacosv2.WithNacosAddressServer(registry.NacosAddressServer),
+				nacosv2.WithDomain(registry.Domain),
+				nacosv2.WithPort(registry.Port),
+				nacosv2.WithNacosAccessKey(registry.NacosAccessKey),
+				nacosv2.WithNacosSecretKey(registry.NacosSecretKey),
+				nacosv2.WithNacosNamespaceId(registry.NacosNamespaceId),
+				nacosv2.WithNacosNamespace(registry.NacosNamespace),
+				nacosv2.WithNacosGroups(registry.NacosGroups),
+				nacosv2.WithNacosRefreshInterval(registry.NacosRefreshInterval),
+				nacosv2.WithAuthOption(authOption),
+			)
+		}
 	case string(Zookeeper):
 		watcher, err = zookeeper.NewWatcher(
 			r.Cache,


### PR DESCRIPTION

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

