### PR TITLE
Add ApiNameAnthropicMessages in claude capabilities

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -279,8 +279,9 @@ func (c *claudeProviderInitializer) ValidateConfig(config *ProviderConfig) error
 
 func (c *claudeProviderInitializer) DefaultCapabilities() map[string]string {
 	return map[string]string{
-		string(ApiNameChatCompletion): PathAnthropicMessages,
-		string(ApiNameCompletion):     PathAnthropicComplete,
+		string(ApiNameChatCompletion):    PathAnthropicMessages,
+		string(ApiNameCompletion):        PathAnthropicComplete,
+		string(ApiNameAnthropicMessages): PathAnthropicMessages,
 		// docs: https://docs.anthropic.com/en/docs/build-with-claude/embeddings#voyage-http-api
 		string(ApiNameEmbeddings): PathOpenAIEmbeddings,
 		string(ApiNameModels):     PathOpenAIModels,


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
It supports to configure anthropic provider without protocol=original.
And then /v1/messages request will be forwarded directly to anthropic while /v1/chat/completion will transform body from openai to claude.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
Fixes https://github.com/alibaba/higress/issues/3039

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
configure ai-proxy like
```
                     "_rules_": [
                            {
                                "_match_service_": "claude.internal.dns",
                                "activeProviderId": "claude"
                            },
                            ....
                       ]
                        "providers": [
                            {
                                "id": "claude",
                                "apiTokens": [
                                    "${CLAUDE_TOKEN}"
                                ],
                                "failover": {
                                    "enabled": false
                                },
                                "claudeVersion": "2023-06-01", 
                                "type": "claude",
                                "retryOnFailure": {
                                    "enabled": false
                                }
                            },
...
                            }                                                       
                        ]
                      }
```

### Ⅴ. Special notes for reviews

