### PR TITLE
fix: Error compiling golang-filter.so on arm64 machine (#2494)

### DIFF
--- a/plugins/golang-filter/Dockerfile
+++ b/plugins/golang-filter/Dockerfile
@@ -17,7 +17,7 @@ RUN if [ "$GOARCH" = "arm64" ]; then \
     else \
         echo "Installing AMD64 toolchain" && \
         apt-get update && \
-        apt-get install -y gcc binutils; \
+        apt-get install -y gcc-x86-64-linux-gnu binutils-x86-64-linux-gnu; \
     fi
 
 WORKDIR /workspace
@@ -30,7 +30,7 @@ RUN go mod tidy
 RUN if [ "$GOARCH" = "arm64" ]; then \
         CC=aarch64-linux-gnu-gcc AS=aarch64-linux-gnu-as go build -o /$GO_FILTER_NAME.so -buildmode=c-shared .; \
     else \
-        go build -o /$GO_FILTER_NAME.so -buildmode=c-shared .; \
+        CC=x86_64-linux-gnu-gcc AS=x86_64-linux-gnu-as go build -o /$GO_FILTER_NAME.so -buildmode=c-shared .; \
     fi
 
 FROM scratch AS output


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Fix error compiling golang-filter.so on arm64 machine.

If you do not specify a specific architecture package, the tools for the corresponding architecture package will be installed. This will cause the x86 compiler tool to be installed on the arm machine, causing an error.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #2494 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

