### PR TITLE
fix(ai-proxy): include usage fields in Claude streaming response even when zero

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -247,8 +247,8 @@ type claudeTextGenContent struct {
 }
 
 type claudeTextGenUsage struct {
-	InputTokens              int    `json:"input_tokens,omitempty"`
-	OutputTokens             int    `json:"output_tokens,omitempty"`
+	InputTokens              int    `json:"input_tokens"`
+	OutputTokens             int    `json:"output_tokens"`
 	CacheReadInputTokens     int    `json:"cache_read_input_tokens,omitempty"`
 	CacheCreationInputTokens int    `json:"cache_creation_input_tokens,omitempty"`
 	ServiceTier              string `json:"service_tier,omitempty"`


### PR DESCRIPTION
## Problem

Some AI providers (e.g., zhipu) do not return usage info in streaming responses, resulting in empty `usage:{}` output. This is inconsistent with Claude's native API format which always includes `input_tokens` and `output_tokens` fields.

**Before:**
```json
{"type":"message_start","message":{...,"usage":{},...}}
```

**After:**
```json
{"type":"message_start","message":{...,"usage":{"input_tokens":0,"output_tokens":0},...}}
```

## Changes

- Remove `omitempty` from `InputTokens` and `OutputTokens` in `claudeTextGenUsage` struct
- Always populate usage fields in `message_start` event (set to 0 if not available)
- Always populate usage fields in `message_delta` event

## Testing

Tested with zhipu provider (glm-5 model) - streaming response now correctly includes usage fields with 0 values instead of empty object.