### PR TITLE
docs: optimize higress-auto-router skill following Clawdbot standards

### DIFF
--- a/.claude/skills/higress-auto-router/SKILL.md
+++ b/.claude/skills/higress-auto-router/SKILL.md
@@ -1,17 +1,11 @@
-# Higress Auto Router SKILL
+---
+name: higress-auto-router
+description: Configure automatic model routing using the get-ai-gateway.sh CLI tool for Higress AI Gateway. Use when: (1) User wants to configure automatic model routing, (2) User mentions "route to", "switch model", "use model when", "auto routing", (3) User describes scenarios that should trigger specific models, (4) User wants to add, list, or remove routing rules.
+---
 
-Configure automatic model routing using the get-ai-gateway.sh CLI tool.
+# Higress Auto Router
 
-## Description
-
-This skill helps users configure Higress AI Gateway's model auto-routing feature through the CLI tool. Auto-routing allows intelligent model selection based on message content triggers.
-
-## When to Use
-
-Use this skill when:
-- User wants to configure automatic model routing
-- User mentions "route to", "switch model", "use model when", "auto routing"
-- User describes scenarios that should trigger specific models
+Configure automatic model routing using the get-ai-gateway.sh CLI tool for intelligent model selection based on message content triggers.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

This PR optimizes the `higress-auto-router` skill to follow Clawdbot skill-creator best practices.

## Changes

- ✅ Add proper YAML frontmatter with `name` and `description` fields
- ✅ Move triggering conditions from body to frontmatter `description`
- ✅ Remove redundant "Description" and "When to Use" sections
- ✅ Improve clarity and conciseness
- ✅ Follow progressive disclosure design principles

## Benefits

1. **Better skill triggering**: All trigger conditions now in frontmatter description where Clawdbot reads them
2. **Reduced token usage**: Removed redundant sections, more concise wording
3. **Standards compliance**: Follows official Clawdbot skill-creator guidelines
4. **Improved maintainability**: Clear structure makes future updates easier

## Testing

- [x] Skill follows YAML frontmatter format
- [x] Description includes both functionality and trigger conditions
- [x] Body contains only workflow guidance (no trigger info)
- [x] All existing functionality preserved