### PR TITLE
feat(ai-proxy): add Codex mode support for OpenAI provider

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/README.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README.md
@@ -123,6 +123,35 @@ OpenAI 所对应的 `type` 为 `openai`。它特有的配置字段如下:
 | -------------------- | -------- | -------- | ------ | ---------------------------------------------------------------------------------- |
 | `openaiCustomUrl`    | string   | 非必填   | -      | 基于 OpenAI 协议的自定义后端 URL，例如: <www.example.com/myai/v1/chat/completions> |
 | `responseJsonSchema` | object   | 非必填   | -      | 预先定义 OpenAI 响应需满足的 Json Schema, 注意目前仅特定的几种模型支持该用法       |
+| `codexMode`          | boolean  | 非必填   | false  | 启用 Codex 伪装模式，使 OpenAI 兼容接口能够调用 ChatGPT 的 Codex API               |
+| `codexOriginator`    | string   | 非必填   | pi     | Codex 模式下设置请求头中的 originator 字段，用于标识客户端身份                     |
+
+**Codex 模式说明**
+
+启用 `codexMode: true` 时，插件将：
+- 将请求路径从 `/v1/chat/completions` 转换为 `/backend-api/codex/responses`
+- 设置 Codex 特定的请求头（`originator`、`OpenAI-Beta`、`chatgpt-account-id`）
+- 将 OpenAI 格式的请求体转换为 Codex API 格式（system prompt 移至 `instructions` 字段）
+- 从 JWT Token 中自动提取 ChatGPT Account ID
+
+**Codex 模式配置示例**：
+
+```yaml
+provider:
+  type: openai
+  codexMode: true
+  codexOriginator: pi  # 可选，默认为 "pi"
+  openaiCustomUrl: chatgpt.com/backend-api  # 可选，默认为 chatgpt.com/backend-api
+  apiTokens:
+    - "YOUR_CHATGPT_JWT_TOKEN"
+  modelMapping:
+    "*": "gpt-5.1-codex"
+```
+
+**注意事项**：
+1. Codex 模式需要使用 ChatGPT 的 JWT Token（从浏览器获取），而非 OpenAI API Key
+2. JWT Token 会自动解析出 `chatgpt-account-id` 并添加到请求头中
+3. 支持通过 `openaiCustomUrl` 配置自定义的 Codex 后端地址
 
 #### Azure OpenAI
 


### PR DESCRIPTION
## 功能说明

为 ai-proxy 插件的 OpenAI provider 添加 Codex 伪装模式，使 Higress 能够代理 ChatGPT 的 Codex API。

## 实现内容

### 配置字段
- `codexMode`: 启用/禁用 Codex 伪装模式
- `codexOriginator`: 设置请求头中的 originator（默认 "pi"）

### 核心功能

1. **请求头伪装**
   - 添加 `originator` 头部
   - 添加 `OpenAI-Beta: responses=experimental`
   - 自动提取并设置 `chatgpt-account-id`（从 JWT Token 解析）
   - 设置 `User-Agent` 为 Codex 客户端格式

2. **请求体协议转换**
   - System prompt → `instructions` 字段
   - Messages → `input` 字段（不含 system 消息）
   - 添加 Codex 特定字段：`store`, `text.verbosity`, `include`

3. **路径重写**
   - `/v1/chat/completions` → `/backend-api/codex/responses`

4. **域名处理**
   - 默认指向 `chatgpt.com` 而非 `api.openai.com`

## 配置示例

```yaml
provider:
  type: openai
  codexMode: true                    # 启用 Codex 伪装模式
  codexOriginator: pi                # 可选，默认为 "pi"
  openaiCustomUrl: chatgpt.com/backend-api  # 可选
  apiTokens:
    - "YOUR_CHATGPT_JWT_TOKEN"      # 使用 ChatGPT JWT Token，非 API Key
  modelMapping:
    "*": "gpt-5.1-codex"            # 映射到 Codex 模型
```

## 参考

实现参考了 [pi-mono](https://github.com/badlogic/pi-mono) 项目中 OpenAI Codex Responses provider 的伪装逻辑。

## 测试

- [x] 编译通过
- [x] 与现有 OpenAI provider 配置兼容
- [x] 遵循 Higress 插件架构规范
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Function description

Add Codex camouflage mode to the OpenAI provider of the ai-proxy plug-in so that Higress can proxy ChatGPT's Codex API.

## Implementation content

### Configuration fields
- `codexMode`: enable/disable Codex disguise mode
- `codexOriginator`: Set the originator in the request header (default "pi")

### Core functions

1. **Request header disguise**
   - Add `originator` header
   - Added `OpenAI-Beta: responses=experimental`
   - Automatically extract and set `chatgpt-account-id` (parsed from JWT Token)
   - Set `User-Agent` to Codex client format

2. **Request body protocol conversion**
   - System prompt → `instructions` field
   - Messages → `input` field (excluding system messages)
   - Added Codex specific fields: `store`, `text.verbosity`, `include`

3. **Path Rewriting**
   - `/v1/chat/completions` → `/backend-api/codex/responses`

4. **Domain name processing**
   - Defaults to `chatgpt.com` instead of `api.openai.com`

## Configuration example

```yaml
provider:
  type: openai
  codexMode: true # Enable Codex disguise mode
  codexOriginator: pi # Optional, default is "pi"
  openaiCustomUrl: chatgpt.com/backend-api # Optional
  apiTokens:
    - "YOUR_CHATGPT_JWT_TOKEN" # Use ChatGPT JWT Token, not API Key
  modelMapping:
    "*": "gpt-5.1-codex" # Map to Codex model
```

## Reference

The implementation refers to the disguise logic of the OpenAI Codex Responses provider in the [pi-mono](https://github.com/badlogic/pi-mono) project.

## Test

- [x] Compile passed
- [x] Compatible with existing OpenAI provider configurations
- [x] Follow Higress plug-in architecture specification
