### PR TITLE
feat: add global.pluginHub and global.pluginNamespace for plugin image config

### DIFF
--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -75,6 +75,15 @@ global:
   # Dev builds from prow are on gcr.io
   hub: higress-registry.cn-hangzhou.cr.aliyuncs.com/higress
 
+  # -- Default hub for plugin images.
+  # Used by higress-console to configure built-in plugin image registry.
+  # If not set, defaults to the same registry as global.hub (without /higress suffix).
+  pluginHub: ""
+  # -- Default namespace for plugin images.
+  # Used by higress-console to configure built-in plugin image namespace.
+  # Default is "plugins".
+  pluginNamespace: ""
+
   # -- Specify image pull policy if default behavior isn't desired.
   # Default behavior: latest images will be Always else IfNotPresent.
   imagePullPolicy: ""

--- a/helm/higress/Chart.yaml
+++ b/helm/higress/Chart.yaml
@@ -18,3 +18,7 @@ dependencies:
   version: 2.2.0
 type: application
 version: 2.2.0
+
+# The following values are passed to sub-charts
+# global.pluginHub is used by higress-console to configure plugin image registry
+# global.pluginNamespace is used by higress-console to configure plugin image namespace


### PR DESCRIPTION
## What this PR does

This PR adds `global.pluginHub` and `global.pluginNamespace` parameters to the Higress Helm chart, allowing users to customize the registry and namespace for built-in plugin images.

### Changes

1. **helm/core/values.yaml**:
   - Added `global.pluginHub` parameter for plugin image registry
   - Added `global.pluginNamespace` parameter for plugin image namespace
   - These values are passed to higress-console sub-chart

2. **helm/higress/Chart.yaml**:
   - Added documentation comments about the new parameters

### Usage

When deploying Higress with a custom plugin registry:

```yaml
global:
  hub: my-registry.example.com/higress
  pluginHub: my-registry.example.com  # For built-in plugins
  pluginNamespace: my-plugins         # Optional, default is "plugins"
```

### How it works

1. `global.pluginHub` is passed to the higress-console sub-chart
2. higress-console uses this value to configure the `HIGRESS_ADMIN_WASM_PLUGIN_IMAGE_REGISTRY` environment variable
3. The WasmPluginService reads this env var and replaces the default registry in plugin URLs

### Related

This PR works together with the [higress-console PR](https://github.com/higress-group/higress-console/pull/666) to provide a complete solution.

### Note

The plugin images use a separate registry configuration (`pluginHub`) from the main Higress images (`hub`), because:
- Main Higress images: `{hub}/gateway`, `{hub}/controller`, etc. (includes `/higress` suffix)
- Plugin images: `{pluginHub}/plugins/{plugin-name}` (no suffix, uses `/plugins` namespace)