### PR TITLE
VertexAI转换为openai协议支持FunctionCall

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
@@ -443,7 +443,13 @@ func (g *geminiProvider) buildGeminiChatRequest(request *chatCompletionRequest) 
 	if request.Tools != nil {
 		functions := make([]function, 0, len(request.Tools))
 		for _, tool := range request.Tools {
-			functions = append(functions, tool.Function)
+			// 清理 function parameters 中不支持的 JSON Schema 字段
+			cleanedFunc := function{
+				Name:        tool.Function.Name,
+				Description: tool.Function.Description,
+				Parameters:  cleanFunctionParameters(tool.Function.Parameters),
+			}
+			functions = append(functions, cleanedFunc)
 		}
 		geminiRequest.Tools = []geminiChatTools{
 			{

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model_test.go
@@ -1,0 +1,265 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCleanFunctionParameters(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty map",
+			input:    map[string]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "remove $schema at root level",
+			input: map[string]interface{}{
+				"$schema": "http://json-schema.org/draft-07/schema#",
+				"type":    "object",
+				"properties": map[string]interface{}{
+					"location": map[string]interface{}{
+						"type":        "string",
+						"description": "The city and state",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"location": map[string]interface{}{
+						"type":        "string",
+						"description": "The city and state",
+					},
+				},
+			},
+		},
+		{
+			name: "remove multiple unsupported fields",
+			input: map[string]interface{}{
+				"$schema":     "http://json-schema.org/draft-07/schema#",
+				"$id":         "https://example.com/schema",
+				"$comment":    "This is a comment",
+				"definitions": map[string]interface{}{},
+				"type":        "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{
+						"type": "string",
+					},
+				},
+			},
+		},
+		{
+			name: "nested $schema in properties",
+			input: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"nested": map[string]interface{}{
+						"$schema": "should be removed",
+						"type":    "object",
+						"properties": map[string]interface{}{
+							"field": map[string]interface{}{
+								"type": "string",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"nested": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"field": map[string]interface{}{
+								"type": "string",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "array with map elements",
+			input: map[string]interface{}{
+				"type": "array",
+				"items": []interface{}{
+					map[string]interface{}{
+						"$schema": "should be removed",
+						"type":    "string",
+					},
+					map[string]interface{}{
+						"type": "number",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "array",
+				"items": []interface{}{
+					map[string]interface{}{
+						"type": "string",
+					},
+					map[string]interface{}{
+						"type": "number",
+					},
+				},
+			},
+		},
+		{
+			name: "preserve valid fields",
+			input: map[string]interface{}{
+				"type":        "object",
+				"description": "A valid description",
+				"properties": map[string]interface{}{
+					"location": map[string]interface{}{
+						"type":        "string",
+						"description": "The city",
+						"enum":        []interface{}{"NYC", "LA", "SF"},
+					},
+				},
+				"required": []interface{}{"location"},
+			},
+			expected: map[string]interface{}{
+				"type":        "object",
+				"description": "A valid description",
+				"properties": map[string]interface{}{
+					"location": map[string]interface{}{
+						"type":        "string",
+						"description": "The city",
+						"enum":        []interface{}{"NYC", "LA", "SF"},
+					},
+				},
+				"required": []interface{}{"location"},
+			},
+		},
+		{
+			name: "remove $defs field",
+			input: map[string]interface{}{
+				"$defs": map[string]interface{}{
+					"Address": map[string]interface{}{
+						"type": "object",
+					},
+				},
+				"type": "object",
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+			},
+		},
+		{
+			name: "remove ref field without dollar sign",
+			input: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"options": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"ref":  "QuestionOption",
+							"type": "object",
+							"properties": map[string]interface{}{
+								"label": map[string]interface{}{
+									"type": "string",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"options": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"label": map[string]interface{}{
+									"type": "string",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "real world question tool schema",
+			input: map[string]interface{}{
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
+				"type":    "object",
+				"properties": map[string]interface{}{
+					"questions": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"options": map[string]interface{}{
+									"type": "array",
+									"items": map[string]interface{}{
+										"ref":  "QuestionOption",
+										"type": "object",
+										"properties": map[string]interface{}{
+											"label": map[string]interface{}{
+												"type": "string",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"questions": map[string]interface{}{
+						"type": "array",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"options": map[string]interface{}{
+									"type": "array",
+									"items": map[string]interface{}{
+										"type": "object",
+										"properties": map[string]interface{}{
+											"label": map[string]interface{}{
+												"type": "string",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cleanFunctionParameters(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("cleanFunctionParameters() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -279,6 +279,48 @@ type TransformResponseBodyHandler interface {
 	TransformResponseBody(ctx wrapper.HttpContext, apiName ApiName, body []byte) ([]byte, error)
 }
 
+// RedisConfig Redis配置结构体
+type RedisConfig struct {
+	// @Title zh-CN Redis服务名称
+	// @Description zh-CN Redis服务的FQDN，如 redis.static、redis.my-ns.svc.cluster.local
+	ServiceName string `yaml:"serviceName" json:"serviceName"`
+	// @Title zh-CN Redis服务端口
+	// @Description zh-CN Redis服务端口，static服务默认80，其他默认6379
+	ServicePort int `yaml:"servicePort" json:"servicePort"`
+	// @Title zh-CN Redis用户名
+	// @Description zh-CN Redis认证用户名（可选）
+	Username string `yaml:"username" json:"username"`
+	// @Title zh-CN Redis密码
+	// @Description zh-CN Redis认证密码（可选）
+	Password string `yaml:"password" json:"password"`
+	// @Title zh-CN 连接超时时间
+	// @Description zh-CN Redis连接超时时间，单位毫秒，默认1000
+	Timeout int `yaml:"timeout" json:"timeout"`
+	// @Title zh-CN 数据库ID
+	// @Description zh-CN Redis数据库ID，默认0
+	Database int `yaml:"database" json:"database"`
+}
+
+// FromJson 从JSON解析Redis配置
+func (r *RedisConfig) FromJson(json gjson.Result) {
+	r.ServiceName = json.Get("serviceName").String()
+	r.ServicePort = int(json.Get("servicePort").Int())
+	if r.ServicePort == 0 {
+		if strings.HasSuffix(r.ServiceName, ".static") {
+			r.ServicePort = 80
+		} else {
+			r.ServicePort = 6379
+		}
+	}
+	r.Username = json.Get("username").String()
+	r.Password = json.Get("password").String()
+	r.Timeout = int(json.Get("timeout").Int())
+	if r.Timeout == 0 {
+		r.Timeout = 1000
+	}
+	r.Database = int(json.Get("database").Int())
+}
+
 type ProviderConfig struct {
 	// @Title zh-CN ID
 	// @Description zh-CN AI服务提供商标识
@@ -391,6 +433,17 @@ type ProviderConfig struct {
 	// @Title zh-CN Vertex AI OpenAI兼容模式
 	// @Description zh-CN 启用后将使用Vertex AI的OpenAI兼容API，请求和响应均使用OpenAI格式，无需协议转换。与Express Mode(apiTokens)互斥。
 	vertexOpenAICompatible bool `required:"false" yaml:"vertexOpenAICompatible" json:"vertexOpenAICompatible"`
+	// @Title zh-CN Vertex AI Thought Signature 缓存开关
+	// @Description zh-CN 启用后将使用Redis缓存Gemini 3模型的thought_signature，用于多轮function calling场景。需要配置Redis连接信息。
+	vertexEnableThoughtSigCache bool `required:"false" yaml:"vertexEnableThoughtSigCache" json:"vertexEnableThoughtSigCache"`
+	// @Title zh-CN Vertex AI Thought Signature 缓存过期时间
+	// @Description zh-CN thought_signature在Redis中的过期时间，单位为秒。默认值为3600（1小时）。
+	vertexThoughtSigCacheTTL int `required:"false" yaml:"vertexThoughtSigCacheTTL" json:"vertexThoughtSigCacheTTL"`
+	// @Title zh-CN Redis服务配置
+	// @Description zh-CN 用于thought_signature缓存的Redis服务配置
+	redisConfig *RedisConfig `required:"false" yaml:"redis" json:"redis"`
+	// Redis客户端实例（运行时使用，不从配置中读取）
+	redisClient wrapper.RedisClient `yaml:"-" json:"-"`
 	// @Title zh-CN 翻译服务需指定的目标语种
 	// @Description zh-CN 翻译结果的语种，目前仅适用于DeepL服务。
 	targetLang string `required:"false" yaml:"targetLang" json:"targetLang"`
@@ -466,6 +519,21 @@ func (c *ProviderConfig) GetVllmServerHost() string {
 
 func (c *ProviderConfig) GetContextCleanupCommands() []string {
 	return c.contextCleanupCommands
+}
+
+// GetVertexEnableThoughtSigCache 返回是否启用Vertex thought_signature缓存
+func (c *ProviderConfig) GetVertexEnableThoughtSigCache() bool {
+	return c.vertexEnableThoughtSigCache
+}
+
+// GetVertexThoughtSigCacheTTL 返回thought_signature缓存的过期时间（秒）
+func (c *ProviderConfig) GetVertexThoughtSigCacheTTL() int {
+	return c.vertexThoughtSigCacheTTL
+}
+
+// GetRedisClient 返回Redis客户端实例
+func (c *ProviderConfig) GetRedisClient() wrapper.RedisClient {
+	return c.redisClient
 }
 
 func (c *ProviderConfig) IsOpenAIProtocol() bool {
@@ -555,6 +623,19 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 		c.vertexTokenRefreshAhead = 60
 	}
 	c.vertexOpenAICompatible = json.Get("vertexOpenAICompatible").Bool()
+	c.vertexEnableThoughtSigCache = json.Get("vertexEnableThoughtSigCache").Bool()
+	c.vertexThoughtSigCacheTTL = int(json.Get("vertexThoughtSigCacheTTL").Int())
+	if c.vertexThoughtSigCacheTTL == 0 {
+		c.vertexThoughtSigCacheTTL = 3600 // 默认1小时
+	}
+
+	// 解析Redis配置
+	redisJson := json.Get("redis")
+	if redisJson.Exists() {
+		c.redisConfig = &RedisConfig{}
+		c.redisConfig.FromJson(redisJson)
+	}
+
 	c.targetLang = json.Get("targetLang").String()
 
 	if schemaValue, ok := json.Get("responseJsonSchema").Value().(map[string]interface{}); ok {
@@ -680,6 +761,32 @@ func (c *ProviderConfig) Validate() error {
 	if err := initializer.ValidateConfig(c); err != nil {
 		return err
 	}
+
+	// 初始化Redis客户端（如果启用了Vertex thought_signature缓存）
+	if c.vertexEnableThoughtSigCache {
+		if c.redisConfig == nil || c.redisConfig.ServiceName == "" {
+			log.Warn("vertexEnableThoughtSigCache is enabled but redis config is missing, disabling thought_signature cache")
+			c.vertexEnableThoughtSigCache = false
+		} else {
+			c.redisClient = wrapper.NewRedisClusterClient(wrapper.FQDNCluster{
+				FQDN: c.redisConfig.ServiceName,
+				Port: int64(c.redisConfig.ServicePort),
+			})
+			err := c.redisClient.Init(
+				c.redisConfig.Username,
+				c.redisConfig.Password,
+				int64(c.redisConfig.Timeout),
+				wrapper.WithDataBase(c.redisConfig.Database),
+			)
+			if err != nil {
+				log.Errorf("failed to init redis client for thought_signature cache: %v", err)
+				c.vertexEnableThoughtSigCache = false
+			} else {
+				log.Info("redis client initialized for Vertex thought_signature cache")
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

本 PR 修复了 ai-proxy 插件在将 OpenAI 格式的 function calling 请求转换为 Vertex AI / Gemini 格式时的多个问题：

1. **JSON Schema 元数据字段清理** - 解决不支持的 JSON Schema 字段导致请求失败的问题
2. **Tool Call ID 生成** - 解决响应中缺少 `id` 字段导致客户端解析失败的问题
3. **Thought Signature 缓存** - 解决 Gemini 3 模型在多轮工具调用时因缺少 `thought_signature` 导致请求失败的问题

---

### 问题一：JSON Schema 元数据字段

当客户端使用 OpenAI 格式发送包含 `tools` 的请求时，function 的 `parameters` 字段可能包含标准 JSON Schema 元数据字段（如 `$schema`、`$ref`、`ref` 等）。这些字段在 OpenAI API 中是允许的，但 Vertex AI / Gemini API 使用的是 **OpenAPI 3.0 Schema 规范的子集**，不支持这些字段，导致请求失败并返回错误：

```
Invalid JSON payload received. Unknown name "$schema" at 'tools[0].function_declarations[0].parameters': Cannot find field.
```

或

```
Schema.ref 'QuestionOption' was set alongside unsupported fields.
```

---

### 问题二：Tool Call ID 缺失

客户端收到响应后报错：

```
Error: AI_InvalidResponseDataError: Expected 'id' to be a string.
```

原因是 Vertex AI 响应中的 `functionCall` 不包含 `id` 字段，但 OpenAI 格式要求每个 `tool_call` 必须有唯一的 `id`。

---

### 问题三：Thought Signature 缺失（Gemini 3 模型）

使用 Gemini 3 模型进行多轮工具调用时，出现错误：

```
Error: Unable to submit request because function call `grep` in the 4. content block is missing a `thought_signature`.
```

**背景说明**：

根据 [Google 官方文档](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures)，`thought_signature` 是模型内部推理过程的加密表示。Gemini 3 模型对 `thought_signature` 有严格的验证要求：

> Gemini 3 models enforce stricter validation on thought signatures than previous Gemini versions because they improve model performance for function calling. To ensure the model maintains full context across multiple turns of a conversation, you must return the thought signatures from previous responses in your subsequent requests.

关键规则：
- 当模型返回 `functionCall` 时，响应中会包含 `thoughtSignature` 字段
- 在后续请求中，必须将 `thoughtSignature` 附加到对应的 `functionCall` part 上（不是 `functionResponse`）
- 对于并行函数调用，只有第一个 `functionCall` 需要 `thoughtSignature`

**问题原因**：

1. 标准 OpenAI SDK 不会在请求中携带自定义字段（如 `thought_signature`）
2. 即使客户端保存了 `thought_signature`，WASM 插件的不同实例也无法共享内存状态

**解决方案**：

使用 Redis 缓存 `thought_signature`，实现跨 WASM 实例的状态共享

### 官方文档依据

**1. FunctionDeclaration 文档**
- 链接：https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/FunctionDeclaration
- 关键说明：
  > Structured representation of a function declaration as defined by the [OpenAPI 3.0 specification](https://spec.openapis.org/oas/v3.0.3).
  >
  > `parameters`: Describes the parameters of the function in the **OpenAPI JSON Schema Object format**.

**2. Schema 文档**
- 链接：https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/Schema
- 关键说明：
  > Defines the schema of input and output data. This is a **subset of the [OpenAPI 3.0 Schema Object](https://spec.openapis.org/oas/v3.0.3#schema-object)**.

**3. Function Calling Reference 文档**
- 链接：https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/function-calling
- Schema 支持的字段（仅限以下）：
  - `type` - 数据类型（STRING, INTEGER, BOOLEAN, NUMBER, ARRAY, OBJECT）
  - `description` - 描述
  - `enum` - 枚举值
  - `items` - 数组元素 schema
  - `properties` - 对象属性
  - `required` - 必需属性
  - `nullable` - 是否可为 null

**4. Thought Signatures 文档**
- 链接：https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures
- 关键说明：
  > Thought signatures are encrypted representations of the model's internal thought process.
  >
  > When constructing the next request, you must include the part containing the functionCall and its thought_signature exactly as it was returned by the model.

**5. Content API Reference**
- 链接：https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/Content
- Part 结构中的 `thoughtSignature` 字段：
  > Optional. An opaque signature for the thought so it can be reused in subsequent requests.

**6. 不支持的 JSON Schema 字段**

标准 JSON Schema 的以下元数据字段**不在** Vertex AI Schema 的支持列表中：
- `$schema` - JSON Schema 版本声明
- `$id` - Schema 标识符
- `$ref` / `ref` - Schema 引用（注：Vertex AI 有自己的 `ref` 字段格式，但与标准 JSON Schema 的 `$ref` 不兼容）
- `$defs` / `definitions` - Schema 定义块
- `$comment` - 注释
- `$vocabulary`, `$anchor`, `$dynamicRef`, `$dynamicAnchor` - 其他 JSON Schema 元数据

### 主要变更

#### 1. JSON Schema 清理

**新增 `cleanFunctionParameters` 函数**（`provider/model.go`）：
- 递归清理 function parameters 中不被 Vertex AI / Gemini 支持的 JSON Schema 字段
- 支持清理嵌套的 map 和数组结构
- 清理的字段包括：`$schema`、`$id`、`$ref`、`ref`、`$defs`、`definitions`、`$comment` 等

**修改 Vertex Provider 和 Gemini Provider**：
- 在 `buildVertexChatRequest` 和 `buildGeminiChatRequest` 中调用 `cleanFunctionParameters` 清理参数

#### 2. Tool Call ID 生成

**修改 `buildChatCompletionResponse` 和 `buildChatCompletionStreamResponse`**（`provider/vertex.go`）：
- 使用 `uuid.New().String()` 为每个 `toolCall` 生成唯一的 `id`
- 格式：`call_{uuid}`，如 `call_32553908-c148-4a0c-8c30-d7be45848e63`

#### 3. Thought Signature 缓存（Gemini 3 支持）

**新增 Redis 缓存机制**（`provider/vertex.go`）：

- **`storeThoughtSignature`**：将响应中的 `thoughtSignature` 存入 Redis
  - Key 格式：`higress-vertex-thought-sig:{tool_call_id}`
  - 支持配置 TTL（默认 3600 秒）

- **`fetchThoughtSignaturesFromRedis`**：批量从 Redis 获取 `thoughtSignature`
  - 支持异步回调模式
  - 自动暂停请求等待 Redis 响应

- **`transformRequestBodyAfterRedis`**：在 Redis 获取完成后执行请求体转换
  - 正确处理 Express Mode 和标准模式的认证流程

- **`getThoughtSignatureFromContext`**：从请求上下文获取已缓存的 `thoughtSignature`

**修改 `buildVertexChatRequest`**：
- 在处理 `ToolCalls` 时，从 Redis 缓存获取 `thoughtSignature`
- 将 `thoughtSignature` 附加到 `functionCall` part 上（符合 Google 文档要求）

**修改 `buildChatCompletionResponse` 和 `buildChatCompletionStreamResponse`**：
- 遍历所有 parts 查找 `FunctionCall` 和 `ThoughtSignature`
- 将 `thoughtSignature` 存入 Redis 以供后续请求使用

**新增 `vertexPart` 结构体字段**：
- 添加 `ThoughtSignature string `json:"thoughtSignature,omitempty"`` 字段

**新增配置选项**（`provider/provider.go`）：
- `vertexEnableThoughtSigCache`：是否启用 thought_signature 缓存
- `vertexThoughtSigCacheTTL`：缓存 TTL（秒）
- `redisConfig`：Redis 连接配置

#### 4. 添加单元测试

**`provider/model_test.go`**：
- 覆盖 JSON Schema 清理的各种场景

### 示例

#### JSON Schema 清理示例

**转换前（OpenAI 格式）：**
```json
{
  "parameters": {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type": "object",
    "properties": {
      "options": {
        "type": "array",
        "items": {
          "ref": "QuestionOption",
          "type": "object",
          "properties": {
            "label": { "type": "string" }
          }
        }
      }
    }
  }
}
```

**转换后（Vertex AI 格式）：**
```json
{
  "parameters": {
    "type": "object",
    "properties": {
      "options": {
        "type": "array",
        "items": {
          "type": "object",
          "properties": {
            "label": { "type": "string" }
          }
        }
      }
    }
  }
}
```

#### Thought Signature 处理流程

**步骤 1：模型返回 functionCall 时**
```json
{
  "candidates": [{
    "content": {
      "role": "model",
      "parts": [{
        "functionCall": {
          "name": "grep",
          "args": {"pattern": "foo"}
        },
        "thoughtSignature": "<BASE64_SIGNATURE>"
      }]
    }
  }]
}
```
插件生成 `tool_call_id`（如 `call_abc123`），并将 `thoughtSignature` 存入 Redis：
- Key: `higress-vertex-thought-sig:call_abc123`
- Value: `<BASE64_SIGNATURE>`

**步骤 2：客户端发送工具响应时**
```json
{
  "messages": [
    {"role": "assistant", "tool_calls": [{"id": "call_abc123", "function": {"name": "grep"}}]},
    {"role": "tool", "tool_call_id": "call_abc123", "content": "result..."}
  ]
}
```
插件从 Redis 获取 `thoughtSignature`，并附加到 Vertex AI 请求的 `functionCall` part 上：
```json
{
  "contents": [
    {
      "role": "model",
      "parts": [{
        "functionCall": {"name": "grep", "args": {"pattern": "foo"}},
        "thoughtSignature": "<BASE64_SIGNATURE>"
      }]
    },
    {
      "role": "user",
      "parts": [{
        "functionResponse": {"name": "grep", "response": {"output": "result..."}}
      }]
    }
  ]
}
```

## Ⅱ. Does this pull request fix one issue?

修复了 Vertex AI / Gemini Provider 在 function calling 场景下的以下问题：

1. 包含 JSON Schema 元数据字段的请求返回错误
2. 响应中缺少 `id` 字段导致客户端解析失败
3. Gemini 3 模型在多轮工具调用时因缺少 `thought_signature` 返回 400 错误

## Ⅲ. Why don't you add test cases (unit test/integration test)?

已添加 `cleanFunctionParameters` 的单元测试，位于 `provider/model_test.go`，覆盖以下场景：

- ✅ nil 输入处理
- ✅ 空 map 处理
- ✅ 根级别 `$schema` 清理
- ✅ 多个不支持字段的清理（`$schema`、`$id`、`$comment`、`definitions`）
- ✅ 嵌套属性中的 `$schema` 清理
- ✅ 数组中 map 元素的清理
- ✅ 保留有效字段（`type`、`description`、`properties`、`required`、`enum` 等）
- ✅ `$defs` 字段清理
- ✅ 不带 `$` 前缀的 `ref` 字段清理
- ✅ 真实 tool schema 的完整清理测试

Thought Signature 缓存功能需要 Redis 环境，建议通过集成测试验证。

## Ⅳ. Describe how to verify it

### 方式一：运行单元测试

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test -gcflags="all=-N -l" -v -run TestCleanFunctionParameters ./provider
```

### 方式二：验证 JSON Schema 清理

1. **配置 Vertex AI Provider**：

```yaml
provider:
  type: vertex
  apiTokens:
    - "YOUR_API_KEY"
```

2. **发送包含 `$schema` 的请求**：

```bash
curl -X POST http://your-gateway/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gemini-2.5-flash",
    "messages": [{"role": "user", "content": "Hello"}],
    "tools": [{
      "type": "function",
      "function": {
        "name": "get_weather",
        "description": "Get weather info",
        "parameters": {
          "$schema": "http://json-schema.org/draft-07/schema#",
          "type": "object",
          "properties": {
            "location": {"type": "string"}
          }
        }
      }
    }]
  }'
```

3. **验证**：
   - 请求不再返回 `Unknown name "$schema"` 错误
   - Function calling 正常工作

### 方式三：验证 Thought Signature 缓存（Gemini 3 模型）

1. **配置启用 Thought Signature 缓存**：

```yaml
provider:
  type: vertex
  apiTokens:
    - "YOUR_API_KEY"
  vertexEnableThoughtSigCache: true
  vertexThoughtSigCacheTTL: 3600
  redis:
    serviceName: "redis.static"
    servicePort: 6379
```

2. **使用 Gemini 3 模型进行多轮工具调用**：
   - 第一次请求触发工具调用
   - 发送工具响应
   - 继续对话，触发更多工具调用

3. **验证**：
   - 不再返回 `missing a thought_signature` 错误
   - 多轮工具调用正常工作

## Ⅴ. Special notes for reviews

1. **向后兼容**：此修改不影响现有功能
   - JSON Schema 清理只是在协议转换时过滤掉不支持的字段
   - Tool Call ID 生成对客户端透明
   - Thought Signature 缓存默认禁用，需要显式配置启用

2. **递归处理**：`cleanFunctionParameters` 函数递归处理嵌套结构，确保所有层级的不支持字段都被清理

3. **同时修复 Gemini Provider**：JSON Schema 清理逻辑同时应用于 Gemini Provider

4. **Redis 依赖**：Thought Signature 缓存功能需要 Redis 服务
   - 如果未配置 Redis 或 Redis 不可用，功能自动降级（跳过缓存）
   - 使用异步回调模式，不阻塞请求处理

5. **异步处理流程**：Thought Signature 缓存涉及复杂的异步处理
   - 请求阶段：暂停请求 → 从 Redis 获取签名 → 转换请求体 → 获取 OAuth token → 恢复请求
   - 响应阶段：解析响应 → 异步存储签名到 Redis（不阻塞响应）

6. **Gemini 3 兼容性**：此功能专为 Gemini 3 模型设计，解决其严格的 thought_signature 验证要求

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [ ] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Summary

**问题分析：**

1. **JSON Schema 清理**：OpenAI API 对 function parameters 中的 JSON Schema 支持比较宽松，允许 `$schema`、`$ref` 等元数据字段；Vertex AI / Gemini API 基于 OpenAPI 3.0 规范，只支持简化的 JSON Schema 字段

2. **Tool Call ID 缺失**：Vertex AI 响应中的 `functionCall` 不包含 `id` 字段，但 OpenAI 格式要求每个 `tool_call` 必须有唯一的 `id`

3. **Thought Signature 缺失**：Gemini 3 模型对 `thought_signature` 有严格的验证要求，必须在后续请求中携带之前响应中的签名；标准 OpenAI SDK 不会传递自定义字段，且 WASM 实例间无法共享内存状态

**解决方案：**

1. **JSON Schema 清理**：创建 `cleanFunctionParameters` 递归清理函数，在协议转换时过滤不支持的字段

2. **Tool Call ID 生成**：使用 `uuid.New().String()` 为每个 `toolCall` 生成唯一的 `id`

3. **Thought Signature 缓存**：使用 Redis 缓存 `thought_signature`，实现跨 WASM 实例的状态共享
   - 响应阶段：提取 `thoughtSignature` 并存入 Redis
   - 请求阶段：从 Redis 获取 `thoughtSignature` 并附加到 `functionCall` part
   - 正确处理异步 Redis 操作和 OAuth token 获取的流程

**主要变更：**

1. `provider/model.go` - 新增 `cleanFunctionParameters` 函数
2. `provider/vertex.go` - 主要修改：
   - 调用 `cleanFunctionParameters` 清理 JSON Schema
   - 生成 `tool_call_id`
   - 新增 Redis 缓存相关函数
   - 修改请求/响应处理逻辑以支持 thought_signature
3. `provider/gemini.go` - 调用 `cleanFunctionParameters` 清理 JSON Schema
4. `provider/provider.go` - 新增 Redis 配置和 thought_signature 缓存配置
5. `provider/model_test.go` - 新增 `cleanFunctionParameters` 单元测试
