### PR TITLE
ext-auth wasm plugin tests

### DIFF
--- a/.github/workflows/translate-test.yml
+++ b/.github/workflows/translate-test.yml
@@ -1,0 +1,25 @@
+name: 'Test Translation Action'
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  translate:
+    permissions:
+      issues: write
+      discussions: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lizheming/github-translate-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          APPEND_TRANSLATION: true

--- a/.github/workflows/translate-test.yml
+++ b/.github/workflows/translate-test.yml
@@ -1,8 +1,12 @@
-name: 'Test Translation Action'
+name: 'Translate GitHub content into English'
 on:
   issues:
     types: [opened, edited]
   issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
     types: [created, edited]
   pull_request_target:
     types: [opened, edited]

--- a/test/e2e/conformance/tests/ext_auth.go
+++ b/test/e2e/conformance/tests/ext_auth.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/test/e2e/conformance/utils/http"
+	"github.com/alibaba/higress/test/e2e/conformance/utils/suite"
+)
+
+func init() {
+	Register(WasmPluginsExtAuth)
+}
+
+var WasmPluginsExtAuth = suite.ConformanceTest{
+	ShortName:   "WasmPluginsExtAuth",
+	Description: "The Ingress in the higress-conformance-infra namespace test the ext-auth wasmplugin.",
+	Manifests:   []string{"tests/ext_auth.yaml", "tests/ext_auth_plugin.yaml"},
+	Features:    []suite.SupportedFeature{suite.WASMGoConformanceFeature},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		testcases := []http.Assertion{
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 1: Blacklist mode - blocked path",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:             "ext-auth-test.example.com",
+						Path:             "/blocked-path",
+						UnfollowRedirect: true,
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 403,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 2: Blacklist mode - allowed path",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:             "ext-auth-test.example.com",
+						Path:             "/allowed-path",
+						UnfollowRedirect: true,
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 3: Method-specific rules - GET allowed",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:             "ext-auth-test.example.com",
+						Path:             "/api",
+						Method:           "GET",
+						UnfollowRedirect: true,
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "case 4: Method-specific rules - POST blocked",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:             "ext-auth-test.example.com",
+						Path:             "/api",
+						Method:           "POST",
+						ContentType:      http.ContentTypeTextPlain,
+						Body:             []byte(`test body`),
+						UnfollowRedirect: true,
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 403,
+					},
+				},
+			},
+		}
+		t.Run("WasmPlugins ext-auth", func(t *testing.T) {
+			for _, testcase := range testcases {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcase)
+			}
+		})
+	},
+}

--- a/test/e2e/conformance/tests/ext_auth.go
+++ b/test/e2e/conformance/tests/ext_auth.go
@@ -22,129 +22,339 @@ import (
 )
 
 func init() {
-    Register(WasmPluginsExtAuth)
+    Register(WasmPluginsExtAuthBlacklistForwardAuth)
+    Register(WasmPluginsExtAuthBlacklistEnvoy)
+    Register(WasmPluginsExtAuthWhitelistForwardAuth)
+    Register(WasmPluginsExtAuthWhitelistEnvoy)
 }
 
-var WasmPluginsExtAuth = suite.ConformanceTest{
-    ShortName:   "WasmPluginsExtAuth",
-    Description: "Verify ext-auth WasmPlugin in blacklist mode with header propagation",
-    Manifests:   []string{"tests/ext_auth.yaml", "tests/ext_auth_plugin.yaml"},
+// WasmPluginsExtAuthBlacklistForwardAuth tests ext-auth WasmPlugin in blacklist mode with forward_auth endpoint
+var WasmPluginsExtAuthBlacklistForwardAuth = suite.ConformanceTest{
+    ShortName:   "WasmPluginsExtAuthBlacklistForwardAuth",
+    Description: "Verify ext-auth WasmPlugin in blacklist mode with forward_auth endpoint",
+    Manifests:   []string{"tests/ext_auth.yaml", "tests/ext_auth_blacklist_forward_auth.yaml"},
     Features:    []suite.SupportedFeature{suite.WASMGoConformanceFeature},
     Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
-        cases := []struct {
-            name      string
-            assertion http.Assertion
-        }{
-            {
-                name: "blacklist-allowed-root",
-                assertion: http.Assertion{
-                    Meta: http.AssertionMeta{
-                        TestCaseName:    "root path allowed",
-                        TargetBackend:   "infra-backend-v1",
-                        TargetNamespace: "higress-conformance-infra",
-                    },
-                    Request: http.AssertionRequest{
-                        ActualRequest: http.Request{
-                            Host: "localhost",
-                            Path: "/allowed-path",
-                        },
-                    },
-                    Response: http.AssertionResponse{
-                        ExpectedResponse: http.Response{
-                            StatusCode: 200,
-                            Headers: map[string]string{
-                                "X-Auth-Status": "OK",
-                            },
-                        },
-                    },
-                },
-            },
-            {
-                name: "method-get-allowed",
-                assertion: http.Assertion{
-                    Meta: http.AssertionMeta{
-                        TestCaseName:    "GET /api allowed",
-                        TargetBackend:   "infra-backend-v1",
-                        TargetNamespace: "higress-conformance-infra",
-                    },
-                    Request: http.AssertionRequest{
-                        ActualRequest: http.Request{
-                            Host:   "localhost",
-                            Path:   "/api",
-                            Method: "GET",
-                        },
-                    },
-                    Response: http.AssertionResponse{
-                        ExpectedResponse: http.Response{
-                            StatusCode: 200,
-                            Headers: map[string]string{
-                                "X-Auth-Status": "OK",
-                            },
-                        },
-                    },
-                },
-            },
-            {
-                name: "method-post-blocked",
-                assertion: http.Assertion{
-                    Meta: http.AssertionMeta{
-                        TestCaseName:    "POST /api blocked",
-                        TargetBackend:   "infra-backend-v1",
-                        TargetNamespace: "higress-conformance-infra",
-                    },
-                    Request: http.AssertionRequest{
-                        ActualRequest: http.Request{
-                            Host:        "localhost",
-                            Path:        "/api",
-                            Method:      "POST",
-                            Body:        []byte("test-body"),
-                            ContentType: http.ContentTypeTextPlain,
-                        },
-                    },
-                    Response: http.AssertionResponse{
-                        ExpectedResponse: http.Response{
-                            StatusCode: 403,
-                            Headers: map[string]string{
-                                "X-Auth-Status": "DENIED",
-                            },
-                        },
-                    },
-                },
-            },
-            {
-                name: "blacklist-blocked-path",
-                assertion: http.Assertion{
-                    Meta: http.AssertionMeta{
-                        TestCaseName:    "blocked-path denied",
-                        TargetBackend:   "infra-backend-v1",
-                        TargetNamespace: "higress-conformance-infra",
-                    },
-                    Request: http.AssertionRequest{
-                        ActualRequest: http.Request{
-                            Host: "localhost",
-                            Path: "/blocked-path",
-                        },
-                    },
-                    Response: http.AssertionResponse{
-                        ExpectedResponse: http.Response{
-                            StatusCode: 403,
-                            Headers: map[string]string{
-                                "X-Auth-Status": "DENIED",
-                            },
-                        },
-                    },
-                },
-            },
-        }
-
-        for _, c := range cases {
-            c := c // capture
-            t.Run(c.name, func(t *testing.T) {
-                t.Parallel()
-                http.MakeRequestAndExpectEventuallyConsistentResponse(
-                    t, s.RoundTripper, s.TimeoutConfig, s.GatewayAddress, c.assertion,
-                )
-            })
-        }
+        runCommonBlacklistTests(t, s, "blacklist-forward-auth")
     },
+}
+
+// WasmPluginsExtAuthBlacklistEnvoy tests ext-auth WasmPlugin in blacklist mode with envoy endpoint
+var WasmPluginsExtAuthBlacklistEnvoy = suite.ConformanceTest{
+    ShortName:   "WasmPluginsExtAuthBlacklistEnvoy",
+    Description: "Verify ext-auth WasmPlugin in blacklist mode with envoy endpoint",
+    Manifests:   []string{"tests/ext_auth.yaml", "tests/ext_auth_blacklist_envoy.yaml"},
+    Features:    []suite.SupportedFeature{suite.WASMGoConformanceFeature},
+    Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+        runCommonBlacklistTests(t, s, "blacklist-envoy")
+    },
+}
+
+// WasmPluginsExtAuthWhitelistForwardAuth tests ext-auth WasmPlugin in whitelist mode with forward_auth endpoint
+var WasmPluginsExtAuthWhitelistForwardAuth = suite.ConformanceTest{
+    ShortName:   "WasmPluginsExtAuthWhitelistForwardAuth",
+    Description: "Verify ext-auth WasmPlugin in whitelist mode with forward_auth endpoint",
+    Manifests:   []string{"tests/ext_auth.yaml", "tests/ext_auth_whitelist_forward_auth.yaml"},
+    Features:    []suite.SupportedFeature{suite.WASMGoConformanceFeature},
+    Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+        runCommonWhitelistTests(t, s, "whitelist-forward-auth")
+    },
+}
+
+// WasmPluginsExtAuthWhitelistEnvoy tests ext-auth WasmPlugin in whitelist mode with envoy endpoint
+var WasmPluginsExtAuthWhitelistEnvoy = suite.ConformanceTest{
+    ShortName:   "WasmPluginsExtAuthWhitelistEnvoy",
+    Description: "Verify ext-auth WasmPlugin in whitelist mode with envoy endpoint",
+    Manifests:   []string{"tests/ext_auth.yaml", "tests/ext_auth_whitelist_envoy.yaml"},
+    Features:    []suite.SupportedFeature{suite.WASMGoConformanceFeature},
+    Test: func(t *testing.T, s *suite.ConformanceTestSuite) {
+        runCommonWhitelistTests(t, s, "whitelist-envoy")
+    },
+}
+
+// runCommonBlacklistTests contains the common test cases for blacklist mode
+func runCommonBlacklistTests(t *testing.T, s *suite.ConformanceTestSuite, prefix string) {
+    cases := []struct {
+        name      string
+        assertion http.Assertion
+    }{
+        {
+            name: prefix + "-allowed-root",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "root path allowed",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host: "localhost",
+                        Path: "/allowed-path",
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 200,
+                        Headers: map[string]string{
+                            "X-Auth-Status": "OK",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: prefix + "-method-get-allowed",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "GET /api allowed",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host:   "localhost",
+                        Path:   "/api",
+                        Method: "GET",
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 200,
+                        Headers: map[string]string{
+                            "X-Auth-Status": "OK",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: prefix + "-method-post-blocked",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "POST /api blocked",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host:        "localhost",
+                        Path:        "/api",
+                        Method:      "POST",
+                        Body:        []byte("test-body"),
+                        ContentType: http.ContentTypeTextPlain,
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 403,
+                        Headers: map[string]string{
+                            "X-Auth-Status": "DENIED",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: prefix + "-blocked-path",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "blocked-path denied",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host: "localhost",
+                        Path: "/blocked-path",
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 403,
+                        Headers: map[string]string{
+                            "X-Auth-Status": "DENIED",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: prefix + "-auth-failure",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "auth server failure",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host: "localhost",
+                        Path: "/allowed-path",
+                        Headers: map[string]string{
+                            "X-Test-Auth-Fail": "true",
+                        },
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 403,
+                    },
+                },
+            },
+        },
+    }
+
+    for _, c := range cases {
+        c := c // capture
+        t.Run(c.name, func(t *testing.T) {
+            t.Parallel()
+            http.MakeRequestAndExpectEventuallyConsistentResponse(
+                t, s.RoundTripper, s.TimeoutConfig, s.GatewayAddress, c.assertion,
+            )
+        })
+    }
+}
+
+// runCommonWhitelistTests contains the common test cases for whitelist mode
+func runCommonWhitelistTests(t *testing.T, s *suite.ConformanceTestSuite, prefix string) {
+    cases := []struct {
+        name      string
+        assertion http.Assertion
+    }{
+        {
+            name: prefix + "-allowed-path",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "allowed path",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host: "localhost",
+                        Path: "/allowed-path",
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 200,
+                        Headers: map[string]string{
+                            "X-Auth-Status": "OK",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: prefix + "-method-allowed",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "GET /api allowed",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host:   "localhost",
+                        Path:   "/api",
+                        Method: "GET",
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 200,
+                        Headers: map[string]string{
+                            "X-Auth-Status": "OK",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: prefix + "-method-get-blocked-path",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "GET non-whitelisted path",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host:   "localhost",
+                        Path:   "/random-path",
+                        Method: "GET",
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 403,
+                        Headers: map[string]string{
+                            "X-Auth-Status": "DENIED",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: prefix + "-method-post-blocked",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "POST /api blocked",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host:        "localhost",
+                        Path:        "/api",
+                        Method:      "POST",
+                        Body:        []byte("test-body"),
+                        ContentType: http.ContentTypeTextPlain,
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 403,
+                        Headers: map[string]string{
+                            "X-Auth-Status": "DENIED",
+                        },
+                    },
+                },
+            },
+        },
+        {
+            name: prefix + "-auth-failure",
+            assertion: http.Assertion{
+                Meta: http.AssertionMeta{
+                    TestCaseName:    "auth server failure",
+                    TargetBackend:   "infra-backend-v1",
+                    TargetNamespace: "higress-conformance-infra",
+                },
+                Request: http.AssertionRequest{
+                    ActualRequest: http.Request{
+                        Host: "localhost",
+                        Path: "/allowed-path",
+                        Headers: map[string]string{
+                            "X-Test-Auth-Fail": "true",
+                        },
+                    },
+                },
+                Response: http.AssertionResponse{
+                    ExpectedResponse: http.Response{
+                        StatusCode: 403,
+                    },
+                },
+            },
+        },
+    }
+
+    for _, c := range cases {
+        c := c // capture
+        t.Run(c.name, func(t *testing.T) {
+            t.Parallel()
+            http.MakeRequestAndExpectEventuallyConsistentResponse(
+                t, s.RoundTripper, s.TimeoutConfig, s.GatewayAddress, c.assertion,
+            )
+        })
+    }
 }

--- a/test/e2e/conformance/tests/ext_auth.go
+++ b/test/e2e/conformance/tests/ext_auth.go
@@ -15,10 +15,14 @@
 package tests
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/alibaba/higress/test/e2e/conformance/utils/http"
 	"github.com/alibaba/higress/test/e2e/conformance/utils/suite"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
@@ -31,6 +35,24 @@ var WasmPluginsExtAuth = suite.ConformanceTest{
 	Manifests:   []string{"tests/ext_auth.yaml", "tests/ext_auth_plugin.yaml"},
 	Features:    []suite.SupportedFeature{suite.WASMGoConformanceFeature},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		// 1. Increase timeout for the test
+		originalTimeout := suite.TimeoutConfig
+		increasedTimeout := suite.TimeoutConfig
+		increasedTimeout.RequestTimeout = 60 * time.Second  // Increase request timeout
+		increasedTimeout.MaxRetries = 20                   // More retries
+		increasedTimeout.InitialDelay = 5 * time.Second    // Add initial delay
+		suite.TimeoutConfig = increasedTimeout
+		
+		// 2. Wait for ext-auth-server deployment to be ready
+		t.Log("Waiting for ext-auth-server deployment to be ready...")
+		waitForDeploymentReady(t, suite, "ext-auth-server", "higress-conformance-infra")
+		
+		// 3. Verify WasmPlugin exists
+		t.Log("Verifying ext-auth WasmPlugin exists...")
+		// This would require an implementation to check if the WasmPlugin is properly loaded
+		// For now, we'll add a delay to give time for the plugin to be processed
+		time.Sleep(15 * time.Second)
+		
 		testcases := []http.Assertion{
 			{
 				Meta: http.AssertionMeta{
@@ -113,10 +135,67 @@ var WasmPluginsExtAuth = suite.ConformanceTest{
 				},
 			},
 		}
+		
+		// 4. Run tests with improved error handling
 		t.Run("WasmPlugins ext-auth", func(t *testing.T) {
-			for _, testcase := range testcases {
+			// Make a simple test request first to ensure connectivity
+			probe := http.Assertion{
+				Meta: http.AssertionMeta{
+					TestCaseName: "Connectivity probe",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host: "ext-auth-test.example.com",
+						Path: "/health",
+					},
+				},
+			}
+			
+			// Try the probe request with shorter timeout
+			probeTimeoutConfig := suite.TimeoutConfig
+			probeTimeoutConfig.RequestTimeout = 10 * time.Second
+			probeTimeoutConfig.MaxRetries = 5
+			
+			t.Log("Probing gateway connectivity...")
+			err := http.MakeRequest(t, suite.RoundTripper, probeTimeoutConfig, suite.GatewayAddress, probe)
+			if err != nil {
+				t.Logf("Probe connectivity warning: %v", err)
+				t.Log("Continuing with tests despite probe failure...")
+			} else {
+				t.Log("Gateway connectivity confirmed.")
+			}
+			
+			// Run the actual test cases
+			for i, testcase := range testcases {
+				t.Logf("Running test case %d: %s", i+1, testcase.Meta.TestCaseName)
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcase)
 			}
 		})
+		
+		// Restore original timeout settings
+		suite.TimeoutConfig = originalTimeout
 	},
+}
+
+// Helper function to wait for a deployment to be ready
+func waitForDeploymentReady(t *testing.T, suite *suite.ConformanceTestSuite, name, namespace string) {
+	clientset := suite.Client.KubernetesClientset
+	
+	// Check deployment readiness
+	for i := 0; i < 30; i++ {
+		deployment, err := clientset.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("Error getting deployment %s/%s: %v", namespace, name, err)
+		} else {
+			if deployment.Status.ReadyReplicas == *deployment.Spec.Replicas {
+				t.Logf("Deployment %s/%s is ready", namespace, name)
+				return
+			}
+			t.Logf("Deployment %s/%s: %d/%d replicas ready", 
+				namespace, name, deployment.Status.ReadyReplicas, *deployment.Spec.Replicas)
+		}
+		time.Sleep(5 * time.Second)
+	}
+	
+	t.Logf("Warning: Deployment %s/%s might not be fully ready, proceeding anyway", namespace, name)
 }

--- a/test/e2e/conformance/tests/ext_auth.go
+++ b/test/e2e/conformance/tests/ext_auth.go
@@ -16,7 +16,6 @@ package tests
 
 import (
 	"testing"
-	"time"
 
 	"github.com/alibaba/higress/test/e2e/conformance/utils/http"
 	"github.com/alibaba/higress/test/e2e/conformance/utils/suite"
@@ -32,19 +31,6 @@ var WasmPluginsExtAuth = suite.ConformanceTest{
 	Manifests:   []string{"tests/ext_auth.yaml", "tests/ext_auth_plugin.yaml"},
 	Features:    []suite.SupportedFeature{suite.WASMGoConformanceFeature},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
-		// Increase timeout and add delay
-		originalTimeout := suite.TimeoutConfig
-		increasedTimeout := suite.TimeoutConfig
-		increasedTimeout.RequestTimeout = 30 * time.Second
-		suite.TimeoutConfig = increasedTimeout
-		
-		t.Log("Waiting for services to be ready...")
-		time.Sleep(30 * time.Second)
-		
-		// Print gateway address for debugging
-		t.Logf("Gateway address: %s", suite.GatewayAddress)
-		
-		// Use "localhost" for all test cases - simple approach based on logs
 		testcases := []http.Assertion{
 			{
 				Meta: http.AssertionMeta{
@@ -127,26 +113,10 @@ var WasmPluginsExtAuth = suite.ConformanceTest{
 				},
 			},
 		}
-		
-		// Run tests one by one
 		t.Run("WasmPlugins ext-auth", func(t *testing.T) {
-			// Start with the allowed path test to verify basic connectivity
-			t.Log("Testing basic connectivity (case 2)...")
-			http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcases[1])
-			
-			// If we get here, run the remaining tests
-			for i, testcase := range testcases {
-				// Skip case 2 since we already ran it
-				if i == 1 {
-					continue
-				}
-				t.Logf("Running test case %d: %s", i+1, testcase.Meta.TestCaseName)
+			for _, testcase := range testcases {
 				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcase)
-				time.Sleep(1 * time.Second)
 			}
 		})
-		
-		// Restore original timeout
-		suite.TimeoutConfig = originalTimeout
 	},
 }

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,10 +15,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    higress.io/ignore-path-case: "true"
   name: wasmplugin-ext-auth
   namespace: higress-conformance-infra
+  annotations:
+    higress.io/ignore-path-case: "true"
 spec:
   ingressClassName: higress
   rules:
@@ -38,8 +38,6 @@ kind: Deployment
 metadata:
   name: ext-auth-server
   namespace: higress-conformance-infra
-  labels:
-    app: ext-auth-server
 spec:
   replicas: 1
   selector:
@@ -51,28 +49,26 @@ spec:
         app: ext-auth-server
     spec:
       containers:
-      - name: ext-auth-server
-        image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/ext-auth-server:latest
-        ports:
-        - containerPort: 8000
-        # Add health check and readiness probe
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        env:
-        - name: LOG_LEVEL
-          value: "debug"
-        # Add resource limits
-        resources:
-          limits:
-            cpu: 200m
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
+        - name: ext-auth-server
+          image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/ext-auth-server:latest
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          env:
+            - name: LOG_LEVEL
+              value: "debug"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
 ---
 apiVersion: v1
 kind: Service
@@ -80,8 +76,8 @@ metadata:
   name: ext-auth-server
   namespace: higress-conformance-infra
 spec:
-  ports:
-  - port: 8000
-    targetPort: 8000
   selector:
     app: ext-auth-server
+  ports:
+    - port: 8000
+      targetPort: 8000

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -53,6 +53,7 @@ spec:
           image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/ext-auth-server:latest
           ports:
             - containerPort: 8000
+            - containerPort: 9000  # For gRPC (envoy mode)
           readinessProbe:
             httpGet:
               path: /health
@@ -79,5 +80,9 @@ spec:
   selector:
     app: ext-auth-server
   ports:
-    - port: 8000
+    - name: http
+      port: 8000
       targetPort: 8000
+    - name: grpc
+      port: 9000
+      targetPort: 9000

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -1,0 +1,54 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+  name: wasmplugin-ext-auth
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "ext-auth-test.example.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ext-auth-server
+  namespace: higress-conformance-infra
+  labels:
+    app: ext-auth-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ext-auth-server
+  template:
+    metadata:
+      labels:
+        app: ext-auth-server
+    spec:
+      containers:
+      - name: ext-auth-server
+        image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/ext-auth-server:latest
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ext-auth-server
+  namespace: higress-conformance-infra
+spec:
+  ports:
+  - port: 8000
+    targetPort: 8000
+  selector:
+    app: ext-auth-server

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -16,13 +16,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    higress.io/ignore-path-case: "true"  # Make path matching case-insensitive
+    higress.io/ignore-path-case: "true"
   name: wasmplugin-ext-auth
   namespace: higress-conformance-infra
 spec:
   ingressClassName: higress
   rules:
-    - host: "localhost"  # Explicit rule for localhost
+    - host: "localhost"
       http:
         paths:
           - pathType: Prefix

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -17,6 +17,10 @@ kind: Ingress
 metadata:
   annotations:
     higress.io/ignore-path-case: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    higress.io/backend-protocol: "HTTP"
+    higress.io/default-host-for-path-network: "true"
   name: wasmplugin-ext-auth
   namespace: higress-conformance-infra
 spec:
@@ -55,13 +59,6 @@ spec:
         image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/ext-auth-server:latest
         ports:
         - containerPort: 8000
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            cpu: 200m
-            memory: 256Mi
 ---
 apiVersion: v1
 kind: Service
@@ -74,4 +71,3 @@ spec:
     targetPort: 8000
   selector:
     app: ext-auth-server
-  type: ClusterIP

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -16,25 +16,13 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    # Add hostAliases annotation
-    higress.io/hosts-alias: "localhost ext-auth-test.example.com"
+    higress.io/ignore-path-case: "true"  # Make path matching case-insensitive
   name: wasmplugin-ext-auth
   namespace: higress-conformance-infra
 spec:
   ingressClassName: higress
   rules:
-    - host: "ext-auth-test.example.com"
-      http:
-        paths:
-          - pathType: Prefix
-            path: "/"
-            backend:
-              service:
-                name: infra-backend-v1
-                port:
-                  number: 8080
-    # Add explicit rule for localhost
-    - host: "localhost"
+    - host: "localhost"  # Explicit rule for localhost
       http:
         paths:
           - pathType: Prefix
@@ -74,9 +62,6 @@ spec:
           limits:
             cpu: 200m
             memory: 256Mi
-        env:
-        - name: LOG_LEVEL
-          value: "debug"  # Set to debug for more verbose logging
 ---
 apiVersion: v1
 kind: Service
@@ -87,7 +72,6 @@ spec:
   ports:
   - port: 8000
     targetPort: 8000
-    name: http
   selector:
     app: ext-auth-server
   type: ClusterIP

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -1,15 +1,40 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
+    # Add hostAliases annotation
+    higress.io/hosts-alias: "localhost ext-auth-test.example.com"
   name: wasmplugin-ext-auth
   namespace: higress-conformance-infra
 spec:
   ingressClassName: higress
   rules:
     - host: "ext-auth-test.example.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+    # Add explicit rule for localhost
+    - host: "localhost"
       http:
         paths:
           - pathType: Prefix
@@ -49,33 +74,15 @@ spec:
           limits:
             cpu: 200m
             memory: 256Mi
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 3
-          successThreshold: 1
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8000
-          initialDelaySeconds: 15
-          periodSeconds: 20
-          timeoutSeconds: 3
         env:
         - name: LOG_LEVEL
-          value: "info"
+          value: "debug"  # Set to debug for more verbose logging
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ext-auth-server
   namespace: higress-conformance-infra
-  annotations:
-    # Add annotation for service to wait until ready
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   ports:
   - port: 8000
@@ -83,7 +90,4 @@ spec:
     name: http
   selector:
     app: ext-auth-server
-  # Set to ClusterIP explicitly for internal services
   type: ClusterIP
-  # Ensure only ready endpoints receive traffic
-  publishNotReadyAddresses: false

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -2,6 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "30"
   name: wasmplugin-ext-auth
   namespace: higress-conformance-infra
 spec:
@@ -40,15 +42,48 @@ spec:
         image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/ext-auth-server:latest
         ports:
         - containerPort: 8000
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 3
+        env:
+        - name: LOG_LEVEL
+          value: "info"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ext-auth-server
   namespace: higress-conformance-infra
+  annotations:
+    # Add annotation for service to wait until ready
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   ports:
   - port: 8000
     targetPort: 8000
+    name: http
   selector:
     app: ext-auth-server
+  # Set to ClusterIP explicitly for internal services
+  type: ClusterIP
+  # Ensure only ready endpoints receive traffic
+  publishNotReadyAddresses: false

--- a/test/e2e/conformance/tests/ext_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth.yaml
@@ -17,10 +17,6 @@ kind: Ingress
 metadata:
   annotations:
     higress.io/ignore-path-case: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    higress.io/backend-protocol: "HTTP"
-    higress.io/default-host-for-path-network: "true"
   name: wasmplugin-ext-auth
   namespace: higress-conformance-infra
 spec:
@@ -59,6 +55,24 @@ spec:
         image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/ext-auth-server:latest
         ports:
         - containerPort: 8000
+        # Add health check and readiness probe
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        env:
+        - name: LOG_LEVEL
+          value: "debug"
+        # Add resource limits
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
 ---
 apiVersion: v1
 kind: Service

--- a/test/e2e/conformance/tests/ext_auth_blacklist_evony.yaml
+++ b/test/e2e/conformance/tests/ext_auth_blacklist_evony.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions.higress.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: ext-auth
+  namespace: higress-system
+spec:
+  phase: AUTHN
+  priority: 100
+  matchRules:
+    - ingress:
+        - higress-conformance-infra/wasmplugin-ext-auth
+  defaultConfig:
+    endpoint_mode: envoy
+    endpoint: http://ext-auth-server.higress-conformance-infra.svc.cluster.local:9000
+    mode: blacklist
+    paths:
+      - /blocked-path
+    method_blacklist:
+      - method: POST
+        paths:
+          - /api
+    timeout: 5s
+    failure_mode_allow: false
+    status_on_error: 403
+    headers_to_upstream:
+      - X

--- a/test/e2e/conformance/tests/ext_auth_blacklist_forward_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth_blacklist_forward_auth.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions.higress.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: ext-auth
+  namespace: higress-system
+spec:
+  phase: AUTHN
+  priority: 100
+  matchRules:
+    - ingress:
+        - higress-conformance-infra/wasmplugin-ext-auth
+  defaultConfig:
+    endpoint_mode: forward_auth
+    endpoint: http://ext-auth-server.higress-conformance-infra.svc.cluster.local:8000
+    mode: blacklist
+    paths:
+      - /blocked-path
+    method_blacklist:
+      - method: POST
+        paths:
+          - /api
+    timeout: 5s
+    failure_mode_allow: false
+    status_on_error: 403
+    headers_to_upstream:
+      - X-Auth-Status

--- a/test/e2e/conformance/tests/ext_auth_plugin.yaml
+++ b/test/e2e/conformance/tests/ext_auth_plugin.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions.higress.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: ext-auth
+  namespace: higress-system
+spec:
+  defaultConfig:
+    endpoint_mode: forward_auth
+    endpoint: http://ext-auth-server.higress-conformance-infra.svc.cluster.local:8000
+    mode: blacklist
+    paths:
+    - /blocked-path
+    method_blacklist:
+    - method: POST
+      paths:
+      - /api
+  matchRules:
+  - ingress:
+    - higress-conformance-infra/wasmplugin-ext-auth

--- a/test/e2e/conformance/tests/ext_auth_plugin.yaml
+++ b/test/e2e/conformance/tests/ext_auth_plugin.yaml
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,23 +18,23 @@ metadata:
   name: ext-auth
   namespace: higress-system
 spec:
+  phase: AUTHN
+  priority: 100
+  matchRules:
+    - ingress:
+        - higress-conformance-infra/wasmplugin-ext-auth
   defaultConfig:
     endpoint_mode: forward_auth
     endpoint: http://ext-auth-server.higress-conformance-infra.svc.cluster.local:8000
     mode: blacklist
     paths:
-    - /blocked-path
+      - /blocked-path
     method_blacklist:
-    - method: POST
-      paths:
-      - /api
-    # Add these settings to improve reliability
+      - method: POST
+        paths:
+          - /api
     timeout: 5s
-    failure_mode_allow: false # Ensures auth failures deny access
-    status_on_error: 403 # Set specific status code on error
-    headers_to_upstream: ["X-Auth-Status"] # Pass auth status header
-  matchRules:
-  - ingress:
-    - higress-conformance-infra/wasmplugin-ext-auth
-  phase: AUTHN
-  priority: 100
+    failure_mode_allow: false
+    status_on_error: 403
+    headers_to_upstream:
+      - X-Auth-Status

--- a/test/e2e/conformance/tests/ext_auth_plugin.yaml
+++ b/test/e2e/conformance/tests/ext_auth_plugin.yaml
@@ -14,6 +14,12 @@ spec:
     - method: POST
       paths:
       - /api
+    # Add timeout and retry configuration
+    timeout: 30s
+    retries: 3
   matchRules:
   - ingress:
     - higress-conformance-infra/wasmplugin-ext-auth
+  # Add plugin phase and priority for proper execution order
+  phase: AUTHN
+  priority: 100

--- a/test/e2e/conformance/tests/ext_auth_plugin.yaml
+++ b/test/e2e/conformance/tests/ext_auth_plugin.yaml
@@ -28,10 +28,11 @@ spec:
     - method: POST
       paths:
       - /api
-    timeout: 15s
-    failure_mode_allow: false  # If auth fails, deny access
+    # Set a reasonable timeout
+    timeout: 5s
   matchRules:
   - ingress:
     - higress-conformance-infra/wasmplugin-ext-auth
+  # Explicitly set the authentication phase
   phase: AUTHN
   priority: 100

--- a/test/e2e/conformance/tests/ext_auth_plugin.yaml
+++ b/test/e2e/conformance/tests/ext_auth_plugin.yaml
@@ -1,3 +1,17 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -14,12 +28,10 @@ spec:
     - method: POST
       paths:
       - /api
-    # Add timeout and retry configuration
-    timeout: 30s
-    retries: 3
+    timeout: 15s
+    failure_mode_allow: false  # If auth fails, deny access
   matchRules:
   - ingress:
     - higress-conformance-infra/wasmplugin-ext-auth
-  # Add plugin phase and priority for proper execution order
   phase: AUTHN
   priority: 100

--- a/test/e2e/conformance/tests/ext_auth_plugin.yaml
+++ b/test/e2e/conformance/tests/ext_auth_plugin.yaml
@@ -28,11 +28,13 @@ spec:
     - method: POST
       paths:
       - /api
-    # Set a reasonable timeout
+    # Add these settings to improve reliability
     timeout: 5s
+    failure_mode_allow: false # Ensures auth failures deny access
+    status_on_error: 403 # Set specific status code on error
+    headers_to_upstream: ["X-Auth-Status"] # Pass auth status header
   matchRules:
   - ingress:
     - higress-conformance-infra/wasmplugin-ext-auth
-  # Explicitly set the authentication phase
   phase: AUTHN
   priority: 100

--- a/test/e2e/conformance/tests/ext_auth_whitelist_envoy.yaml
+++ b/test/e2e/conformance/tests/ext_auth_whitelist_envoy.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions.higress.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: ext-auth
+  namespace: higress-system
+spec:
+  phase: AUTHN
+  priority: 100
+  matchRules:
+    - ingress:
+        - higress-conformance-infra/wasmplugin-ext-auth
+  defaultConfig:
+    endpoint_mode: envoy
+    endpoint: http://ext-auth-server.higress-conformance-infra.svc.cluster.local:9000
+    mode: whitelist
+    paths:
+      - /allowed-path
+    method_whitelist:
+      - method: GET
+        paths:
+          - /api
+    timeout: 5s
+    failure_mode_allow: false
+    status_on_error: 403
+    headers_to_upstream:
+      - X-Auth-Status

--- a/test/e2e/conformance/tests/ext_auth_whitelist_forward_auth.yaml
+++ b/test/e2e/conformance/tests/ext_auth_whitelist_forward_auth.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions.higress.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: ext-auth
+  namespace: higress-system
+spec:
+  phase: AUTHN
+  priority: 100
+  matchRules:
+    - ingress:
+        - higress-conformance-infra/wasmplugin-ext-auth
+  defaultConfig:
+    endpoint_mode: forward_auth
+    endpoint: http://ext-auth-server.higress-conformance-infra.svc.cluster.local:8000
+    mode: whitelist
+    paths:
+      - /allowed-path
+    method_whitelist:
+      - method: GET
+        paths:
+          - /api
+    timeout: 5s
+    failure_mode_allow: false
+    status_on_error: 403
+    headers_to_upstream:
+      - X-Auth-Status


### PR DESCRIPTION
 Add a new ext-auth wasm plugin along with test configurations to validate its functionality.
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Add a new ext-auth wasm plugin along with test configurations to validate its functionality.
