### PR TITLE
vertex support global region

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
@@ -31,6 +31,7 @@ const (
 	vertexChatCompletionAction       = "generateContent"
 	vertexChatCompletionStreamAction = "streamGenerateContent?alt=sse"
 	vertexEmbeddingAction            = "predict"
+	vertexGlobalRegion               = "global"
 )
 
 type vertexProviderInitializer struct{}
@@ -95,7 +96,7 @@ func (v *vertexProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 
 func (v *vertexProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
 	var finalVertexDomain string
-	if v.config.vertexRegion != "global" {
+	if v.config.vertexRegion != vertexGlobalRegion {
 		finalVertexDomain = fmt.Sprintf("%s-%s", v.config.vertexRegion, vertexDomain)
 	} else {
 		finalVertexDomain = vertexDomain


### PR DESCRIPTION
## Ⅰ. Describe what this PR did
目前vertex倾向于使用global方式取代原来的指定region的方式，最新的gemini-3系列模型仅支持global方式访问，此PR增加ai-proxy对global的支持

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


## Ⅲ. Why don't you add test cases (unit test/integration test)? 


## Ⅳ. Describe how to verify it


## Ⅴ. Special notes for reviews



