### PR TITLE
fix: Allow duplicated items in the IP list of ip-restriction config

### DIFF
--- a/plugins/wasm-go/extensions/ip-restriction/utils.go
+++ b/plugins/wasm-go/extensions/ip-restriction/utils.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/asergeyev/nradix"
 	"github.com/tidwall/gjson"
 	"github.com/zmap/go-iptree/iptree"
 )
@@ -16,8 +18,8 @@ func parseIPNets(array []gjson.Result) (*iptree.IPTree, error) {
 		tree := iptree.New()
 		for _, result := range array {
 			err := tree.AddByString(result.String(), 0)
-			if err != nil {
-				return nil, fmt.Errorf("invalid IP[%s]", result.String())
+			if err != nil && !errors.Is(err, nradix.ErrNodeBusy) { // ErrNodeBusy means the IP already exists in the tree
+				return nil, fmt.Errorf("add IP [%s] into tree failed: %v", result.String(), err)
 			}
 		}
 		return tree, nil


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Ignore item existed error when adding IPs into iptree in ip-restriction plugin, and show error details returned by the iptree.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/alibaba/higress/issues/2737

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

