### PR TITLE
Add test translation workflow

### DIFF
--- a/.github/workflows/translate-test.yml
+++ b/.github/workflows/translate-test.yml
@@ -1,0 +1,25 @@
+name: 'Test Translation Action'
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  translate:
+    permissions:
+      issues: write
+      discussions: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lizheming/github-translate-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          APPEND_TRANSLATION: true

--- a/.github/workflows/translate-test.yml
+++ b/.github/workflows/translate-test.yml
@@ -1,8 +1,12 @@
-name: 'Test Translation Action'
+name: 'Translate GitHub content into English'
 on:
   issues:
     types: [opened, edited]
   issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
     types: [created, edited]
   pull_request_target:
     types: [opened, edited]


### PR DESCRIPTION
# Adding Automated Translation for Higress

This PR introduces a GitHub Actions workflow that automates translations for non-English issues and PR comments. By implementing this workflow, we aim to enhance Higress's global visibility and make it more accessible to international users and contributors.

## Features Implemented

- Added a GitHub Actions workflow that automatically detects and translates non-English content in:
  - Issues (when opened or edited)
  - Issue comments
  - Pull requests
  - PR review comments

- The translation is appended to the original content for a non-intrusive user experience

## Implementation Details

- Uses the `lizheming/github-translate-action` which is specifically designed for GitHub content translation
- Configured to translate to English by default
- Permissions are properly set to allow writing to issues and pull requests
- Retains the original non-English content while adding the translation

## Testing Done

- Verified the workflow triggers correctly on new non-English issues
- Tested with non-English PR comments to ensure proper translation
- Confirmed the action runs with appropriate permissions

## Benefits for the Project

This implementation will help Higress in several ways:

1. International users can comfortably write in their native language while maintainers can read in English
2. Reduces communication barriers for global contributors
3. Makes the project more inclusive and accessible
4. Maintainers can respond to all issues regardless of language used

This is a step toward making Higress a truly global open source project with contributors from diverse linguistic backgrounds.

## Next Steps

After this is merged, we can:
- Collect feedback on translation quality
- Consider extending translation capabilities to documentation
- Explore options for translating the project website


Fixes #2226 