### PR TITLE
chore: update higress-console helm dependency to 2.2.0

### DIFF
--- a/helm/higress/Chart.lock
+++ b/helm/higress/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.2.0
 - name: higress-console
   repository: https://higress.io/helm-charts/
-  version: 2.1.9
-digest: sha256:a19cce034e4447f5e6e7fc82585fa83940f3d939cb1c928f1a819b8b2a06a084
-generated: "2026-02-11T17:24:09.254005+08:00"
+  version: 2.2.0
+digest: sha256:2cb148fa6d52856344e1905d3fea018466c2feb52013e08997c2d5c7d50f2e5d
+generated: "2026-02-11T17:45:59.187965929+08:00"

--- a/helm/higress/Chart.yaml
+++ b/helm/higress/Chart.yaml
@@ -15,6 +15,6 @@ dependencies:
   version: 2.2.0
 - name: higress-console
   repository: "https://higress.io/helm-charts/"
-  version: 2.1.9
+  version: 2.2.0
 type: application
 version: 2.2.0


### PR DESCRIPTION
Update higress-console helm chart dependency from 2.1.9 to 2.2.0.

Changes:
- Update Chart.yaml: higress-console version 2.1.9 → 2.2.0
- Update Chart.lock via `helm dependency update`