### PR TITLE
fix: use absolute path for packaging skills

### DIFF
--- a/.github/workflows/sync-skills-to-oss.yaml
+++ b/.github/workflows/sync-skills-to-oss.yaml
@@ -25,13 +25,12 @@ jobs:
       - name: Package Skills
         run: |
           mkdir -p packaged-skills
-          cd .claude/skills
-          for skill_dir in */; do
-            skill_name="${skill_dir%/}"
-            echo "Packaging $skill_name..."
-            cd "$skill_dir"
-            zip -r "../../packaged-skills/${skill_name}.zip" .
-            cd ..
+          for skill_dir in .claude/skills/*/; do
+            if [ -d "$skill_dir" ]; then
+              skill_name=$(basename "$skill_dir")
+              echo "Packaging $skill_name..."
+              (cd "$skill_dir" && zip -r "$GITHUB_WORKSPACE/packaged-skills/${skill_name}.zip" .)
+            fi
           done
 
       - name: Sync Skills to OSS


### PR DESCRIPTION
Fix the path resolution issue in the skills packaging workflow.

## Problem
The previous implementation used relative paths which failed when cd into subdirectories:
```bash
cd "$skill_dir"
zip -r "../../packaged-skills/${skill_name}.zip" .  # Path breaks here
```

## Solution
- Use `$GITHUB_WORKSPACE` to create absolute paths
- Use subshell to avoid changing working directory
- Add directory existence check for safety

This ensures the zip command can always find the output directory regardless of the current working directory.