### PR TITLE
fix(log-request-response): enhance response body logging by checking Content-Encoding

### DIFF
--- a/plugins/wasm-go/extensions/log-request-response/go.mod
+++ b/plugins/wasm-go/extensions/log-request-response/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.4
 
 require (
 	github.com/higress-group/proxy-wasm-go-sdk v0.0.0-20250822030947-8345453fddd0
-	github.com/higress-group/wasm-go v1.0.2-0.20250821081215-b573359becf8
+	github.com/higress-group/wasm-go v1.0.3-0.20251011083635-792cb1547bac
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5

--- a/plugins/wasm-go/extensions/log-request-response/go.sum
+++ b/plugins/wasm-go/extensions/log-request-response/go.sum
@@ -6,6 +6,8 @@ github.com/higress-group/proxy-wasm-go-sdk v0.0.0-20250822030947-8345453fddd0 h1
 github.com/higress-group/proxy-wasm-go-sdk v0.0.0-20250822030947-8345453fddd0/go.mod h1:tRI2LfMudSkKHhyv1uex3BWzcice2s/l8Ah8axporfA=
 github.com/higress-group/wasm-go v1.0.2-0.20250821081215-b573359becf8 h1:rs+AH1wfZy4swzuAyiRXT7xPUm8gycXt9Gwy0tqOq0o=
 github.com/higress-group/wasm-go v1.0.2-0.20250821081215-b573359becf8/go.mod h1:9k7L730huS/q4V5iH9WLDgf5ZUHEtfhM/uXcegKDG/M=
+github.com/higress-group/wasm-go v1.0.3-0.20251011083635-792cb1547bac h1:tdJzS56Xa6BSHAi9P2omvb98bpI8qFGg6jnCPtPmDgA=
+github.com/higress-group/wasm-go v1.0.3-0.20251011083635-792cb1547bac/go.mod h1:B8C6+OlpnyYyZUBEdUXA7tYZYD+uwZTNjfkE5FywA+A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/plugins/wasm-go/extensions/log-request-response/main.go
+++ b/plugins/wasm-go/extensions/log-request-response/main.go
@@ -355,13 +355,21 @@ func onHttpResponseHeaders(ctx wrapper.HttpContext, config PluginConfig) types.A
 		return types.ActionContinue
 	}
 
-	// Check Content-Type for response body logging
+	// Check Content-Type and Content-Encoding for response body logging
 	contentType := ""
+	hasContentEncoding := false
 	for _, header := range headers {
 		if strings.ToLower(header[0]) == "content-type" {
 			contentType = header[1]
-			break
+		} else if strings.ToLower(header[0]) == "content-encoding" {
+			hasContentEncoding = true
 		}
+	}
+
+	// Skip response body logging if content encoding is present (avoid logging compressed content)
+	if hasContentEncoding {
+		ctx.DontReadResponseBody()
+		return types.ActionContinue
 	}
 
 	// Skip response body logging if content type is not in the configured list


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
Add content-encoding check in log-request-response plugin to skip logging compressed request/response bodies, avoiding garbled text in access logs.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
No.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
N/A - This PR only adds defensive checks. Existing tests should still pass.

### Ⅳ. Describe how to verify it
1. Configure the plugin to log request/response bodies
2. Send a request with Content-Encoding: gzip header
3. Verify that the compressed body is not logged in access logs
4. Verify that uncompressed bodies are still logged normally

### Ⅴ. Special notes for reviews

