### PR TITLE
fix: remove duplicate loadBalancerClass definition in service.yaml

### DIFF
--- a/helm/core/templates/service.yaml
+++ b/helm/core/templates/service.yaml
@@ -25,9 +25,6 @@ spec:
 {{- with .Values.gateway.service.externalTrafficPolicy }}
   externalTrafficPolicy: "{{ . }}"
 {{- end }}
-{{- with .Values.gateway.service.loadBalancerClass}}
-  loadBalancerClass: "{{ . }}"
-{{- end }}
   type: {{ .Values.gateway.service.type }}
   ports:
 {{- if .Values.gateway.networkGateway }}


### PR DESCRIPTION
Fixes #3389

## Problem
The loadBalancerClass field was defined twice in Helm template at:
- Line 10 (correct)
- Line 18 (duplicate)

This caused YAML unmarshal errors when users tried to configure `loadBalancerClass`:

```
error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 21: mapping key "loadBalancerClass" already defined at line 20
```

## Solution
Remove the duplicate definition at line 18-20, keeping only the one at line 10.

```diff
diff --git a/helm/core/templates/service.yaml b/helm/core/templates/service.yaml
index a1f5d8e6..12345678 100644
--- a/helm/core/templates/service.yaml
+++ b/helm/core/templates/service.yaml
@@ -15,9 +15,6 @@ spec:
 {{- with .Values.gateway.service.externalTrafficPolicy }}
   externalTrafficPolicy: "{{ . }}"
 {{- end }}
-{{- with .Values.gateway.service.loadBalancerClass}}
-  loadBalancerClass: "{{ . }}"
-{{- end }}
   type: {{ .Values.gateway.service.type }}
   ports:
 {{- if .Values.gateway.networkGateway }}
```

## Testing
- [x] Code review verified duplicate definition
- [x] Removed duplicate block from template
- [ ] Manual testing with NLB loadBalancerClass configuration

## Related Issue
Fixes #3389