### PR TITLE
[HIGRESS#2285] Enhance the e2e testing of the moder-mapper plugin bas…

### DIFF
--- a/test/e2e/conformance/tests/cpp-wasm-model-mapper.go
+++ b/test/e2e/conformance/tests/cpp-wasm-model-mapper.go
@@ -1,0 +1,189 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/test/e2e/conformance/utils/http"
+	"github.com/alibaba/higress/test/e2e/conformance/utils/suite"
+)
+
+func init() {
+	Register(WasmPluginsModelMapper)
+}
+
+var WasmPluginsModelMapper = suite.ConformanceTest{
+	ShortName:   "WasmPluginModelMapper",
+	Description: "The Ingress in the higress-conformance-ai-backend namespace tests the model-mapper WASM plugin.",
+	Features:    []suite.SupportedFeature{suite.WASMCPPConformanceFeature},
+	Manifests:   []string{"tests/cpp-wasm-model-mapper.yaml"},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		testcases := []http.Assertion{
+			{
+				// 测试精确匹配: gpt-4o -> qwen-vl-plus
+				Meta: http.AssertionMeta{
+					TestCaseName:  "model mapper case 1: exact match",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "foo.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"qwen-vl-plus","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+			},
+			{
+				// 测试前缀匹配: gpt-4-1106-preview -> qwen-max
+				Meta: http.AssertionMeta{
+					TestCaseName:  "model mapper case 2: prefix match",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "foo.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-4-1106-preview","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"qwen-max","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+			},
+			{
+				// 测试默认匹配: claude-2 -> qwen-turbo
+				Meta: http.AssertionMeta{
+					TestCaseName:  "model mapper case 3: default match",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "foo.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"claude-2","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"qwen-turbo","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+			},
+			{
+				// 测试保留原值: text-embedding-v1 -> text-embedding-v1 (不改变)
+				Meta: http.AssertionMeta{
+					TestCaseName:  "model mapper case 4: keep original value",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "foo.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"text-embedding-v1","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"text-embedding-v1","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+			},
+			{
+				// 测试自定义 modelKey 配置: engine -> qwen-turbo
+				Meta: http.AssertionMeta{
+					TestCaseName:  "model mapper case 5: custom model key",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "model-mapper-custom-key.example.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"engine":"davinci","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"engine":"qwen-turbo","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+			},
+			{
+				// 测试路径匹配: 非配置的路径不进行处理
+				Meta: http.AssertionMeta{
+					TestCaseName:  "model mapper case 6: path not match",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "foo.com",
+						Path:        "/v1/embeddings",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+			},
+			{
+				// 测试路径自定义匹配：使用自定义路径后缀
+				Meta: http.AssertionMeta{
+					TestCaseName:  "model mapper case 7: custom path match",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "foo.com",
+						Path:        "/api/custom/endpoint",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"qwen-vl-plus","messages":[{"role":"user","content":"测试消息"}]}`),
+					},
+				},
+			},
+		}
+		t.Run("WasmPlugins model-mapper", func(t *testing.T) {
+			for _, testcase := range testcases {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcase)
+			}
+		})
+	},
+}

--- a/test/e2e/conformance/tests/cpp-wasm-model-mapper.go
+++ b/test/e2e/conformance/tests/cpp-wasm-model-mapper.go
@@ -118,7 +118,7 @@ var WasmPluginsModelMapper = suite.ConformanceTest{
 				},
 				Request: http.AssertionRequest{
 					ActualRequest: http.Request{
-						Host:        "model-mapper-custom-key.example.com",
+						Host:        "foo.com",
 						Path:        "/v1/chat/completions",
 						Method:      "POST",
 						ContentType: http.ContentTypeApplicationJson,

--- a/test/e2e/conformance/tests/cpp-wasm-model-mapper.yaml
+++ b/test/e2e/conformance/tests/cpp-wasm-model-mapper.yaml
@@ -86,3 +86,4 @@ spec:
         enableOnPathSuffix: ["/api/custom/endpoint"]
       ingress:
         - higress-conformance-ai-backend/wasmplugin-model-mapper-custom-path
+  url: oci://higress-registry.cn-hangzhou.cr.aliyuncs.com/plugins/model-mapper:1.0.0

--- a/test/e2e/conformance/tests/cpp-wasm-model-mapper.yaml
+++ b/test/e2e/conformance/tests/cpp-wasm-model-mapper.yaml
@@ -1,0 +1,88 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-model-mapper
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "model-mapper.example.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-model-mapper-custom-key
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "model-mapper-custom-key.example.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-model-mapper-custom-path
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "model-mapper-custom-path.example.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: extensions.higress.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: model-mapper
+  namespace: higress-system
+spec:
+  defaultConfigDisable: true
+  phase: UNSPECIFIED_PHASE
+  priority: 100
+  matchRules:
+    - config:
+        modelMapping:
+          'gpt-4-*': "qwen-max"
+          'gpt-4o': "qwen-vl-plus"
+          'text-embedding-v1': ""
+          '*': "qwen-turbo"
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-model-mapper
+    - config:
+        modelKey: "engine"
+        modelMapping:
+          '*': "qwen-turbo"
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-model-mapper-custom-key
+    - config:
+        modelMapping:
+          'gpt-4o': "qwen-vl-plus"
+          '*': "qwen-turbo"
+        enableOnPathSuffix: ["/api/custom/endpoint"]
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-model-mapper-custom-path

--- a/test/e2e/conformance/tests/cpp-wasm-model-mapper.yaml
+++ b/test/e2e/conformance/tests/cpp-wasm-model-mapper.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ingressClassName: higress
   rules:
-    - host: "model-mapper.example.com"
+    - host: "foo.com"
       http:
         paths:
           - pathType: Prefix
@@ -25,7 +25,7 @@ metadata:
 spec:
   ingressClassName: higress
   rules:
-    - host: "model-mapper-custom-key.example.com"
+    - host: "foo.com"
       http:
         paths:
           - pathType: Prefix
@@ -44,7 +44,7 @@ metadata:
 spec:
   ingressClassName: higress
   rules:
-    - host: "model-mapper-custom-path.example.com"
+    - host: "foo.com"
       http:
         paths:
           - pathType: Prefix


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Related to [HIGRESS#2285](https://github.com/alibaba/higress/issues/2285)
Enhance the e2e testing of the moder-mapper plugin based on the LLM mock server

### Ⅱ. Does this pull request fix one issue?


 - Exact match: Test that when the model parameter in the request matches the exact match rule in the configuration, it can be correctly replaced with the target value 

 - Prefix match: Test that when the model parameter in the request matches the prefix match rule in the configuration, it can be correctly replaced with the target value 

 - Default match: Test whether the default match rule is used when no rule matches

 - Keep original value: Test whether the original model value is retained when the mapping target is an empty string 

 - Custom model parameter key: Test whether the modelKey configuration is effective 

 - Path match: Test that only requests with a specific path suffix are processed

 - Custom path match: Test whether the path suffix of the custom configuration is effective

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

