### PR TITLE
feat(ai-proxy): 修复 openai 配置 openaiCustomUrl 之后, 对不支持 Api 透传路径错误的问题 || feat(ai-proxy): Fixed the issue that the API pass-through path error does not support openaiCustomUrl after openai is configured.

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
@@ -101,15 +101,10 @@ func (m *openaiProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 }
 
 func (m *openaiProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
-	if m.customPath != "" {
-		if m.isDirectCustomPath || apiName == "" {
-			util.OverwriteRequestPathHeader(headers, m.customPath)
-		} else {
-			util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), m.config.capabilities)
-		}
-	} else {
+	if m.customPath != "" && !m.isDirectCustomPath && apiName != "" {
 		util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), m.config.capabilities)
 	}
+
 	if m.customDomain != "" {
 		util.OverwriteRequestHostHeader(headers, m.customDomain)
 	} else {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
@@ -40,6 +40,7 @@ func (m *openaiProviderInitializer) DefaultCapabilities() map[string]string {
 		string(ApiNameBatches):             PathOpenAIBatches,
 		string(ApiNameRetrieveBatch):       PathOpenAIRetrieveBatch,
 		string(ApiNameCancelBatch):         PathOpenAICancelBatch,
+		string(ApiNameResponses):           PathOpenAIResponses,
 	}
 }
 
@@ -50,7 +51,8 @@ func isDirectPath(path string) bool {
 		strings.HasSuffix(path, "/images/generations") ||
 		strings.HasSuffix(path, "/images/variations") ||
 		strings.HasSuffix(path, "/images/edits") ||
-		strings.HasSuffix(path, "/models")
+		strings.HasSuffix(path, "/models") ||
+		strings.HasSuffix(path, "/responses")
 }
 
 func (m *openaiProviderInitializer) CreateProvider(config ProviderConfig) (Provider, error) {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
@@ -47,7 +47,10 @@ func isDirectPath(path string) bool {
 	return strings.HasSuffix(path, "/completions") ||
 		strings.HasSuffix(path, "/embeddings") ||
 		strings.HasSuffix(path, "/audio/speech") ||
-		strings.HasSuffix(path, "/images/generations")
+		strings.HasSuffix(path, "/images/generations") ||
+		strings.HasSuffix(path, "/images/variations") ||
+		strings.HasSuffix(path, "/images/edits") ||
+		strings.HasSuffix(path, "/models")
 }
 
 func (m *openaiProviderInitializer) CreateProvider(config ProviderConfig) (Provider, error) {
@@ -101,7 +104,11 @@ func (m *openaiProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 }
 
 func (m *openaiProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
-	if m.customPath != "" && !m.isDirectCustomPath && apiName != "" {
+	if m.isDirectCustomPath {
+		util.OverwriteRequestPathHeader(headers, m.customPath)
+	}
+
+	if apiName != "" {
 		util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), m.config.capabilities)
 	}
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -41,6 +41,7 @@ const (
 	ApiNameRetrieveBatch       ApiName = "openai/v1/retrievebatch"
 	ApiNameCancelBatch         ApiName = "openai/v1/cancelbatch"
 	ApiNameModels              ApiName = "openai/v1/models"
+	ApiNameResponses           ApiName = "openai/v1/responses"
 
 	PathOpenAICompletions         = "/v1/completions"
 	PathOpenAIChatCompletions     = "/v1/chat/completions"
@@ -56,6 +57,7 @@ const (
 	PathOpenAIImageEdit           = "/v1/images/edits"
 	PathOpenAIImageVariation      = "/v1/images/variations"
 	PathOpenAIAudioSpeech         = "/v1/audio/speech"
+	PathOpenAIResponses           = "/v1/responses"
 
 	// TODO: 以下是一些非标准的API名称，需要进一步确认是否支持
 	ApiNameCohereV1Rerank ApiName = "cohere/v1/rerank"


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews


<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
<!-- Please make sure you have read and understand the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)?


### Ⅳ. Describe how to verify it


### V. Special notes for reviews
