### PR TITLE
feat(skill): add z.ai domain and code plan mode options

### DIFF
--- a/.claude/skills/higress-openclaw-integration/scripts/detect-region.sh
+++ b/.claude/skills/higress-openclaw-integration/scripts/detect-region.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Detect if user is in China region based on timezone
+# Returns: "china" or "international"
+
+TIMEZONE=$(cat /etc/timezone 2>/dev/null || timedatectl show --property=Timezone --value 2>/dev/null || echo "Unknown")
+
+# Check if timezone indicates China region (including Hong Kong)
+if [[ "$TIMEZONE" == "Asia/Shanghai" ]] || \
+   [[ "$TIMEZONE" == "Asia/Hong_Kong" ]] || \
+   [[ "$TIMEZONE" == *"China"* ]] || \
+   [[ "$TIMEZONE" == *"Beijing"* ]]; then
+  echo "china"
+else
+  echo "international"
+fi


### PR DESCRIPTION
## Summary

This PR updates the `higress-openclaw-integration` skill to support new z.ai options.

### Changes

1. **Brand Name Display**:
   - Chinese users see "智谱"
   - English users see "z.ai"

2. **Auto Domain Detection**:
   - Auto-detect timezone when user selects z.ai
   - If NOT in China: automatically set `--zhipuai-domain api.z.ai`
   - After deployment, notify user in English: "The z.ai endpoint domain has been set to api.z.ai. If you want to change it, let me know and I can update the configuration."

3. **Code Plan Mode**: Enabled by default for z.ai

4. **Skill Content**: All in English, only brand names can show Chinese

### Workflow

```
User selects z.ai/zhipu provider
         ↓
Detect user timezone
         ↓
Not in China? → Add --zhipuai-domain api.z.ai
         ↓
Deploy with --zhipuai-code-plan-mode
         ↓
Notify user about domain setting (in English)
         ↓
User can request domain change anytime
```

### Related PRs

- Backend support: https://github.com/alibaba/higress/pull/3488 (already merged)
- Standalone script support: https://github.com/higress-group/higress-standalone/pull/247