### PR TITLE
fix ai token ratelimit request header phase

### DIFF
--- a/plugins/wasm-go/extensions/ai-token-ratelimit/main.go
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/main.go
@@ -140,7 +140,7 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config ClusterKeyRateLimitCon
 		log.Errorf("redis call failed: %v", err)
 		return types.ActionContinue
 	}
-	return types.ActionPause
+	return types.HeaderStopAllIterationAndBuffer
 }
 
 func onHttpStreamingBody(ctx wrapper.HttpContext, config ClusterKeyRateLimitConfig, data []byte, endOfStream bool, log wrapper.Log) []byte {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

ai-token-ratelimit should return `HeaderStopAllIterationAndBuffer` at request header phase,  since it will return `Continue` default at request body phase, which will resume the filter chain before redis call back.

### Ⅱ. Does this pull request fix one issue?

fixes #2215 

