### PR TITLE
feat: support for wanxiang image/video generation in ai-proxy & ai-statistics

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -58,6 +58,8 @@ const (
 
 	// TODO: 以下是一些非标准的API名称，需要进一步确认是否支持
 	ApiNameCohereV1Rerank ApiName = "cohere/v1/rerank"
+	ApiNameQwenAsyncAIGC ApiName = "api/v1/services/aigc"
+	ApiNameQwenAsyncTask ApiName = "api/v1/tasks/"
 
 	providerTypeMoonshot   = "moonshot"
 	providerTypeAzure      = "azure"

--- a/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
@@ -694,9 +694,9 @@ func (m *qwenProvider) GetApiName(path string) ApiName {
 	case strings.Contains(path, qwenTextEmbeddingPath),
 		strings.Contains(path, qwenCompatibleTextEmbeddingPath):
 		return ApiNameEmbeddings
-	case strings.Contains(path, "/api/v1/services/aigc"):
+	case strings.Contains(path, qwenAsyncAIGCPath):
 		return ApiNameQwenAsyncAIGC
-	case strings.Contains(path, "/api/v1/tasks/"):
+	case strings.Contains(path, qwenAsyncTaskPath):
 		return ApiNameQwenAsyncTask
 	default:
 		return ""

--- a/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
@@ -37,6 +37,9 @@ const (
 	qwenBailianPath                       = "/api/v1/apps"
 	qwenMultimodalGenerationPath          = "/api/v1/services/aigc/multimodal-generation/generation"
 
+	qwenAsyncAIGCPath                     = "/api/v1/services/aigc/"
+	qwenAsyncTaskPath                     = "/api/v1/tasks/"
+
 	qwenTopPMin = 0.000001
 	qwenTopPMax = 0.999999
 
@@ -74,6 +77,8 @@ func (m *qwenProviderInitializer) DefaultCapabilities(qwenEnableCompatible bool)
 		return map[string]string{
 			string(ApiNameChatCompletion): qwenChatCompletionPath,
 			string(ApiNameEmbeddings):     qwenTextEmbeddingPath,
+			string(ApiNameQwenAsyncAIGC): qwenAsyncAIGCPath,
+			string(ApiNameQwenAsyncTask): qwenAsyncTaskPath,
 		}
 	}
 }
@@ -689,6 +694,10 @@ func (m *qwenProvider) GetApiName(path string) ApiName {
 	case strings.Contains(path, qwenTextEmbeddingPath),
 		strings.Contains(path, qwenCompatibleTextEmbeddingPath):
 		return ApiNameEmbeddings
+	case strings.Contains(path, "/api/v1/services/aigc"):
+		return ApiNameQwenAsyncAIGC
+	case strings.Contains(path, "/api/v1/tasks/"):
+		return ApiNameQwenAsyncTask
 	default:
 		return ""
 	}

--- a/plugins/wasm-go/extensions/ai-statistics/README.md
+++ b/plugins/wasm-go/extensions/ai-statistics/README.md
@@ -23,6 +23,7 @@ description: AI可观测配置参考
 | 名称             | 数据类型  | 填写要求 | 默认值 | 描述                     |
 |----------------|-------|------|-----|------------------------|
 | `attributes` | []Attribute | 非必填  | -   | 用户希望记录在log/span中的信息 |
+| `disableOpenaiUsage` | bool | 非必填  | false   | 非openai兼容协议时，model、token的支持非标，配置为true时可以避免报错 |
 
 Attribute 配置说明:
 

--- a/plugins/wasm-go/extensions/ai-statistics/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-statistics/README_EN.md
@@ -22,7 +22,8 @@ Users can also expand observable values ​​through configuration:
 
 | Name             | Type  | Required | Default | Description |
 |----------------|-------|------|-----|------------------------|
-| `attributes` | []Attribute | required  | -   | Information that the user wants to record in log/span |
+| `attributes` | []Attribute | optional  | -   | Information that the user wants to record in log/span |
+| `disableOpenaiUsage` | bool | optional  | false   | When using a non-OpenAI-compatible protocol, the support for model and token is non-standard. Setting the configuration to true can prevent errors. |
 
 Attribute Configuration instructions:
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

support for wanx image/video generation in ai-proxy & ai-statistics

1. In **ai-proxy**, add the WANX AIGC async submit and query paths.
2. In **ai-statistics**, add the `disableOpenaiUsage` config to prevent errors related to OpenAI model and token extraction in logs.
- The default value of `disableOpenaiUsage` is false, so existing configurations will not be affected.


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it
use yaml below, and test with such requests: 

```bash
curl --location 'localhost:8080/api/v1/services/aigc/text2image/image-synthesis' \
--header 'Content-Type: application/json' \
--header 'X-DashScope-Async: enable' \
--data '{
        "model": "wanx2.1-t2i-turbo",
        "input": {
            "prompt": "生成一张由写实风格的家具图像描述的是书房的布置。其中正在下雪，室内有火炉，窗外有摇曳的树木；书桌靠着窗户，书桌上有正在阅读的书和没吃完的甜品；书桌旁边挨着床，床上还没有叠被子"
        },
        "parameters": {
            "size": "1024*1024",
            "n": 1
        }
    }'

curl --location 'localhost:8080/api/v1/services/aigc/video-generation/video-synthesis' \
--header 'Content-Type: application/json' \
--header 'X-DashScope-Async: enable' \
--data '{
    "model": "wanx2.1-t2v-turbo",
    "input": {
        "prompt": "一只小猫在月光下奔跑"
    },
    "parameters": {
        "size": "1280*720"
    }
}'

# replace with above task_id
curl --location 'localhost:8080/api/v1/tasks/{task_id}'

```

```yaml
admin:
  profile_path: /dev/null
  access_log_path: /workspaces/envoy/log/run_access.log
  address:
    socket_address:
      address: 0.0.0.0
      port_value: 15000

static_resources:
  listeners:
  - address:
      socket_address:
        address: 0.0.0.0
        port_value: 8080
    filter_chains:
    - filters:
      - name: envoy.filters.network.http_connection_manager
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
          scheme_header_transformation:
            scheme_to_overwrite: https
          stat_prefix: ingress_http
          # Output envoy logs to stdout
          access_log:
          - name: envoy.access_loggers.file
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
              log_format:
                text_format_source:
                  inline_string: "{\"ai_log\":\"%FILTER_STATE(wasm.ai_log:PLAIN)%\"\n"
              path: /dev/stdout
          # Modify as required
          route_config:
            name: local_route
            virtual_hosts:
              - name: local_service
                domains: ["*"]
                routes:
                - name: submit_task
                  match:
                    prefix: "/api/v1/services/aigc/"
                  route:
                    cluster: dashscope
                    timeout: 300s
                - name: get_task
                  match:
                    prefix: "/api/v1/tasks"
                  route:
                    cluster: dashscope
                    timeout: 300s
          http_filters:
          - name: envoy.filters.http.wasm
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
              config:
                name: "ai-statistics"
                root_id: ""
                vm_config:
                  vm_id: "f1"
                  code:
                    local: 
                      filename: "/workspaces/envoy/stat.wasm"
                  runtime: "envoy.wasm.runtime.v8"
                  allow_precompiled: "true"
                configuration: 
                  "@type": "type.googleapis.com/google.protobuf.StringValue"
                  value: |
                    {
                      "_rules_": [
                        {
                          "_match_route_prefix_": [
                            "submit_task"
                          ],
                          "disable_openai_usage": true,
                          "attributes": [
                            {
                              "apply_to_log": true,
                              "key": "question",
                              "value": "input",
                              "value_source": "request_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "answer",
                              "value": "output.task_id",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "chat_id",
                              "value": "request_id",
                              "value_source": "response_body"
                            }
                          ]
                        },
                        {
                          "_match_route_prefix_": [
                            "get_task"
                          ],
                          "disable_openai_usage": true,
                          "attributes": [
                            {
                              "apply_to_log": true,
                              "key": "question",
                              "value": "output.task_id",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "answer",
                              "value": "output.task_status",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "chat_id",
                              "value": "request_id",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "image_result",
                              "value": "output.results",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "image_count",
                              "value": "usage.image_count",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "video_result",
                              "value": "output.video_url",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "video_duration_second",
                              "value": "usage.video_duration",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "async_llm_submit_time",
                              "value": "output.submit_time",
                              "value_source": "response_body"
                            },
                            {
                              "apply_to_log": true,
                              "key": "async_llm_finish_time",
                              "value": "output.end_time",
                              "value_source": "response_body"
                            }
                          ]
                        }
                      ]
                    }
          - name: envoy.filters.http.wasm
            typed_config:
              "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
              config:
                name: "ai-proxy"
                root_id: ""
                vm_config:
                  vm_id: "f2"
                  code:
                    local: 
                      filename: "/workspaces/envoy/plugin.wasm"
                  runtime: "envoy.wasm.runtime.v8"
                  allow_precompiled: "true"
                configuration: 
                  "@type": "type.googleapis.com/google.protobuf.StringValue"
                  value: |
                    {
                      "provider": {
                          "type": "qwen",
                          "apiTokens": [
                              "sk-xxxxxxxxxxxxx"
                          ],
                          "protocol": "original"
                      }
                    }
          - name: envoy.filters.http.router
            typed_config:
              '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
  clusters:
  - name: dashscope
    connect_timeout: 30s
    type: LOGICAL_DNS
    dns_lookup_family: V4_ONLY
    lb_policy: ROUND_ROBIN
    load_assignment:
      cluster_name: dashscope
      endpoints:
        - lb_endpoints:
            - endpoint:
                address:
                  socket_address:
                    address: dashscope.aliyuncs.com
                    port_value: 443
    transport_socket:
      name: envoy.transport_sockets.tls
      typed_config:
        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
        "sni": "dashscope.aliyuncs.com"
```




### Ⅴ. Special notes for reviews

