### PR TITLE
feat(ai-proxy): support qiniu ai provider

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/README.md
+++ b/plugins/wasm-go/extensions/ai-proxy/README.md
@@ -192,6 +192,10 @@ OpenRouter 所对应的 `type` 为 `openrouter`。它并无特有的配置字段
 
 Fireworks AI 所对应的 `type` 为 `fireworks`。它并无特有的配置字段。
 
+#### 七牛云（Qiniu）
+
+七牛云所对应的 `type` 为 `qiniu`。它并无特有的配置字段。
+
 #### 文心一言（Baidu）
 
 文心一言所对应的 `type` 为 `baidu`。它并无特有的配置字段。
@@ -2436,6 +2440,58 @@ providers:
         }
     ],
     "model": "gpt2",
+}
+```
+
+
+### 使用 OpenAI 协议代理七牛云服务
+
+**配置信息**
+
+```yaml
+provider:
+  type: qiniu
+  apiTokens:
+    - "YOUR_QINIU_API_TOKEN"
+```
+
+**请求示例**
+
+```json
+{
+  "model": "openai/gpt-5",
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ]
+}
+```
+
+**响应示例**
+
+```json
+{
+  "id": "chatcmpl-xxxx",
+  "object": "chat.completion",
+  "created": 1699123456,
+  "model": "openai/gpt-5",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "你好！我是 Codex，基于 GPT-5 的编码助手，在你的本机 Codex CLI 里工作。有什么可以帮助你的吗？"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 25,
+    "total_tokens": 35
+  }
 }
 ```
 

--- a/plugins/wasm-go/extensions/ai-proxy/main_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main_test.go
@@ -212,3 +212,9 @@ func TestConsumerAffinity(t *testing.T) {
 	test.RunConsumerAffinityParseConfigTests(t)
 	test.RunConsumerAffinityOnHttpRequestHeadersTests(t)
 }
+
+func TestQiniu(t *testing.T) {
+	test.RunQiniuParseConfigTests(t)
+	test.RunQiniuOnHttpRequestHeadersTests(t)
+	test.RunQiniuOnHttpRequestBodyTests(t)
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -147,6 +147,7 @@ const (
 	providerTypeLongcat    = "longcat"
 	providerTypeFireworks  = "fireworks"
 	providerTypeVllm       = "vllm"
+	providerTypeQiniu      = "qiniu"
 	providerTypeGeneric    = "generic"
 
 	protocolOpenAI   = "openai"
@@ -238,6 +239,7 @@ var (
 		providerTypeLongcat:    &longcatProviderInitializer{},
 		providerTypeFireworks:  &fireworksProviderInitializer{},
 		providerTypeVllm:       &vllmProviderInitializer{},
+		providerTypeQiniu:      &qiniuProviderInitializer{},
 		providerTypeGeneric:    &genericProviderInitializer{},
 	}
 )

--- a/plugins/wasm-go/extensions/ai-proxy/provider/qiniu.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qiniu.go
@@ -1,0 +1,67 @@
+package provider
+
+import (
+    "errors"
+    "net/http"
+
+    "github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
+    "github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+    "github.com/higress-group/wasm-go/pkg/wrapper"
+)
+
+// qiniuProvider is the provider for Qiniu AI service.
+const (
+    qiniuDomain = "api.qnaigc.com" 
+)
+
+type qiniuProviderInitializer struct{}
+
+func (m *qiniuProviderInitializer) ValidateConfig(config *ProviderConfig) error {
+    if len(config.apiTokens) == 0 {
+        return errors.New("no apiToken found in provider config")
+    }
+    return nil
+}
+
+func (m *qiniuProviderInitializer) DefaultCapabilities() map[string]string {
+    return map[string]string{
+        string(ApiNameChatCompletion): PathOpenAIChatCompletions,
+        string(ApiNameModels):         PathOpenAIModels,
+    }
+}
+
+func (m *qiniuProviderInitializer) CreateProvider(config ProviderConfig) (Provider, error) {
+    config.setDefaultCapabilities(m.DefaultCapabilities())
+    return &qiniuProvider{
+        config:       config,
+        contextCache: createContextCache(&config),
+    }, nil
+}
+
+type qiniuProvider struct {
+    config       ProviderConfig
+    contextCache *contextCache
+}
+
+func (m *qiniuProvider) GetProviderType() string {
+    return providerTypeQiniu
+}
+
+func (m *qiniuProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiName) error {
+    m.config.handleRequestHeaders(m, ctx, apiName)
+    return nil
+}
+
+func (m *qiniuProvider) OnRequestBody(ctx wrapper.HttpContext, apiName ApiName, body []byte) (types.Action, error) {
+    if !m.config.isSupportedAPI(apiName) {
+        return types.ActionContinue, errUnsupportedApiName
+    }
+    return m.config.handleRequestBody(m, m.contextCache, ctx, apiName, body)
+}
+
+func (m *qiniuProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
+    util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), m.config.capabilities)
+    util.OverwriteRequestHostHeader(headers, qiniuDomain)
+    util.OverwriteRequestAuthorizationHeader(headers, "Bearer "+m.config.GetApiTokenInUse(ctx))
+    headers.Del("Content-Length")
+}

--- a/plugins/wasm-go/extensions/ai-proxy/test/qiniu.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/qiniu.go
@@ -1,0 +1,117 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+var basicQiniuConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":      "qiniu",
+			"apiTokens": []string{"qiniu-test-token-123"},
+			"modelMapping": map[string]string{
+				"*": "Qwen/Qwen2.5-7B-Instruct",
+			},
+		},
+	})
+	return data
+}()
+
+var invalidQiniuConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":      "qiniu",
+			"apiTokens": []string{},
+		},
+	})
+	return data
+}()
+
+func RunQiniuParseConfigTests(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		t.Run("basic qiniu config", func(t *testing.T) {
+			host, status := test.NewTestHost(basicQiniuConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			config, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			require.NotNil(t, config)
+		})
+
+		t.Run("invalid qiniu config - missing apiToken", func(t *testing.T) {
+			host, status := test.NewTestHost(invalidQiniuConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusFailed, status)
+		})
+	})
+}
+
+func RunQiniuOnHttpRequestHeadersTests(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("qiniu chat completion request headers", func(t *testing.T) {
+			host, status := test.NewTestHost(basicQiniuConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+
+			// 验证 Host 替换为七牛域名
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost)
+			require.Equal(t, "api.qnaigc.com", hostValue)
+
+			// 验证 Authorization
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth)
+			require.Equal(t, "Bearer qiniu-test-token-123", authValue)
+
+			// 验证 Path
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath)
+			require.Equal(t, "/v1/chat/completions", pathValue)
+
+			// 验证 Content-Length 被删除
+			_, hasContentLength := test.GetHeaderValue(requestHeaders, "Content-Length")
+			require.False(t, hasContentLength)
+		})
+	})
+}
+
+func RunQiniuOnHttpRequestBodyTests(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("qiniu chat completion request body", func(t *testing.T) {
+			host, status := test.NewTestHost(basicQiniuConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			requestBody := `{"model":"gpt-4","messages":[{"role":"user","content":"你好"}]}`
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			// 验证模型被映射
+			require.Contains(t, string(processedBody), "Qwen/Qwen2.5-7B-Instruct")
+		})
+	})
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did
Add Qiniu (七牛云) AI provider support to the `ai-proxy` plugin.

The Qiniu provider is OpenAI-compatible and routes requests to `api.qnaigc.com`. It supports chat completions and model listing APIs.

Files changed:
- `provider/qiniu.go`: New provider implementation
- `provider/provider.go`: Register `qiniu` provider type
- `test/qiniu.go`: Unit tests for the Qiniu provider
- `main_test.go`: Register `TestQiniu` test suite
- `README.md`: Add Qiniu provider documentation and usage example

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
N/A

## Ⅲ. Why don't you add test cases (unit test/integration test)? 

Test cases are included. All tests pass:
- `RunQiniuParseConfigTests`: config parsing validation
- `RunQiniuOnHttpRequestHeadersTests`: request header transformation (Host, Authorization)
- `RunQiniuOnHttpRequestBodyTests`: request body processing and model mapping


## Ⅳ. Describe how to verify it
1. Run unit tests:
```bash
cd plugins/wasm-go/extensions/ai-proxy
go test -v -run TestQiniu ./...
```
2. Integration test with envoy.yaml (replace token with a valid Qiniu API token):
```bash
docker run --rm -it \
  -v $(pwd)/out/plugin.wasm:/etc/envoy/plugin.wasm \
  -v $(pwd)/envoy.yaml:/etc/envoy/envoy.yaml \
  -p 10000:10000 \
  --entrypoint /usr/local/bin/envoy \
  higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/gateway:latest \
  -c /etc/envoy/envoy.yaml

curl -X POST http://localhost:10000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "stream": false}'

```

## Ⅴ. Special notes for reviews

The Qiniu provider follows the same pattern as other OpenAI-compatible providers. No special handling is needed — it simply rewrites the Host header to api.qnaigc.com and injects the Bearer token.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)
<!-- 
**IMPORTANT**: If you used AI Coding tools (e.g., Cursor, GitHub Copilot, etc.) to generate this PR, please check the following items.
PRs that don't meet these requirements will have **LOWER REVIEW PRIORITY** and we **CANNOT GUARANTEE** timely reviews.

If you did NOT use AI Coding tools, you can skip this section entirely.
-->

**Please check all applicable items:**

- [ ] **For regular updates/changes** (not new plugins):
  - [] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [*] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)
<!-- Paste the prompts/instructions you provided to the AI Coding tool -->


### AI Coding Summary
<!-- 
AI Coding tool should provide a summary after completing the work, including:
- Key decisions made
- Major changes implemented  
- Important considerations or limitations
-->
#### Key decisions made:

- Followed the existing OpenAI-compatible provider pattern (same as groq, fireworks, deepseek)
- Used api.qnaigc.com as the provider domain
- Registered capabilities for ChatCompletion and Models APIs only, as Qiniu's API is OpenAI-compatible

#### Major changes implemented:
- New qiniuProvider struct implementing the Provider interface
- TransformRequestHeaders: rewrites Host to api.qnaigc.com, injects Bearer token, removes Content-Length
- ValidateConfig: requires at least one API token
- Registered providerTypeQiniu = "qiniu" in the provider initializers map

#### Important considerations:
- No custom request/response transformation needed; Qiniu's API is fully OpenAI-compatible



