### PR TITLE
feat(ingress): support custom parameter names for MCP SSE stateful sessions

### DIFF
--- a/pkg/ingress/kube/annotations/loadbalance.go
+++ b/pkg/ingress/kube/annotations/loadbalance.go
@@ -41,6 +41,9 @@ const (
 
 	defaultAffinityCookieName = "INGRESSCOOKIE"
 	defaultAffinityCookiePath = "/"
+
+	mcpSseStatefulKey        = "mcp-sse-stateful-param-name"
+	defaultMcpSseStatefulKey = "sessionId"
 )
 
 var (
@@ -66,10 +69,11 @@ type consistentHashByCookie struct {
 }
 
 type LoadBalanceConfig struct {
-	simple         networking.LoadBalancerSettings_SimpleLB
-	other          *consistentHashByOther
-	cookie         *consistentHashByCookie
-	McpSseStateful bool
+	simple            networking.LoadBalancerSettings_SimpleLB
+	other             *consistentHashByOther
+	cookie            *consistentHashByCookie
+	McpSseStateful    bool
+	McpSseStatefulKey string
 }
 
 type loadBalance struct{}
@@ -139,6 +143,11 @@ func (l loadBalance) Parse(annotations Annotations, config *Ingress, _ *GlobalCo
 			lb = strings.ToUpper(lb)
 			if lb == "MCP-SSE" {
 				loadBalanceConfig.McpSseStateful = true
+				if key, err := annotations.ParseStringASAP(mcpSseStatefulKey); err == nil {
+					loadBalanceConfig.McpSseStatefulKey = key
+				} else {
+					loadBalanceConfig.McpSseStatefulKey = defaultMcpSseStatefulKey
+				}
 			} else {
 				loadBalanceConfig.simple = networking.LoadBalancerSettings_SimpleLB(networking.LoadBalancerSettings_SimpleLB_value[lb])
 			}


### PR DESCRIPTION

<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
support custom parameter names for MCP SSE stateful sessions

Users need to set your own param name in the `higress.io/mcp-sse-stateful-param-name` annotation to specify your param name.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes #2991 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

