### PR TITLE
fix: Remove the Authorization request header when using AI-proxy to proxy Gemini

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
@@ -68,6 +68,7 @@ func (g *geminiProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 func (g *geminiProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
 	util.OverwriteRequestHostHeader(headers, geminiDomain)
 	headers.Set(geminiApiKeyHeader, g.config.GetApiTokenInUse(ctx))
+	util.OverwriteRequestAuthorizationHeader(headers, "")
 }
 
 func (g *geminiProvider) OnRequestBody(ctx wrapper.HttpContext, apiName ApiName, body []byte) (types.Action, error) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
ai-proxy 代理 gemini 时移除 Authorization 请求头

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #2199

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
修复前原始请求带 Authorization 请求头代理 gemini 时，报错：
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/062a736f-f66c-4457-a81e-7f45535cc8f7" />


修复后原始请求带 Authorization 请求头也能正常代理到 gemini

<img width="1357" alt="image" src="https://github.com/user-attachments/assets/92348b69-136a-46c8-ade6-2c65a5a54b8a" />


### Ⅴ. Special notes for reviews

