### PR TITLE
fix too much logs when nacos is not avaiable

### DIFF
--- a/registry/nacos/mcpserver/client.go
+++ b/registry/nacos/mcpserver/client.go
@@ -142,11 +142,12 @@ func (n *NacosRegistryClient) listMcpServerConfigs() ([]model.ConfigItem, error)
 
 		if err != nil {
 			mcpServerLog.Errorf("List mcp server configs for page size %d, page number %d error %v", currentPageNum, DefaultNacosListConfigPageSize)
+			break
 		}
 
 		if configPage == nil {
 			mcpServerLog.Errorf("List mcp server configs for page size %d, page number %d null %v", currentPageNum, DefaultNacosListConfigPageSize)
-			continue
+			break
 		}
 
 		result = append(result, configPage.PageItems...)

--- a/registry/nacos/mcpserver/client.go
+++ b/registry/nacos/mcpserver/client.go
@@ -141,12 +141,12 @@ func (n *NacosRegistryClient) listMcpServerConfigs() ([]model.ConfigItem, error)
 		})
 
 		if err != nil {
-			mcpServerLog.Errorf("List mcp server configs for page size %d, page number %d error %v", currentPageNum, DefaultNacosListConfigPageSize)
+			mcpServerLog.Errorf("List mcp server configs for page size %d, page number %d error %v", currentPageNum, DefaultNacosListConfigPageSize, err)
 			break
 		}
 
 		if configPage == nil {
-			mcpServerLog.Errorf("List mcp server configs for page size %d, page number %d null %v", currentPageNum, DefaultNacosListConfigPageSize)
+			mcpServerLog.Errorf("List mcp server configs for page size %d, page number %d null", currentPageNum, DefaultNacosListConfigPageSize)
 			break
 		}
 

--- a/registry/nacos/mcpserver/watcher.go
+++ b/registry/nacos/mcpserver/watcher.go
@@ -50,6 +50,8 @@ const (
 	DefaultNacosCacheDir        = "/var/log/nacos/log/mcp/cache"
 	DefaultNacosNotLoadCache    = true
 	DefaultNacosLogMaxAge       = 3
+	DefaultNacosLogMaxSize      = 64
+	DefaultNacosLogMaxBackups   = 3
 	DefaultRefreshInterval      = time.Second * 30
 	DefaultRefreshIntervalLimit = time.Second * 10
 )
@@ -128,6 +130,8 @@ func NewWatcher(cache memory.Cache, opts ...WatcherOption) (provider.Watcher, er
 		constant.WithNotLoadCacheAtStart(DefaultNacosNotLoadCache),
 		constant.WithLogRollingConfig(&constant.ClientLogRollingConfig{
 			MaxAge: DefaultNacosLogMaxAge,
+			MaxSize: DefaultNacosLogMaxSize,
+			MaxBackups: DefaultNacosLogMaxBackups,
 		}),
 		constant.WithUpdateCacheWhenEmpty(w.updateCacheWhenEmpty),
 		constant.WithNamespaceId(w.NacosNamespaceId),


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

fix too much logs when nacos is not avaiable

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

There will be too much logs when nacos is not avaiable for mcp server discovery.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

