### PR TITLE
chore: Remove the redundant Makefile for ai-proxy

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/Makefile
+++ b/plugins/wasm-go/extensions/ai-proxy/Makefile
@@ -1,4 +1,0 @@
-.DEFAULT:
-build:
-	tinygo build -o ai-proxy.wasm -scheduler=none -target=wasi -gc=custom -tags='custommalloc nottinygc_finalizer proxy_wasm_version_0_2_100' ./main.go
-	mv ai-proxy.wasm ../../../../docker-compose-test/


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

### Ⅰ. Describe what this PR did

Remove the redundant Makefile for ai-proxy which still uses tinygo to build wasm binary.

### Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews

