### PR TITLE
fix(ai-proxy): Unify the naming convention & fix api name mapping

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -383,13 +383,13 @@ func getApiName(path string) provider.ApiName {
 		return provider.ApiNameFineTuningJobs
 	}
 	if util.RegRetrieveFineTuningJobPath.MatchString(path) {
-		return provider.ApiNameFineTuningRetrieveJob
+		return provider.ApiNameRetrieveFineTuningJob
 	}
 	if util.RegRetrieveFineTuningJobEventsPath.MatchString(path) {
-		return provider.PathOpenAIFineTuningJobEvents
+		return provider.ApiNameFineTuningJobEvents
 	}
 	if util.RegRetrieveFineTuningJobCheckpointsPath.MatchString(path) {
-		return provider.PathOpenAIFineTuningJobCheckpoints
+		return provider.ApiNameFineTuningJobCheckpoints
 	}
 	if util.RegCancelFineTuningJobPath.MatchString(path) {
 		return provider.ApiNameFineTuningCancelJob
@@ -404,7 +404,7 @@ func getApiName(path string) provider.ApiName {
 		return provider.ApiNameFineTuningCheckpointPermissions
 	}
 	if util.RegDeleteFineTuningCheckpointPermissionPath.MatchString(path) {
-		return provider.PathOpenAIFineDeleteTuningCheckpointPermission
+		return provider.ApiNameDeleteFineTuningCheckpointPermission
 	}
 	// cohere style
 	if strings.HasSuffix(path, "/v1/rerank") {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -43,7 +43,7 @@ const (
 	ApiNameModels                               ApiName = "openai/v1/models"
 	ApiNameResponses                            ApiName = "openai/v1/responses"
 	ApiNameFineTuningJobs                       ApiName = "openai/v1/fine-tuningjobs"
-	ApiNameFineTuningRetrieveJob                ApiName = "openai/v1/retrievefine-tuningjob"
+	ApiNameRetrieveFineTuningJob                ApiName = "openai/v1/retrievefine-tuningjob"
 	ApiNameFineTuningJobEvents                  ApiName = "openai/v1/fine-tuningjobsevents"
 	ApiNameFineTuningJobCheckpoints             ApiName = "openai/v1/fine-tuningjobcheckpoints"
 	ApiNameFineTuningCancelJob                  ApiName = "openai/v1/cancelfine-tuningjob"


### PR DESCRIPTION
Unify the naming convention for API name constants & fix ApiName mapping

### Ⅰ. Describe what this PR did

- Modified the naming of multiple API name constants to be more consistent and clear
- Updated references to these constants in relevant functions to match the new naming convention
- Fix constants mapping in getApiName

### Ⅱ. Does this pull request fix one issue?

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it

### Ⅴ. Special notes for reviews

