### PR TITLE
fix(ai-proxy): fix openai provider customPath compatibility

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
@@ -120,9 +120,7 @@ func (m *openaiProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 func (m *openaiProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
 	if m.isDirectCustomPath {
 		util.OverwriteRequestPathHeader(headers, m.customPath)
-	}
-
-	if apiName != "" {
+	} else if apiName != "" {
 		util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), m.config.capabilities)
 	}
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

修复 openai provider 配置 openaiCustomUrl 为单个接口时 customPath 传递错误导致 404 的问题
该问题仅影响 openai 兼容接口 path 前缀不为 /v1 的情况， 比如千问的前缀为 /compatible-mode/v1

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

