### PR TITLE
fix(ai-proxy): fix claude system content null serialization

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -73,8 +73,8 @@ type claudeChatMessageContent struct {
 	Name  string                 `json:"name,omitempty"`  // For tool_use
 	Input map[string]interface{} `json:"input,omitempty"` // For tool_use
 	// Tool result fields
-	ToolUseId string                     `json:"tool_use_id,omitempty"` // For tool_result
-	Content   claudeChatMessageContentWr `json:"content,omitempty"`     // For tool_result - can be string or array
+	ToolUseId string                      `json:"tool_use_id,omitempty"` // For tool_result
+	Content   *claudeChatMessageContentWr `json:"content,omitempty"`     // For tool_result - can be string or array
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for claudeChatMessageContentWr


### PR DESCRIPTION
## Problem

When using Claude Code mode in ai-proxy, the system prompt is built with `claudeChatMessageContent` struct. The `Content` field in this struct was being serialized as `null` instead of being omitted when empty:

```json
{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"你好"}],"system":[{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude.","cache_control":{"type":"ephemeral"},"content":null}],"max_tokens":4096}
```

This caused Claude API to reject the request with error:
```
system.0.content: Extra inputs are not permitted
```

## Root Cause

The `Content` field was defined as a value type (`claudeChatMessageContentWr`) with `omitempty` tag. However, Go's `omitempty` doesn't work for struct types with custom `MarshalJSON` - an empty struct still gets marshaled (to `null` in this case) instead of being omitted.

## Solution

Changed `Content` field from value type to pointer type (`*claudeChatMessageContentWr`). When the pointer is `nil`, `omitempty` correctly omits the field from JSON output.