### PR TITLE
fix: add condition for higress-console in Chart.yaml

### DIFF
--- a/helm/higress/Chart.yaml
+++ b/helm/higress/Chart.yaml
@@ -16,5 +16,6 @@ dependencies:
 - name: higress-console
   repository: "https://higress.io/helm-charts/"
   version: 2.1.7
+  condition: higress-console.enabled
 type: application
 version: 2.1.7

--- a/helm/higress/values.yaml
+++ b/helm/higress/values.yaml
@@ -1,0 +1,4 @@
+# Support Helm chart values for Higress. For more details, refer to the official Higress documentation.
+higress-console:
+  # Set to true to enable the Higress console.
+  enabled: true


### PR DESCRIPTION
This pull request introduces a small configuration improvement to the `helm/higress/Chart.yaml` file. The change adds a conditional field to the `higress-console` dependency, allowing it to be enabled or disabled based on the `higress-console.enabled` value.

* Added `condition: higress-console.enabled` to the `higress-console` dependency to support conditional installation in Helm charts.