### PR TITLE
feat(ai-proxy): 添加 Claude 图片理解与 Tools 调用能力 || feat(ai-proxy): Add Claude image understanding and Tools calling capabilities

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -20,8 +20,10 @@ const (
 
 	httpStatus200 = "200"
 
-	contentTypeText     = "text"
-	contentTypeImageUrl = "image_url"
+	contentTypeText       = "text"
+	contentTypeImageUrl   = "image_url"
+	contentTypeInputAudio = "input_audio"
+	contentTypeFile       = "file"
 
 	reasoningStartTag = "<think>"
 	reasoningEndTag   = "</think>"
@@ -53,9 +55,38 @@ type chatCompletionRequest struct {
 	Temperature         float64                `json:"temperature,omitempty"`
 	TopP                float64                `json:"top_p,omitempty"`
 	Tools               []tool                 `json:"tools,omitempty"`
-	ToolChoice          *toolChoice            `json:"tool_choice,omitempty"`
+	ToolChoice          interface{}            `json:"tool_choice,omitempty"`
 	ParallelToolCalls   bool                   `json:"parallel_tool_calls,omitempty"`
 	User                string                 `json:"user,omitempty"`
+}
+
+func (c *chatCompletionRequest) getMaxTokens() int {
+	if c.MaxCompletionTokens > 0 {
+		return c.MaxCompletionTokens
+	}
+	return c.MaxTokens
+}
+
+func (c *chatCompletionRequest) getToolChoiceString() string {
+	if c.ToolChoice == nil {
+		return ""
+	}
+
+	if tc, ok := c.ToolChoice.(string); ok {
+		return tc
+	}
+	return ""
+}
+
+func (c *chatCompletionRequest) getToolChoiceObject() *toolChoice {
+	if c.ToolChoice == nil {
+		return nil
+	}
+
+	if tc, ok := c.ToolChoice.(*toolChoice); ok {
+		return tc
+	}
+	return nil
 }
 
 type CompletionRequest struct {
@@ -200,13 +231,26 @@ func (m *chatMessage) handleStreamingReasoningContent(ctx wrapper.HttpContext, r
 	}
 }
 
-type messageContent struct {
-	Type     string    `json:"type,omitempty"`
-	Text     string    `json:"text"`
-	ImageUrl *imageUrl `json:"image_url,omitempty"`
+type chatMessageContent struct {
+	Type       string                      `json:"type,omitempty"`
+	Text       string                      `json:"text"`
+	ImageUrl   *chatMessageContentImageUrl `json:"image_url,omitempty"`
+	File       *chatMessageContentFile     `json:"file,omitempty"`
+	InputAudio *chatMessageContentAudio    `json:"input_audio,omitempty"`
 }
 
-type imageUrl struct {
+type chatMessageContentAudio struct {
+	Data   string `json:"data"`
+	Format string `json:"format"`
+}
+
+type chatMessageContentFile struct {
+	FileData string `json:"file_data,omitempty"`
+	FileId   string `json:"file_id,omitempty"`
+	FileName string `json:"file_name,omitempty"`
+}
+
+type chatMessageContentImageUrl struct {
 	Url    string `json:"url,omitempty"`
 	Detail string `json:"detail,omitempty"`
 }
@@ -266,11 +310,11 @@ func (m *chatMessage) StringContent() string {
 	return ""
 }
 
-func (m *chatMessage) ParseContent() []messageContent {
-	var contentList []messageContent
+func (m *chatMessage) ParseContent() []chatMessageContent {
+	var contentList []chatMessageContent
 	content, ok := m.Content.(string)
 	if ok {
-		contentList = append(contentList, messageContent{
+		contentList = append(contentList, chatMessageContent{
 			Type: contentTypeText,
 			Text: content,
 		})
@@ -286,17 +330,42 @@ func (m *chatMessage) ParseContent() []messageContent {
 			switch contentMap["type"] {
 			case contentTypeText:
 				if subStr, ok := contentMap[contentTypeText].(string); ok {
-					contentList = append(contentList, messageContent{
+					contentList = append(contentList, chatMessageContent{
 						Type: contentTypeText,
 						Text: subStr,
 					})
 				}
 			case contentTypeImageUrl:
 				if subObj, ok := contentMap[contentTypeImageUrl].(map[string]any); ok {
-					contentList = append(contentList, messageContent{
+					msg := chatMessageContent{
 						Type: contentTypeImageUrl,
-						ImageUrl: &imageUrl{
+						ImageUrl: &chatMessageContentImageUrl{
 							Url: subObj["url"].(string),
+						},
+					}
+					if detail, ok := subObj["detail"].(string); ok {
+						msg.ImageUrl.Detail = detail
+					}
+					contentList = append(contentList, msg)
+				}
+			case contentTypeInputAudio:
+				if subObj, ok := contentMap[contentTypeInputAudio].(map[string]any); ok {
+					contentList = append(contentList, chatMessageContent{
+						Type: contentTypeInputAudio,
+						InputAudio: &chatMessageContentAudio{
+							Data:   subObj["data"].(string),
+							Format: subObj["format"].(string),
+						},
+					})
+				}
+			case contentTypeFile:
+				if subObj, ok := contentMap[contentTypeFile].(map[string]any); ok {
+					contentList = append(contentList, chatMessageContent{
+						Type: contentTypeFile,
+						File: &chatMessageContentFile{
+							FileId: subObj["file_id"].(string),
+							// FileName: subObj["file_name"].(string),
+							// FileData: subObj["file_data"].(string),
 						},
 					})
 				}

--- a/plugins/wasm-go/extensions/ai-proxy/util/http.go
+++ b/plugins/wasm-go/extensions/ai-proxy/util/http.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/alibaba/higress/plugins/wasm-go/pkg/log"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 )
 
@@ -109,6 +110,7 @@ func OverwriteRequestPathHeaderByCapability(headers http.Header, apiName string,
 		}
 	}
 	headers.Set(":path", mappedPath)
+	log.Debugf("[OverwriteRequestPath] originPath=%s, mappedPath=%s", originPath, mappedPath)
 }
 
 func OverwriteRequestAuthorizationHeader(headers http.Header, credential string) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

增加以下功能:
- /v1/chat/completions 对话接口支持图片输入(兼容了 Claude 与 openai 接口在 messages 中对 image 的结构定义不一致)
- /v1/chat/completions  对话接口支持 Tools 调用能力
- /v1/chat/completions 对话接口流式输出忽略掉 claude messages 接口中的 ping 信息输出（部分场景下会因 ping 的结构与 openai 结构不一致，导致客户端异常）
- /v1/chat/completions 对话接口流式增加 tokens 统计信息，保持与 openai 行为一致
- 添加对 models 接口的支持


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it

docker-compose.yaml

```yaml
services:
  envoy:
    image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway:v2.1.3
    entrypoint: /usr/local/bin/envoy
    command: -c /etc/envoy/envoy.yaml --component-log-level wasm:debug
    networks:
      - wasmtest
    ports:
      - '10000:10000'
    volumes:
      - ./envoy.yaml:/etc/envoy/envoy.yaml
      - ./plugin.wasm:/etc/envoy/plugin.wasm

networks:
  wasmtest: {}
```

envoy.yaml

```yaml
# File generated by hgctl. Modify as required.

admin:
  address:
    socket_address:
      protocol: TCP
      address: 0.0.0.0
      port_value: 9901
static_resources:
  listeners:
    - name: listener_0
      address:
        socket_address:
          protocol: TCP
          address: 0.0.0.0
          port_value: 10000
      filter_chains:
        - filters:
            - name: envoy.filters.network.http_connection_manager
              typed_config:
                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                scheme_header_transformation:
                  scheme_to_overwrite: https
                stat_prefix: ingress_http
                # Output envoy logs to stdout
                access_log:
                  - name: envoy.access_loggers.stdout
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
                # Modify as required
                route_config:
                  name: local_route
                  virtual_hosts:
                    - name: local_service
                      domains: ["*"]
                      routes:
                        - match:
                            prefix: "/"
                          route:
                            cluster: claude
                            timeout: 300s
                http_filters:
                  - name: wasmtest
                    typed_config:
                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                      value:
                        config:
                          name: wasmtest
                          vm_config:
                            runtime: envoy.wasm.runtime.v8
                            code:
                              local:
                                filename: /etc/envoy/plugin.wasm
                          configuration:
                            "@type": "type.googleapis.com/google.protobuf.StringValue"
                            value: |
                              {
                                "provider": {
                                    "type": "claude",
                                    "apiTokens": [
                                        "sk-ant-api03-XXX"
                                    ],
                                    "apiVersion": "2023-06-01"
                                }
                              }
                  - name: envoy.filters.http.router
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
  clusters:
    - name: claude
      connect_timeout: 30s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: claude
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: api.anthropic.com
                      port_value: 443
      transport_socket:
        name: envoy.transport_sockets.tls
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
          "sni": "api.anthropic.com"

```


流式输出，最后一条消息输出 tokens 使用，保持与 openai 行为一致
```shell
$ curl -s http://127.0.0.1:10000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
      "messages": [
        {
          "role": "user",
          "content": "Who Are you"
        }
      ],
      "model": "claude-sonnet-4-20250514", 
      "stream": true
    }'
data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"role":"assistant","content":""}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":"I'm Claude,"}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" an AI assistant created by Anthropic"}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":". I'm here to help with a"}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" wide variety of tasks like answering questions"}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":", helping with analysis and research, creative writing,"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" math and coding problems, or"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" just having a conversation. Is"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" there something specific I can help you with"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" today?"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{"prompt_tokens":10,"completion_tokens":67,"total_tokens":77}}
```

输入图片分析
```shell
$ curl -s http://127.0.0.1:10000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
      "messages": [
        {
          "role": "user",
          "content": [
            {
              "type": "text",
              "text": "帮我分析下这张图片表达了什么内容"
            },
            {
              "type": "image_url",
              "image_url": {
                "url": "https://img.alicdn.com/imgextra/i4/O1CN01OgGP1728t0xeRfRYJ_!!6000000007989-0-tps-1726-1366.jpg"
              }
            }
          ]
        }
      ],
      "model": "claude-sonnet-4-20250514"
    }'
{
  "id": "msg_01WowNqysWxVjexkYBCzW9xR",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "这张图片展示了 **Higress** 的整体架构设计，Higress 是一个云原生的 API 网关产品。图片主要表达了以下内容：\n\n## 整体架构分层\n\n**1. Higress OPS Plane（运维层）**\n- Console（控制台）\n- Higress CLI（命令行工具）\n- kubectl（Kubernetes 命令行工具）\n- 通过 Ingress/Gateway API/Istio CR 与控制层交互\n\n**2. Higress Control Plane（控制层）**\n- 基于 Kubernetes 和 NACOS 的双模式部署\n- 核心组件包括：\n  - Multi-k8s Remote Cluster（多 K8s 远程集群管理）\n  - Config Controller（配置控制器）\n  - Multi-ServiceRegistry（多服务注册中心）\n  - Nginx Ingress Adapter（Nginx Ingress 适配器）\n  - Abstract Model（抽象模型）\n  - xDS Server（配置分发服务器）\n  - Plugins Manager（插件管理器）\n\n**3. Higress Data Plane（数据层）**\n- 基于 Envoy 代理\n- 扩展组件包括：\n  - Sentinel（流量控制）\n  - Dubbo Transcoder（Dubbo 协议转换）\n  - ModSecurity（Web 应用防火墙）\n  - Wasm Route Base Filter（基于 Wasm 的路由过滤器）\n  - External Host Filter（外部主机过滤器）\n\n## 核心特性\n\n- **多部署模式**：支持 Kubernetes 原生部署和传统部署\n- **服务网格集成**：可选集成 Istio\n- **扩展性**：支持自定义过滤器（Java/Golang）\n- **多协议支持**：支持 HTTP、Dubbo 等多种协议\n- **安全防护**：集成 ModSecurity 等安全组件\n\n这个架构图清晰地展示了 Higress 如何通过分层设计实现云原生 API 网关的完整功能。"
      },
      "finish_reason": "stop"
    }
  ],
  "created": 1749521985,
  "model": "claude-sonnet-4-20250514",
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 1568,
    "completion_tokens": 590,
    "total_tokens": 2158
  }
}
```

工具调用

```shell
$ curl -s http://127.0.0.1:10000/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{
  "model": "claude-sonnet-4-20250514",
  "messages": [
    {
      "role": "user",
      "content": "What is the weather like in Beijing today?"
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_current_weather",
        "description": "Get the current weather in a given location",
        "parameters": {
          "type": "object",
          "properties": {
            "location": {
              "type": "string",
              "description": "The city and state, e.g. San Francisco, CA"
            },
            "unit": {
              "type": "string",
              "enum": ["celsius", "fahrenheit"]
            }
          },
          "required": ["location"]
        }
      }
    }
  ],
  "tool_choice": "auto"
}'
{
  "id": "msg_01RWQ1WUGpECPXResNQGBZzA",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "I'll check the current weather in Beijing for you."
      },
      "finish_reason": "tool_use"
    }
  ],
  "created": 1749522070,
  "model": "claude-sonnet-4-20250514",
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 425,
    "completion_tokens": 69,
    "total_tokens": 494
  }
}
```

获取模型列表

```shell
$ curl -s http://127.0.0.1:10000/v1/models | jq
{
  "data": [
    {
      "type": "model",
      "id": "claude-opus-4-20250514",
      "display_name": "Claude Opus 4",
      "created_at": "2025-05-22T00:00:00Z"
    },
    {
      "type": "model",
      "id": "claude-sonnet-4-20250514",
      "display_name": "Claude Sonnet 4",
      "created_at": "2025-05-22T00:00:00Z"
    },
    {
      "type": "model",
      "id": "claude-3-7-sonnet-20250219",
      "display_name": "Claude Sonnet 3.7",
      "created_at": "2025-02-24T00:00:00Z"
    },
    {
      "type": "model",
      "id": "claude-3-5-sonnet-20241022",
      "display_name": "Claude Sonnet 3.5 (New)",
      "created_at": "2024-10-22T00:00:00Z"
    }
  ]
}
```

### Ⅴ. Special notes for reviews


<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
<!-- Please make sure you have read and understand the contributing guidelines -->

### Ⅰ. Describe what this PR did

Added the following features:
- /v1/chat/completes dialogue interface supports image input (compatible with the structural definitions of image in messages between Claude and openai interfaces)
- /v1/chat/completes dialog interface supports Tools calling capability
- /v1/chat/completes The streaming output of the dialogue interface ignores the ping information output in the claude messages interface (in some scenarios, the ping structure is inconsistent with the openai structure, resulting in client exceptions)
- /v1/chat/completes dialog interface streams tokens statistics to maintain consistency with openai behavior
- Add support for models interface


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)?


### Ⅳ. Describe how to verify it

docker-compose.yaml

```yaml
services:
  envoy:
    image: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway:v2.1.3
    entrypoint: /usr/local/bin/envoy
    command: -c /etc/envoy/envoy.yaml --component-log-level wasm:debug
    networks:
      - wasmtest
    Ports:
      - '10000:10000'
    Volumes:
      - ./envoy.yaml:/etc/envoy/envoy.yaml
      - ./plugin.wasm:/etc/envoy/plugin.wasm

networks:
  wasmtest: {}
```

envoy.yaml

```yaml
# File generated by hgctl. Modify as required.

admin:
  address:
    socket_address:
      protocol: TCP
      address: 0.0.0.0
      port_value: 9901
static_resources:
  listeners:
    - name: listener_0
      address:
        socket_address:
          protocol: TCP
          address: 0.0.0.0
          port_value: 10000
      filter_chains:
        - filters:
            - name: envoy.filters.network.http_connection_manager
              typed_config:
                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                scheme_header_transformation:
                  scheme_to_overwrite: https
                stat_prefix: ingress_http
                # Output envoy logs to stdout
                access_log:
                  - name: envoy.access_loggers.stdout
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
                # Modify as required
                route_config:
                  name: local_route
                  virtual_hosts:
                    - name: local_service
                      domains: ["*"]
                      routes:
                        - match:
                            prefix: "/"
                          route:
                            cluster: claude
                            timeout: 300s
                http_filters:
                  - name: wasmtest
                    typed_config:
                      "@type": type.googleapis.com/udpa.type.v1.TypedStruct
                      type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
                      value:
                        config:
                          name: wasmtest
                          vm_config:
                            runtime: envoy.wasm.runtime.v8
                            code:
                              local:
                                filename: /etc/envoy/plugin.wasm
                          configuration:
                            "@type": "type.googleapis.com/google.protobuf.StringValue"
                            value: |
                              {
                                "provider": {
                                    "type": "claude",
                                    "apiTokens": [
                                        "sk-ant-api03-XXX"
                                    ],
                                    "apiVersion": "2023-06-01"
                                }
                              }
                  - name: envoy.filters.http.router
                    typed_config:
                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
  clusters:
    - name: claude
      connect_timeout: 30s
      type: LOGICAL_DNS
      dns_lookup_family: V4_ONLY
      lb_policy: ROUND_ROBIN
      load_assignment:
        cluster_name: claude
        endpoints:
          - lb_endpoints:
              - endpoint:
                  address:
                    socket_address:
                      address: api.anthropic.com
                      port_value: 443
      transport_socket:
        name: envoy.transport_sockets.tls
        typed_config:
          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
          "sni": "api.anthropic.com"

```


Streaming output, the last message output is used tokens, keeping consistent with openai behavior
```shell
$ curl -s http://127.0.0.1:10000/v1/chat/completes \
  -H "Content-Type: application/json" \
  -d '{
      "messages": [
        {
          "role": "user",
          "content": "Who Are you"
        }
      ],
      "model": "claude-sonnet-4-20250514",
      "stream": true
    }'
data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"role":"assistant","content":""}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":"I'm Claude,"}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" an AI assistant created by Anthropic"}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":". I'm here to help with a"}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":"wide variety of tasks like answering questions"}}],"created":1749521843,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":", helping with analysis and research, creative writing,"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":"math and coding problems, or"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" just having a conversation. Is"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":" there something specific I can help you with"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{"content":"day?"}}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{}}

data: {"id":"msg_01SHPsnk1A18GfwpdvaTnrbq","choices":[],"created":1749521844,"model":"claude-sonnet-4-20250514","service_tier":"standard","object":"chat.completion.chunk","usage":{"prompt_tokens":10,"completion_tokens":67,"total_tokens":77}}
```

Enter picture analysis
```shell
$ curl -s http://127.0.0.1:10000/v1/chat/completes \
  -H "Content-Type: application/json" \
  -d '{
      "messages": [
        {
          "role": "user",
          "content": [
            {
              "type": "text",
              "text": "Help me analyze what this picture expresses"
            },
            {
              "type": "image_url",
              "image_url": {
                "url": "https://img.alicdn.com/imgextra/i4/O1CN01OgGP1728t0xeRfRYJ_!!6000000007989-0-tps-1726-1366.jpg"
              }
            }
          ]
        }
      ],
      "model": "claude-sonnet-4-20250514"
    }'
{
  "id": "msg_01WowNqysWxVjexkYBCzW9xR",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "This image shows the overall architecture design of **Hagress**, a cloud-native API gateway product. The image mainly expresses the following content:\n\n## Overall architecture layering\n\n**1. Higress OPS Plane (Operation and Maintenance Layer)**\n- Console (Console)\n- Higress CLI (Command Line Tool)\n- kubectl (Kubernetes Command Line Tool)\n- Interaction with the control layer through Ingress/Gateway API/Istio CR\n\n**2. Higress Control Plane (Control Layer)**\n- Dual-mode deployment based on Kubernetes and NACOS\n- Core components include:\n- Multi-k8s Remote Cluster\n - Config Controller\n - Multi-ServiceRegistry\n - Nginx Ingress Adapter\n - Abstract Model\n - xDS Server\n - Plugins Manager\n\n\n**3. Higress Data Plane**\n- Envoy-based Agent\n- Extension components include:\n - Sentinel\n- Dubbo Transcoder\n Protocol Transformation)\n - ModSecurity (Web Application Firewall)\n - Wasm Route Base Filter (Wasm-based routing filter)\n - External Host Filter (External Host Filter)\n\n## Core Features\n\n- **Multi-deployment mode**: Supports Kubernetes native and traditional deployments\n- **Service mesh integration**: optional integration Istio\n- **Extensibility**: Supports custom filters (Java/Golang)\n- **Multi-protocol support**: Supports HTTP, Dubbo and other protocols\n- **Security protection**: Integrates security components such as ModSecurity\n\nThis architecture diagram clearly shows Higress How to implement the full functionality of a cloud-native API gateway through layered design. "
      },
      "finish_reason": "stop"
    }
  ],
  "created": 1749521985,
  "model": "claude-sonnet-4-20250514",
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 1568,
    "completion_tokens": 590,
    "total_tokens": 2158
  }
}
```

Tool calls

```shell
$ curl -s http://127.0.0.1:10000/v1/chat/completes \
-H "Content-Type: application/json" \
-d '{
  "model": "claude-sonnet-4-20250514",
  "messages": [
    {
      "role": "user",
      "content": "What is the weather like in Beijing today?"
    }
  ],
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_current_weather",
        "description": "Get the current weather in a given location",
        "parameters": {
          "type": "object",
          "properties": {
            "location": {
              "type": "string",
              "description": "The city and state, e.g. San Francisco, CA"
            },
            "unit": {
              "type": "string",
              "enum": ["celsius", "fahrenheit"]
            }
          },
          "required": ["location"]
        }
      }
    }
  ],
  "tool_choice": "auto"
}'
{
  "id": "msg_01RWQ1WUGpECPXResNQGBZzA",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "I'll check the current weather in Beijing for you."
      },
      "finish_reason": "tool_use"
    }
  ],
  "created": 1749522070,
  "model": "claude-sonnet-4-20250514",
  "object": "chat.completion",
  "usage": {
    "prompt_tokens": 425,
    "completion_tokens": 69,
    "total_tokens": 494
  }
}
```

Get the model list

```shell
$ curl -s http://127.0.0.1:10000/v1/models | jq
{
  "data": [
    {
      "type": "model",
      "id": "claude-opus-4-20250514",
      "display_name": "Claude Opus 4",
      "created_at": "2025-05-22T00:00:00Z"
    },
    {
      "type": "model",
      "id": "claude-sonnet-4-20250514",
      "display_name": "Claude Sonnet 4",
      "created_at": "2025-05-22T00:00:00Z"
    },
    {
      "type": "model",
      "id": "claude-3-7-sonnet-20250219",
      "display_name": "Claude Sonnet 3.7",
      "created_at": "2025-02-24T00:00:00Z"
    },
    {
      "type": "model",
      "id": "claude-3-5-sonnet-20241022",
      "display_name": "Claude Sonnet 3.5 (New)",
      "created_at": "2024-10-22T00:00:00Z"
    }
  ]
}
```

### V. Special notes for reviews
