### PR TITLE
fix: prevent port-level policy from overwriting existing ingress annotation configs

### DIFF
--- a/pkg/ingress/config/ingress_config.go
+++ b/pkg/ingress/config/ingress_config.go
@@ -857,8 +857,17 @@ func (m *IngressConfig) convertDestinationRule(configs []common.WrapperConfig) [
 					portUpdated := false
 					for _, policy := range dr.DestinationRule.TrafficPolicy.PortLevelSettings {
 						if policy.Port.Number == portTrafficPolicy.Port.Number {
-							policy.Tls = portTrafficPolicy.Tls
-							policy.LoadBalancer = portTrafficPolicy.LoadBalancer
+							// Only set Tls if not already configured
+							if policy.Tls == nil && portTrafficPolicy.Tls != nil {
+								policy.Tls = portTrafficPolicy.Tls
+							}
+							// Only set LoadBalancer if not already configured
+							if policy.LoadBalancer == nil && portTrafficPolicy.LoadBalancer != nil {
+								policy.LoadBalancer = portTrafficPolicy.LoadBalancer
+							} else if policy.LoadBalancer != nil && policy.LoadBalancer.LbPolicy == nil &&
+								portTrafficPolicy.LoadBalancer != nil && portTrafficPolicy.LoadBalancer.LbPolicy != nil {
+								policy.LoadBalancer.LbPolicy = portTrafficPolicy.LoadBalancer.LbPolicy
+							}
 							portUpdated = true
 							break
 						}


### PR DESCRIPTION
Fix the issue where port-level Tls and LoadBalancer settings from DestinationRule would unconditionally overwrite existing configurations converted from ingress annotations.

Changes:
- Add nil checks before setting policy.Tls to avoid overwriting existing configs
- Add nil checks before setting policy.LoadBalancer, with granular LbPolicy merging
- Align port-level policy merging logic with traffic-level policy merging (lines 841-853)



<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

