### PR TITLE
feat: optimize skills packaging in OSS sync workflow

### DIFF
--- a/.github/workflows/sync-skills-to-oss.yaml
+++ b/.github/workflows/sync-skills-to-oss.yaml
@@ -22,10 +22,22 @@ jobs:
           wget -O install.sh https://raw.githubusercontent.com/higress-group/higress-standalone/main/all-in-one/get-ai-gateway.sh
           chmod +x install.sh
 
+      - name: Package Skills
+        run: |
+          mkdir -p packaged-skills
+          cd .claude/skills
+          for skill_dir in */; do
+            skill_name="${skill_dir%/}"
+            echo "Packaging $skill_name..."
+            cd "$skill_dir"
+            zip -r "../../packaged-skills/${skill_name}.zip" .
+            cd ..
+          done
+
       - name: Sync Skills to OSS
         uses: go-choppy/ossutil-github-action@master
         with:
-          ossArgs: 'cp -r -u .claude/skills/ oss://higress-ai/skills/'
+          ossArgs: 'cp -r -u packaged-skills/ oss://higress-ai/skills/'
           accessKey: ${{ secrets.ACCESS_KEYID }}
           accessSecret: ${{ secrets.ACCESS_KEYSECRET }}
           endpoint: oss-cn-hongkong.aliyuncs.com


### PR DESCRIPTION
Optimize the skills sync workflow to package each skill as a separate zip file before uploading to OSS.

## Changes
- Each skill directory under `.claude/skills/` is now packaged as `{skill-name}.zip`
- Zip files are uploaded to `oss://higress-ai/skills/`
- Maintains the same OSS sync for AI Gateway install script

## Package Structure
```
my-skill.zip
└── my-skill/
    ├── SKILL.md
    └── resources/
```

This makes it easier to download and distribute individual skills.