### PR TITLE
fix: set "EnableSemanticCachefalse" to false when no vector configured in ai-cache

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/config/config.go
+++ b/plugins/wasm-go/extensions/ai-cache/config/config.go
@@ -90,6 +90,8 @@ func (c *PluginConfig) FromJson(json gjson.Result, log wrapper.Log) {
 
 	if json.Get("enableSemanticCache").Exists() {
 		c.EnableSemanticCache = json.Get("enableSemanticCache").Bool()
+	} else if c.GetVectorProvider() == nil {
+		c.EnableSemanticCache = false	// set value to false when no vector provider 
 	} else {
 		c.EnableSemanticCache = true // set default value to true
 	}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Set "EnableSemanticCachefalse" to false when no vector configured in ai-cache, which avoids error log in `handleResponse`

https://github.com/alibaba/higress/blob/main/plugins/wasm-go/extensions/ai-cache/core.go#52


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

