### PR TITLE
fix: Remove "accept-encoding" header for mcp-sse upstreams

### DIFF
--- a/plugins/golang-filter/mcp-session/filter.go
+++ b/plugins/golang-filter/mcp-session/filter.go
@@ -149,6 +149,9 @@ func (f *filter) processMcpRequestHeadersForRestUpstream(header api.RequestHeade
 func (f *filter) processMcpRequestHeadersForSSEUpstream(header api.RequestHeaderMap, endStream bool) api.StatusType {
 	// We don't need to process the request body for SSE upstream.
 	f.skipRequestBody = true
+	// Remove Accept-Encoding header to avoid gzip encoding,
+	// which our response body handling logic doesn't support.
+	header.Del("Accept-Encoding")
 	return api.Continue
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

When processing requests for an MCP server upstream with SSE transport in `mcp-session` filter, remove the "accept-encoding" header, because the filter usually needs to rewrite the endpoint path in the response body, but it is unable to process compressed body data.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

