### PR TITLE
feat: add support for custom tags in tracing configuration

### DIFF
--- a/pkg/ingress/kube/configmap/tracing_test.go
+++ b/pkg/ingress/kube/configmap/tracing_test.go
@@ -1,0 +1,128 @@
+package configmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidTracing(t *testing.T) {
+	// nil tracing
+	assert.NoError(t, validTracing(nil))
+
+	// timeout <= 0
+	tr := &Tracing{Enable: true, Timeout: 0, Sampling: 50, Zipkin: &Zipkin{Service: "svc", Port: "9411"}}
+	assert.Error(t, validTracing(tr))
+
+	// sampling < 0
+	tr.Timeout = 100
+	tr.Sampling = -1
+	assert.Error(t, validTracing(tr))
+
+	// sampling > 100
+	tr.Sampling = 101
+	assert.Error(t, validTracing(tr))
+
+	// multiple tracers
+	tr.Sampling = 50
+	tr.Zipkin = &Zipkin{Service: "svc", Port: "9411"}
+	tr.Skywalking = &Skywalking{Service: "svc", Port: "11800"}
+	assert.Error(t, validTracing(tr))
+
+	// valid zipkin
+	tr.Skywalking = nil
+	assert.NoError(t, validTracing(tr))
+
+	// valid skywalking
+	tr.Zipkin = nil
+	tr.Skywalking = &Skywalking{Service: "svc", Port: "11800"}
+	assert.NoError(t, validTracing(tr))
+
+	// valid opentelemetry
+	tr.Skywalking = nil
+	tr.OpenTelemetry = &OpenTelemetry{Service: "svc", Port: "4317"}
+	assert.NoError(t, validTracing(tr))
+
+	// custom tag duplicate
+	tr.CustomTag = []CustomTag{{Tag: "foo", Literal: "bar"}, {Tag: "foo", Literal: "baz"}}
+	assert.Error(t, validTracing(tr))
+}
+
+func TestValidCustomTag(t *testing.T) {
+	// empty tag name
+	tag := CustomTag{Tag: "", Literal: "val"}
+	assert.Error(t, validCustomTag(tag))
+
+	// empty value
+	tag = CustomTag{Tag: "foo"}
+	assert.Error(t, validCustomTag(tag))
+
+	// multiple values
+	tag = CustomTag{Tag: "foo", Literal: "val", Environment: &CustomTagValue{Key: "env"}}
+	assert.Error(t, validCustomTag(tag))
+
+	// valid literal
+	tag = CustomTag{Tag: "foo", Literal: "val"}
+	assert.NoError(t, validCustomTag(tag))
+
+	// valid environment
+	tag = CustomTag{Tag: "foo", Environment: &CustomTagValue{Key: "env"}}
+	assert.NoError(t, validCustomTag(tag))
+
+	// valid requestHeader
+	tag = CustomTag{Tag: "foo", RequestHeader: &CustomTagValue{Key: "header"}}
+	assert.NoError(t, validCustomTag(tag))
+}
+
+func TestCompareTracing(t *testing.T) {
+	old := &Tracing{Enable: true, Timeout: 100, Sampling: 50}
+	new := &Tracing{Enable: true, Timeout: 100, Sampling: 50}
+	res, err := compareTracing(old, new)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultNothing, res)
+
+	res, err = compareTracing(nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultNothing, res)
+
+	res, err = compareTracing(old, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultDelete, res)
+
+	new.Timeout = 200
+	res, err = compareTracing(old, new)
+	assert.NoError(t, err)
+	assert.Equal(t, ResultReplace, res)
+}
+
+func TestDeepCopyTracing(t *testing.T) {
+	tr := &Tracing{Enable: true, Timeout: 100, Sampling: 50}
+	copy, err := deepCopyTracing(tr)
+	assert.NoError(t, err)
+	assert.Equal(t, tr, copy)
+	copy.Timeout = 200
+	assert.NotEqual(t, tr.Timeout, copy.Timeout)
+}
+
+func TestNewDefaultTracing(t *testing.T) {
+	tr := NewDefaultTracing()
+	assert.False(t, tr.Enable)
+	assert.Equal(t, int32(500), tr.Timeout)
+	assert.Equal(t, 100.0, tr.Sampling)
+}
+
+func TestConstructCustomTags(t *testing.T) {
+	tags := []CustomTag{
+		{Tag: "foo", Literal: "bar"},
+		{Tag: "env", Environment: &CustomTagValue{Key: "ENV", DefaultValue: "def"}},
+		{Tag: "header", RequestHeader: &CustomTagValue{Key: "X-Header", DefaultValue: "def"}},
+	}
+	result := constructCustomTags(tags)
+	assert.Equal(t, 3, len(result))
+	assert.Equal(t, "foo", result[0].Tag)
+	assert.Equal(t, "bar", result[0].Literal.Value)
+	assert.Equal(t, "ENV", result[1].Env.Name)
+	assert.Equal(t, "def", result[1].Env.DefaultValue)
+	assert.Equal(t, "X-Header", result[2].Header.Name)
+	assert.Equal(t, "def", result[2].Header.DefaultValue)
+}

--- a/test/e2e/conformance/tests/configmap-tracing.go
+++ b/test/e2e/conformance/tests/configmap-tracing.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/v2/pkg/ingress/kube/configmap"
+	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/envoy"
+	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/kubernetes"
+	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/suite"
+)
+
+var ConfigmapTracing = suite.ConformanceTest{
+	ShortName:   "ConfigmapTracing",
+	Description: "The Ingress in the higress-conformance-infra namespace uses the configmap tracing.",
+	Manifests:   []string{"tests/configmap-tracing.yaml"},
+	Features:    []suite.SupportedFeature{suite.EnvoyConfigConformanceFeature},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		t.Run("Configmap Tracing", func(t *testing.T) {
+			for _, testcase := range tracingTestCases {
+				err := kubernetes.ApplyConfigmapDataWithYaml(t, suite.Client, "higress-system", "higress-config", "higress", testcase.higressConfig)
+				if err != nil {
+					t.Fatalf("can't apply configmap %s in namespace %s for data key %s", "higress-config", "higress-system", "higress")
+				}
+				envoy.AssertEnvoyConfig(t, suite.TimeoutConfig, testcase.envoyAssertion)
+			}
+		})
+	},
+}
+
+var tracingTestCases = []struct {
+	name           string
+	higressConfig  *configmap.HigressConfig
+	envoyAssertion envoy.Assertion
+}{
+	{
+		name: "tracing disabled",
+		higressConfig: &configmap.HigressConfig{
+			Tracing: &configmap.Tracing{
+				Enable: false,
+			},
+		},
+		envoyAssertion: envoy.Assertion{
+			Path:              "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config.tracing",
+			TargetNamespace:   "higress-system",
+			CheckType:         envoy.CheckTypeNotExist,
+			ExpectEnvoyConfig: map[string]interface{}{},
+		},
+	},
+	{
+		name: "tracing enabled: OpenTelemetry tracer",
+		higressConfig: &configmap.HigressConfig{
+			Tracing: &configmap.Tracing{
+				Enable:   true,
+				Sampling: 100.0,
+				Timeout:  500,
+				OpenTelemetry: &configmap.OpenTelemetry{
+					Service: "otel-collector",
+					Port:    "4317",
+				},
+			},
+		},
+		envoyAssertion: envoy.Assertion{
+			Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config.tracing.provider",
+			TargetNamespace: "higress-system",
+			CheckType:       envoy.CheckTypeExist,
+			ExpectEnvoyConfig: map[string]interface{}{
+				"name": "envoy.tracers.opentelemetry",
+				"typed_config": map[string]interface{}{
+					"@type":        "type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig",
+					"service_name": "higress-gateway.higress-system",
+					"grpc_service": map[string]interface{}{
+						"envoy_grpc": map[string]interface{}{
+							"cluster_name": "outbound|4317||otel-collector",
+						},
+						"timeout": "0.500s",
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "tracing enabled: OpenTelemetry tracer with customTag literal",
+		higressConfig: &configmap.HigressConfig{
+			Tracing: &configmap.Tracing{
+				Enable:   true,
+				Sampling: 100.0,
+				Timeout:  500,
+				OpenTelemetry: &configmap.OpenTelemetry{
+					Service: "otel-collector",
+					Port:    "4317",
+				},
+				CustomTag: []configmap.CustomTag{
+					{
+						Tag:     "custom-literal",
+						Literal: "literal-value",
+					},
+				},
+			},
+		},
+		envoyAssertion: envoy.Assertion{
+			Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config.tracing.custom_tags",
+			TargetNamespace: "higress-system",
+			CheckType:       envoy.CheckTypeExist,
+			ExpectEnvoyConfig: map[string]interface{}{
+				"tag": "custom-literal",
+				"literal": map[string]interface{}{
+					"value": "literal-value",
+				},
+			},
+		},
+	},
+	{
+		name: "tracing enabled: OpenTelemetry tracer with customTag environment",
+		higressConfig: &configmap.HigressConfig{
+			Tracing: &configmap.Tracing{
+				Enable:   true,
+				Sampling: 100.0,
+				Timeout:  500,
+				OpenTelemetry: &configmap.OpenTelemetry{
+					Service: "otel-collector",
+					Port:    "4317",
+				},
+				CustomTag: []configmap.CustomTag{
+					{
+						Tag: "custom-env",
+						Environment: &configmap.CustomTagValue{
+							Key:          "ENV_KEY",
+							DefaultValue: "env-default",
+						},
+					},
+				},
+			},
+		},
+		envoyAssertion: envoy.Assertion{
+			Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config.tracing.custom_tags",
+			TargetNamespace: "higress-system",
+			CheckType:       envoy.CheckTypeExist,
+			ExpectEnvoyConfig: map[string]interface{}{
+				"tag": "custom-env",
+				"environment": map[string]interface{}{
+					"name":          "ENV_KEY",
+					"default_value": "env-default",
+				},
+			},
+		},
+	},
+	{
+		name: "tracing enabled: OpenTelemetry tracer with customTag requestHeader",
+		higressConfig: &configmap.HigressConfig{
+			Tracing: &configmap.Tracing{
+				Enable:   true,
+				Sampling: 100.0,
+				Timeout:  500,
+				OpenTelemetry: &configmap.OpenTelemetry{
+					Service: "otel-collector",
+					Port:    "4317",
+				},
+				CustomTag: []configmap.CustomTag{
+					{
+						Tag: "custom-header",
+						RequestHeader: &configmap.CustomTagValue{
+							Key:          "X-My-Header",
+							DefaultValue: "header-default",
+						},
+					},
+				},
+			},
+		},
+		envoyAssertion: envoy.Assertion{
+			Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config.tracing.custom_tags",
+			TargetNamespace: "higress-system",
+			CheckType:       envoy.CheckTypeExist,
+			ExpectEnvoyConfig: map[string]interface{}{
+				"tag": "custom-header",
+				"request_header": map[string]interface{}{
+					"name":          "X-My-Header",
+					"default_value": "header-default",
+				},
+			},
+		},
+	},
+	{
+		name: "tracing enabled: OpenTelemetry tracer with sampling 50",
+		higressConfig: &configmap.HigressConfig{
+			Tracing: &configmap.Tracing{
+				Enable:   true,
+				Sampling: 50.0,
+				Timeout:  501,
+				OpenTelemetry: &configmap.OpenTelemetry{
+					Service: "otel-collector",
+					Port:    "4317",
+				},
+			},
+		},
+		envoyAssertion: envoy.Assertion{
+			Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config.tracing.random_sampling",
+			TargetNamespace: "higress-system",
+			CheckType:       envoy.CheckTypeExist,
+			ExpectEnvoyConfig: map[string]interface{}{
+				"value": 50.0,
+			},
+		},
+	},
+	{
+		name: "tracing enabled: OpenTelemetry tracer with timeout 1000",
+		higressConfig: &configmap.HigressConfig{
+			Tracing: &configmap.Tracing{
+				Enable:  true,
+				Timeout: 1000,
+				OpenTelemetry: &configmap.OpenTelemetry{
+					Service: "otel-collector",
+					Port:    "4317",
+				},
+			},
+		},
+		envoyAssertion: envoy.Assertion{
+			Path:            "configs.#.dynamic_listeners.#.active_state.listener.filter_chains.#.filters.#.typed_config.tracing.provider",
+			TargetNamespace: "higress-system",
+			CheckType:       envoy.CheckTypeExist,
+			ExpectEnvoyConfig: map[string]interface{}{
+				"name": "envoy.tracers.opentelemetry",
+				"typed_config": map[string]interface{}{
+					"@type":        "type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig",
+					"service_name": "higress-gateway.higress-system",
+					"grpc_service": map[string]interface{}{
+						"envoy_grpc": map[string]interface{}{
+							"cluster_name": "outbound|4317||otel-collector",
+						},
+						"timeout": "1s",
+					},
+				},
+			},
+		},
+	},
+}
+
+func init() {
+	Register(ConfigmapTracing)
+}

--- a/test/e2e/conformance/tests/configmap-tracing.yaml
+++ b/test/e2e/conformance/tests/configmap-tracing.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: higress-conformance-infra-tracing-test
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "foo.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/foo"
+            backend:
+              service:
+                name: infra-backend-v3
+                port:
+                  number: 8080
+
+---
+apiVersion: networking.higress.io/v1
+kind: McpBridge
+metadata:
+  name: default
+  namespace: higress-system
+spec:
+  registries:
+    - type: dns
+      domain: otel-collector.higress-system.svc.cluster.local
+      name: otel-collector
+      port: 4317
+      protocol: http


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did
在配置链路时新增自定义标签的选项，有以下逻辑：

当链路追踪开启时生效，默认为空

支持添加多个自定义标签，每个自定义标签的key不能为空且不能重复。

自定义标签的值分为固定值，从环境变量获取，从请求头中获取，而且值的获取方式只能选择其中一个。从环境变量获取和请求头中获取时可以设置默认值。值不允许为空。

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #3098 

### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

