### PR TITLE
fix: When the sse event is divided into multiple chunks, the sse connection is blocked

### DIFF
--- a/plugins/golang-filter/mcp-session/filter.go
+++ b/plugins/golang-filter/mcp-session/filter.go
@@ -310,7 +310,7 @@ func (f *filter) encodeDataFromSSEUpstream(buffer api.BufferInstance, endStream 
 		// No endpoint URL found. Need to buffer and check again.
 		f.cachedResponseBody = []byte(combinedData)
 		buffer.Reset()
-		return api.StopAndBufferWatermark
+		return api.Continue
 	}
 	// Clear cached data
 	f.cachedResponseBody = nil


### PR DESCRIPTION

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
对于代理 mcp server 场景，当 上游 sse server 返回的一个event 分为多个 chunk，需要做一个缓存，且不阻塞整个 sse 后续数据的处理

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #2864 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

