### PR TITLE
fix: add missing controller sa annotation.

### DIFF
--- a/helm/core/templates/controller-serviceaccont.yaml
+++ b/helm/core/templates/controller-serviceaccont.yaml
@@ -6,4 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "controller.labels" . | nindent 4 }}
+  {{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
introduce the missing controller sa annotation, it would be useful when we need to set annotation on controller sa, e.g. use sa annotation to bind with an aws iam role for aws resource authentication.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #2442

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

### Ⅳ. Describe how to verify it
Just did the helm install and check the controller sa annotation content.

### Ⅴ. Special notes for reviews
