### PR TITLE
bugfix for model-mapper & model-router

### DIFF
--- a/plugins/wasm-go/extensions/model-mapper/main.go
+++ b/plugins/wasm-go/extensions/model-mapper/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"sort"
 	"strings"
@@ -136,11 +137,8 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config Config) types.Action {
 			break
 		}
 	}
-	if !matched {
-		return types.ActionContinue
-	}
 
-	if !ctx.HasRequestBody() {
+	if !matched || !ctx.HasRequestBody() {
 		ctx.DontReadRequestBody()
 		return types.ActionContinue
 	}
@@ -155,6 +153,11 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config Config) types.Action {
 
 func onHttpRequestBody(ctx wrapper.HttpContext, config Config, body []byte) types.Action {
 	if len(body) == 0 {
+		return types.ActionContinue
+	}
+
+	if !json.Valid(body) {
+		log.Error("invalid json body")
 		return types.ActionContinue
 	}
 

--- a/plugins/wasm-go/extensions/model-router/main.go
+++ b/plugins/wasm-go/extensions/model-router/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -91,12 +92,8 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config ModelRouterConfig) typ
 		}
 	}
 
-	if !enable {
+	if !enable || !ctx.HasRequestBody() {
 		ctx.DontReadRequestBody()
-		return types.ActionContinue
-	}
-
-	if !ctx.HasRequestBody() {
 		return types.ActionContinue
 	}
 
@@ -124,7 +121,10 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config ModelRouterConfig, body [
 }
 
 func handleJsonBody(ctx wrapper.HttpContext, config ModelRouterConfig, body []byte) types.Action {
-
+	if !json.Valid(body) {
+		log.Error("invalid json body")
+		return types.ActionContinue
+	}
 	modelValue := gjson.GetBytes(body, config.modelKey).String()
 	if modelValue == "" {
 		return types.ActionContinue


### PR DESCRIPTION
## Ⅰ. Describe what this PR did
- bugfix: 修复model-mapper中后缀不匹配时仍会处理请求body的
- 增加对body的json验证，确保body是有效的json

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


## Ⅲ. Why don't you add test cases (unit test/integration test)? 


## Ⅳ. Describe how to verify it


## Ⅴ. Special notes for reviews



<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Ⅰ. Describe what this PR did
- bugfix: Fixed the problem that the request body will still be processed when the suffix does not match in model-mapper
- Add json verification for body to ensure that body is valid json

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


## Ⅲ. Why don't you add test cases (unit test/integration test)?


## Ⅳ. Describe how to verify it


## Ⅴ. Special notes for reviews
