### PR TITLE
docs: remove IMAGE_REPO from skill, use PLUGIN_REGISTRY only

### DIFF
--- a/.claude/skills/higress-clawdbot-integration/SKILL.md
+++ b/.claude/skills/higress-clawdbot-integration/SKILL.md
@@ -190,22 +190,22 @@ After deployment, manage API keys without redeploying:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `IMAGE_REPO` | Container image repository URL (auto-selected based on timezone) | `higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/all-in-one` |
-| `PLUGIN_REGISTRY` | WASM plugin registry URL (auto-selected based on timezone) | `higress-registry.cn-hangzhou.cr.aliyuncs.com` |
+| `PLUGIN_REGISTRY` | Registry URL for container images and WASM plugins (auto-selected based on timezone) | `higress-registry.cn-hangzhou.cr.aliyuncs.com` |
 
 **Auto-Selection Logic:**
 
-Both `IMAGE_REPO` and `PLUGIN_REGISTRY` are automatically selected based on your timezone:
+The registry is automatically selected based on your timezone:
 
-- **China & nearby** (Asia/Shanghai, etc.) → Hangzhou mirror
-- **Southeast Asia** (Asia/Singapore, etc.) → Singapore mirror  
-- **North America** (America/*, etc.) → North America mirror
-- **Others** → Hangzhou mirror (default)
+- **China & nearby** (Asia/Shanghai, etc.) → `higress-registry.cn-hangzhou.cr.aliyuncs.com`
+- **Southeast Asia** (Asia/Singapore, etc.) → `higress-registry.ap-southeast-7.cr.aliyuncs.com`
+- **North America** (America/*, etc.) → `higress-registry.us-west-1.cr.aliyuncs.com`
+- **Others** → `higress-registry.cn-hangzhou.cr.aliyuncs.com` (default)
+
+Both container images and WASM plugins use the same registry for consistency.
 
 **Manual Override:**
 
 ```bash
-IMAGE_REPO="higress-registry.ap-southeast-7.cr.aliyuncs.com/higress/all-in-one" \
 PLUGIN_REGISTRY="higress-registry.ap-southeast-7.cr.aliyuncs.com" \
   ./get-ai-gateway.sh start --non-interactive ...
 ```


### PR DESCRIPTION
## Summary

Simplify the higress-clawdbot-integration skill documentation by removing `IMAGE_REPO` from the exposed environment variables. Users now only need to know about `PLUGIN_REGISTRY`.

## Background

After higress-group/higress-standalone#240:
- `IMAGE_REPO` is automatically derived from `PLUGIN_REGISTRY`
- Users no longer need to set both variables
- Single source of truth: `PLUGIN_REGISTRY`

## Changes

### Environment Variables Section

**Before:**
| Variable | Description | Default |
|----------|-------------|---------|
| `IMAGE_REPO` | Container image repository URL (auto-selected based on timezone) | `higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/all-in-one` |
| `PLUGIN_REGISTRY` | WASM plugin registry URL (auto-selected based on timezone) | `higress-registry.cn-hangzhou.cr.aliyuncs.com` |

**Manual Override:**
```bash
IMAGE_REPO="..." PLUGIN_REGISTRY="..." ./get-ai-gateway.sh ...
```

**After:**
| Variable | Description | Default |
|----------|-------------|---------|
| `PLUGIN_REGISTRY` | Registry URL for container images and WASM plugins (auto-selected based on timezone) | `higress-registry.cn-hangzhou.cr.aliyuncs.com` |

**Manual Override:**
```bash
PLUGIN_REGISTRY="..." ./get-ai-gateway.sh ...
```

### Updates

1. **Removed `IMAGE_REPO` row** from Environment Variables table
2. **Updated `PLUGIN_REGISTRY` description** to mention both container images and plugins
3. **Simplified auto-selection logic** - no need to explain both variables
4. **Updated manual override example** - only one variable needed
5. **Added clarification** - "Both container images and WASM plugins use the same registry for consistency"

## Benefits

✅ **Simpler user interface** - One variable instead of two  
✅ **Less confusion** - No need to understand IMAGE_REPO vs PLUGIN_REGISTRY  
✅ **Single source of truth** - PLUGIN_REGISTRY controls everything  
✅ **Consistent with implementation** - Matches higress-standalone#240 behavior

## User Impact

**Before:**
Users might think they need to set both `IMAGE_REPO` and `PLUGIN_REGISTRY`:
```bash
IMAGE_REPO="higress-registry.ap-southeast-7.cr.aliyuncs.com/higress/all-in-one" \
PLUGIN_REGISTRY="higress-registry.ap-southeast-7.cr.aliyuncs.com" \
  ./get-ai-gateway.sh start ...
```

**After:**
Users only need to set `PLUGIN_REGISTRY`:
```bash
PLUGIN_REGISTRY="higress-registry.ap-southeast-7.cr.aliyuncs.com" \
  ./get-ai-gateway.sh start ...
```

(The script automatically constructs `IMAGE_REPO` as `${PLUGIN_REGISTRY}/higress/all-in-one`)

## Testing

- [x] Documentation clearly explains PLUGIN_REGISTRY controls both
- [x] Manual override example simplified
- [x] Auto-selection logic remains clear
- [x] No references to IMAGE_REPO remain in Environment Variables

## Related

- Depends on: higress-group/higress-standalone#240 (reuse PLUGIN_REGISTRY for IMAGE_REPO)
- Follows: #3441 (initial auto-registry documentation)