### PR TITLE
fix(ai-proxy): 处理 Qwen 响应无选择项的情况

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
@@ -334,6 +334,11 @@ func (m *qwenProvider) buildChatCompletionResponse(ctx wrapper.HttpContext, qwen
 }
 
 func (m *qwenProvider) buildChatCompletionStreamingResponse(ctx wrapper.HttpContext, qwenResponse *qwenTextGenResponse, incrementalStreaming bool) []*chatCompletionResponse {
+	if len(qwenResponse.Output.Choices) == 0 {
+		log.Warnf("qwen response has no choices, request_id: %s", qwenResponse.RequestId)
+		return nil
+	}
+
 	baseMessage := chatCompletionResponse{
 		Id:                qwenResponse.RequestId,
 		Created:           time.Now().UnixMilli() / 1000,


### PR DESCRIPTION
根据修复内容，以下是按模板生成的 PR 描述：

---

## Ⅰ. Describe what this PR did

Fix a panic issue caused by array index out of bounds in `qwenProvider.buildChatCompletionStreamingResponse` when processing streaming responses.

**Root Cause:**
In high-concurrency scenarios, Qwen API may return responses with an empty `Choices` array. The original code directly accessed `Choices[0]` without checking if the array was empty, causing:
```
runtime error: index out of range [0] with length 0
```

**Fix:**
Added a length check before accessing `Choices[0]`. When `Choices` is empty, the function now logs a warning and returns `nil` gracefully instead of panicking.

```go
if len(qwenResponse.Output.Choices) == 0 {
    log.Warnf("qwen response has no choices, request_id: %s", qwenResponse.RequestId)
    return nil
}
```

## Ⅱ. Does this pull request fix one issue?

N/A (discovered during stress testing)

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This is a defensive programming fix for an edge case that occurs when the upstream Qwen API returns an unexpected empty response. The fix is straightforward (null check) and follows the existing error handling pattern in the codebase (returning `nil` for invalid responses).

## Ⅳ. Describe how to verify it

1. Run stress tests against the ai-proxy plugin with Qwen provider
2. Monitor logs for the warning message: `qwen response has no choices, request_id: xxx`
3. Verify no panic occurs even when upstream returns empty Choices array

## Ⅴ. Special notes for reviews

- The fix follows the existing pattern in the same function (line 364: `return nil` when tool call arguments are not ready)
- Added warning log to help trace upstream API anomalies
- Minimal change with no side effects on normal request processing

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

```
这是一个压测报告，你需要分析下这个报告的结论是否属实，如果 qwen ai-proxy 插件有问题，你需要修复它

崩溃函数:
- 文件: provider/qwen.go
- 行号: 348
- 函数: buildChatCompletionStreamingResponse
- 错误: 尝试访问长度为 0 的数组的第 0 个元素
```

### AI Coding Summary

**Key decisions made:**
- Chose to return `nil` (consistent with existing error handling in the same function) rather than returning an empty slice or error

**Major changes implemented:**
- Added array length check before accessing `Choices[0]` in `buildChatCompletionStreamingResponse`
- Added warning log with request_id for debugging upstream API issues

**Important considerations:**
- This is a defensive fix; the root cause may be upstream Qwen API behavior under high load
- The warning log helps identify if this edge case occurs frequently in production