### PR TITLE
feat(key_auth): record consumer to response_code_details when request is denied

### DIFF
--- a/plugins/wasm-cpp/extensions/key_auth/plugin.cc
+++ b/plugins/wasm-cpp/extensions/key_auth/plugin.cc
@@ -49,8 +49,8 @@ void deniedInvalidCredentials(const std::string& realm) {
                     {{"WWW-Authenticate", absl::StrCat("Key realm=", realm)}});
 }
 
-void deniedUnauthorizedConsumer(const std::string& realm) {
-  sendLocalResponse(403, "Request denied by Key Auth check. Unauthorized consumer", "",
+void deniedUnauthorizedConsumer(const std::string& realm, const std::string& consumer) {
+  sendLocalResponse(403, absl::StrCat("Request denied by Key Auth check. Unauthorized consumer::", consumer), "",
                     {{"WWW-Authenticate", absl::StrCat("Basic realm=", realm)}});
 }
 
@@ -313,7 +313,7 @@ bool PluginRootContext::checkPlugin(
         if (allow_set && !allow_set->empty()) {
           if (allow_set->find(credential_to_name_iter->second) ==
               allow_set->end()) {
-            deniedUnauthorizedConsumer(rule.realm);
+            deniedUnauthorizedConsumer(rule.realm, credential_to_name_iter->second);
             LOG_DEBUG("unauthorized consumer: " +
                       credential_to_name_iter->second);
             return false;
@@ -353,11 +353,11 @@ bool PluginRootContext::checkPlugin(
           if (allow_set) {
             if (allow_set->empty()) {
               LOG_DEBUG("allow set is empty, nobody is allowed");
-              deniedUnauthorizedConsumer(rule.realm);
+              deniedUnauthorizedConsumer(rule.realm, credential_to_name_iter->second);
               return false;
             }
             if (allow_set->find(credential_to_name_iter->second) == allow_set->end()) {
-              deniedUnauthorizedConsumer(rule.realm);
+              deniedUnauthorizedConsumer(rule.realm, credential_to_name_iter->second);
               LOG_DEBUG("unauthorized consumer: " +
                         credential_to_name_iter->second);
               return false;


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

当请求被拒绝时在 response_code_details 中记录 Consumer 信息

<img width="1105" height="48" alt="image" src="https://github.com/user-attachments/assets/d4fa7717-b105-4709-862b-872a41719ec1" />


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

