### PR TITLE
docs: update higress-clawdbot-integration SKILL.md with config subcommand

### DIFF
--- a/.claude/skills/higress-clawdbot-integration/SKILL.md
+++ b/.claude/skills/higress-clawdbot-integration/SKILL.md
@@ -97,6 +97,24 @@ clawdbot models auth login --provider higress
 
 This will configure Clawdbot to use Higress AI Gateway as a model provider.
 
+### Step 6: Manage API Keys (optional)
+
+After deployment, you can manage API keys without redeploying:
+
+```bash
+# View configured API keys
+./get-ai-gateway.sh config list
+
+# Add or update an API key
+./get-ai-gateway.sh config add --provider <provider> --key <api-key>
+
+# Remove an API key
+./get-ai-gateway.sh config remove --provider <provider>
+
+# Restart gateway to apply changes
+./get-ai-gateway.sh stop && ./get-ai-gateway.sh start
+```
+
 ## CLI Parameters Reference
 
 ### Basic Options
@@ -147,6 +165,48 @@ $DATA_FOLDER/logs/access.log
 ```
 
 These logs can be used with the **agent-session-monitor** skill for token tracking and conversation analysis.
+
+## Managing API Keys
+
+After deployment, use the `config` subcommand to manage LLM provider API keys:
+
+```bash
+# List all configured API keys
+./get-ai-gateway.sh config list
+
+# Add or update an API key
+./get-ai-gateway.sh config add --provider deepseek --key sk-xxx
+
+# Remove an API key
+./get-ai-gateway.sh config remove --provider deepseek
+```
+
+**Note:** After updating API keys using the `config` command, restart the gateway to apply changes:
+```bash
+./get-ai-gateway.sh stop && ./get-ai-gateway.sh start
+```
+
+**Supported providers:**
+- `dashscope` (or `qwen`) - Aliyun Dashscope (Qwen)
+- `deepseek` - DeepSeek
+- `moonshot` (or `kimi`) - Moonshot (Kimi)
+- `zhipuai` (or `zhipu`) - Zhipu AI
+- `openai` - OpenAI
+- `openrouter` - OpenRouter
+- `claude` - Claude
+- `gemini` - Google Gemini
+- `groq` - Groq
+- `doubao` - Doubao
+- `baichuan` - Baichuan AI
+- `yi` - 01.AI (Yi)
+- `stepfun` - Stepfun
+- `minimax` - Minimax
+- `cohere` - Cohere
+- `mistral` - Mistral AI
+- `github` - Github Models
+- `fireworks` - Fireworks AI
+- `togetherai` (or `together`) - Together AI
+- `grok` - Grok
 
 ## Managing Routing Rules
 
@@ -270,7 +330,48 @@ curl 'http://localhost:8080/v1/chat/completions' \
 - deep thinking What's the best architecture for this system?
 ```
 
-### Example 4: Full Integration with Clawdbot
+### Example 4: Manage API Keys
+
+**User:** 帮我查看当前配置的API keys，并添加一个DeepSeek的key
+
+**Steps:**
+1. List current API keys:
+   ```bash
+   ./get-ai-gateway.sh config list
+   ```
+
+2. Add DeepSeek API key:
+   ```bash
+   ./get-ai-gateway.sh config add --provider deepseek --key sk-xxx
+   ```
+
+3. Restart gateway:
+   ```bash
+   ./get-ai-gateway.sh stop && ./get-ai-gateway.sh start
+   ```
+
+**Response:**
+```
+当前配置的API keys:
+
+  Aliyun Dashscope (Qwen): sk-ab***ef12
+  OpenAI:                  sk-cd***gh34
+
+添加 DeepSeek API key...
+
+✅ API key updated successfully!
+
+Provider: DeepSeek
+Key: sk-xx***yy56
+
+Restart the gateway to apply changes:
+  ./get-ai-gateway.sh stop && ./get-ai-gateway.sh start
+
+正在重启网关...
+✅ 网关已重启，新的API key已生效！
+```
+
+### Example 5: Full Integration with Clawdbot
 
 **User:** 完整配置Higress和Clawdbot的集成
 


### PR DESCRIPTION
## Description

This PR updates the `higress-clawdbot-integration/SKILL.md` to document the new `config` subcommand for managing API keys.

## Changes

### New Documentation Sections

1. **Managing API Keys** - New section showing how to use the `config` subcommand:
   - `config list` - View all configured API keys (with masking)
   - `config add` - Add or update an API key
   - `config remove` - Remove an API key

2. **Step 6 in Workflow** - Added optional step for managing API keys after deployment

3. **Example 4** - New example showing API key management workflow

4. **Provider List** - Documented all supported provider names and aliases

### Updated Examples
- Renumbered Example 4 → Example 5 (Clawdbot integration) to make room for new API key example

## Related PR
This documentation update corresponds to the implementation PR:
- higress-standalone: https://github.com/higress-group/higress-standalone/pull/231

## Benefits
- Clear guidance on managing API keys without manual config file editing
- Better user experience for the `get-ai-gateway.sh` script
- Complete documentation of the new config subcommand

## Testing
- [x] Markdown syntax is correct
- [x] Examples are clear and accurate
- [x] Links and references are valid