### PR TITLE
ai-token-ratelimit: support rate limiting based on the number of request

### DIFF
--- a/plugins/wasm-go/extensions/ai-token-ratelimit/README.md
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/README.md
@@ -41,13 +41,15 @@ description: AI Token限流插件配置参考
 
 `limit_keys`中每一项的配置字段说明
 
-| 配置项           | 类型   | 必填                                                         | 默认值 | 说明                                                         |
-| ---------------- | ------ | ------------------------------------------------------------ | ------ | ------------------------------------------------------------ |
-| key              | string | 是                                                           | -      | 匹配的键值，`limit_by_per_header`,`limit_by_per_param`,`limit_by_per_consumer`,`limit_by_per_cookie` 类型支持配置正则表达式（以regexp:开头后面跟正则表达式）或者*（代表所有），正则表达式示例：`regexp:^d.*`（以d开头的所有字符串）；`limit_by_per_ip`支持配置 IP 地址或 IP 段 |
-| token_per_second | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每秒请求token数                                             |
-| token_per_minute | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每分钟请求token数                                           |
-| token_per_hour   | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每小时请求token数                                           |
-| token_per_day    | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每天请求token数                                             |
+
+| 配置项           | 类型   | 必填                                                                                  | 默认值 | 说明                                                                                                                                                                                                                                                                           |
+| ---------------- | ------ | ------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| key              | string | 是                                                                                    | -      | 匹配的键值，`limit_by_per_header`,`limit_by_per_param`,`limit_by_per_consumer`,`limit_by_per_cookie` 类型支持配置正则表达式（以regexp:开头后面跟正则表达式）或者*（代表所有），正则表达式示例：`regexp:^d.*`（以d开头的所有字符串）；`limit_by_per_ip`支持配置 IP 地址或 IP 段 |
+| limit_type |  string | 否 | token | 限流模式， `request` 时基于请求数限流, `token` 时基于 AI token 数限流 |
+| token_per_second | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每秒请求`token/request`数（由 `limit_type`类型决定）                                                                                                                                                                                                                                                            |
+| token_per_minute | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每分钟请求`token/request`数（由 `limit_type` 类型决定）                                                                                                                                                                                                                                                              |
+| token_per_hour   | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每小时请求`token/request`数（由 `limit_type`类型决定）                                                                                                                                                                                                                                                         |
+| token_per_day    | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每天请求`token/request`数（由 `limit_type`类型决定）                                                                                                                                                                                                                                                              |
 
 `redis`中每一项的配置字段说明
 
@@ -63,7 +65,7 @@ description: AI Token限流插件配置参考
 
 ## 配置示例
 
-### 识别请求参数 apikey，进行区别限流
+### 识别请求参数 apikey，进行区别 AI token 限流
 
 ```yaml
 rule_name: default_rule
@@ -89,9 +91,35 @@ redis:
   service_name: redis.static
 ```
 
+相应的，基于请求数限流，只需在 `limit_keys`中添加 `limit_mode`: request，如下所示：
+```yaml
+rule_name: default_rule
+rule_items:
+  - limit_by_param: apikey
+    limit_keys:
+      - key: 9a342114-ba8a-11ec-b1bf-00163e1250b5
+        token_per_minute: 10
+        limit_type: request
+      - key: a6a6d7f2-ba8a-11ec-bec2-00163e1250b5
+        token_per_hour: 100
+        limit_type: request
+  - limit_by_per_param: apikey
+    limit_keys:
+      - key: "regexp:^a.*"
+        token_per_second: 10
+        limit_type: request
+      - key: "regexp:^b.*"
+        token_per_minute: 100
+        limit_type: request
+      - key: "*"
+        token_per_hour: 1000
+        limit_type: request
+redis:
+  service_name: redis.static
+```
 
 
-### 识别请求头 x-ca-key，进行区别限流
+### 识别请求头 x-ca-key，进行区别 AI token 限流
 
 ```yaml
 rule_name: default_rule
@@ -119,7 +147,7 @@ redis:
 
 
 
-### 根据请求头 x-forwarded-for 获取对端IP，进行区别限流
+### 根据请求头 x-forwarded-for 获取对端IP，进行区别 AI token 限流
 
 ```yaml
 rule_name: default_rule
@@ -167,7 +195,7 @@ redis:
 
 
 
-### 识别cookie中的键值对，进行区别限流
+### 识别cookie中的键值对，进行区别 AI token 限流
 
 ```yaml
 rule_name: default_rule

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/README.md
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/README.md
@@ -91,7 +91,7 @@ redis:
   service_name: redis.static
 ```
 
-相应的，基于请求数限流，只需在 `limit_keys`中添加 `limit_mode`: request，如下所示：
+相应的，基于请求数限流，只需在 `limit_keys`中添加 `limit_type`: request，如下所示：
 ```yaml
 rule_name: default_rule
 rule_items:

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/README_EN.md
@@ -37,10 +37,11 @@ Field descriptions for each item in `limit_keys`
 | Configuration Item      | Type              | Required                                    | Default Value | Description                                     |
 | ----------------------- | ----------------- | ------------------------------------------- | ------------- | ----------------------------------------------- |
 | key                     | string            | Yes                                         | -             | Matched key value. Types `limit_by_per_header`, `limit_by_per_param`, `limit_by_per_consumer`, `limit_by_per_cookie` support configuring regular expressions (beginning with regexp: followed by the regex) or `*` (representing all). Example regex: `regexp:^d.*` (all strings starting with d); `limit_by_per_ip` supports configuring IP addresses or IP segments |
-| token_per_second        | int               | No, optionally select one in `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` | -             | Allowed number of token requests per second     |
-| token_per_minute       | int               | No, optionally select one in `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` | -             | Allowed number of token requests per minute     |
-| token_per_hour         | int               | No, optionally select one in `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` | -             | Allowed number of token requests per hour       |
-| token_per_day          | int               | No, optionally select one in `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` | -             | Allowed number of token requests per day        |
+| limit_type |  string | NO | token | limit type， `request` limit base on request, `token` limit base on AI token |
+| token_per_second        | int               | No, optionally select one in `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` | -             | Allowed number of token/request  per second (decided by `limit_type`)    |
+| token_per_minute       | int               | No, optionally select one in `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` | -             | Allowed number of token/request per minute (decided by `limit_type`)     |
+| token_per_hour         | int               | No, optionally select one in `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` | -             | Allowed number of token/request per hour  (decided by `limit_type`)      |
+| token_per_day          | int               | No, optionally select one in `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` | -             | Allowed number of token/request per day  (decided by `limit_type`)       |
 
 Field descriptions for each item in `redis`
 | Configuration Item      | Type              | Required | Default Value                                                                    | Description                                                                                                    |
@@ -77,6 +78,34 @@ rule_items:
 redis:
   service_name: redis.static
 ```
+
+Correspondingly, ratelimit based on the number of requests, just add `limit_mode`: request in `limit_keys`, as shown below:
+```yaml
+rule_name: default_rule
+rule_items:
+  - limit_by_param: apikey
+    limit_keys:
+      - key: 9a342114-ba8a-11ec-b1bf-00163e1250b5
+        token_per_minute: 10
+        limit_type: request
+      - key: a6a6d7f2-ba8a-11ec-bec2-00163e1250b5
+        token_per_hour: 100
+        limit_type: request
+  - limit_by_per_param: apikey
+    limit_keys:
+      - key: "regexp:^a.*"
+        token_per_second: 10
+        limit_type: request
+      - key: "regexp:^b.*"
+        token_per_minute: 100
+        limit_type: request
+      - key: "*"
+        token_per_hour: 1000
+        limit_type: request
+redis:
+  service_name: redis.static
+```
+
 ### Identify request header x-ca-key for differentiated rate limiting
 ```yaml
 rule_name: default_rule

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/README_EN.md
@@ -79,7 +79,7 @@ redis:
   service_name: redis.static
 ```
 
-Correspondingly, ratelimit based on the number of requests, just add `limit_mode`: request in `limit_keys`, as shown below:
+Correspondingly, ratelimit based on the number of requests, just add `limit_type`: request in `limit_keys`, as shown below:
 ```yaml
 rule_name: default_rule
 rule_items:

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/go.mod
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56 // indirect
 	github.com/tetratelabs/wazero v1.7.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 )
 
 require (

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/go.sum
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/go.sum
@@ -13,6 +13,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/tetratelabs/wazero v1.7.1 h1:QtSfd6KLc41DIMpDYlJdoMc6k7QTN246DM2+n2Y/Dx8=
 github.com/tetratelabs/wazero v1.7.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.17.3 h1:bwWLZU7icoKRG+C+0PNwIKC6FCJO/Q3p2pZvuP0jN94=
 github.com/tidwall/gjson v1.17.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -21,6 +22,8 @@ github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/resp v0.1.1 h1:Ly20wkhqKTmDUPlyM1S7pWo5kk0tDu8OoC/vFArXmwE=
 github.com/tidwall/resp v0.1.1/go.mod h1:3/FrruOBAxPTPtundW0VXgmsQ4ZBA0Aw714lVYgwFa0=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/wasilibs/go-re2 v1.5.3 h1:wiuTcgDZdLhu8NG8oqF5sF5Q3yIU14lPAvXqeYzDK3g=
 github.com/wasilibs/go-re2 v1.5.3/go.mod h1:PzpVPsBdFC7vM8QJbbEnOeTmwA0DGE783d/Gex8eCV8=
 github.com/wasilibs/nottinygc v0.4.0 h1:h1TJMihMC4neN6Zq+WKpLxgd9xCFMw7O9ETLwY2exJQ=


### PR DESCRIPTION

### Ⅰ. Describe what this PR did
A minor change enables the ai-token-ratelimit  plugin to support both token-based limiting and request-based  limiting(The two plugins ai-token-ratelimit and cluster-key-rate-limit have 90% of the same code. Consider maintaining only one plugin.)

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

