### PR TITLE
fix(skill): update higress-openclaw-integration to use dedicated install directory

### DIFF
--- a/.claude/skills/higress-openclaw-integration/SKILL.md
+++ b/.claude/skills/higress-openclaw-integration/SKILL.md
@@ -53,6 +53,10 @@ Deploy Higress AI Gateway and configure OpenClaw to use it as a unified model pr
 ### Step 2: Deploy Gateway
 
 ```bash
+# Create installation directory
+mkdir -p higress-install
+cd higress-install
+
 # Download script (if not exists)
 curl -fsSL https://higress.ai/ai-gateway/install.sh -o get-ai-gateway.sh
 chmod +x get-ai-gateway.sh
@@ -157,7 +161,7 @@ Provider aliases: `dashscope`/`qwen`, `moonshot`/`kimi`, `zhipuai`/`zhipu`
 |----------|-----|
 | Chat Completions | http://localhost:8080/v1/chat/completions |
 | Console | http://localhost:8001 |
-| Logs | `./higress/logs/access.log` |
+| Logs | `./higress-install/logs/access.log` |
 
 ## Testing
 


### PR DESCRIPTION
## Description

This PR updates the higress-openclaw-integration skill to use a dedicated installation directory instead of polluting the current working directory.

## Changes

- Add `mkdir -p higress-install` and `cd higress-install` before running deployment
- Update log path from `./higress/logs/access.log` to `./higress-install/logs/access.log`

## Benefits

- Keeps the workspace clean by isolating Higress installation files
- Makes it easier to clean up or reinstall by simply removing the `higress-install` directory
- Aligns with best practices for tool installation workflows