### PR TITLE
修复 ai-proxy 插件 Bedrock Provider 在 AWS AK/SK 鉴权模式下仅对部分 API 进行 SigV4 签名的问题 || Fixed the problem of ai-proxy plug-in Bedrock Provider only performing SigV4 signature on some APIs in AWS AK/SK authentication mode

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
@@ -40,6 +40,11 @@ const (
 	requestIdHeader        = "X-Amzn-Requestid"
 )
 
+var (
+	bedrockConversePathPattern = regexp.MustCompile(`/model/[^/]+/converse(-stream)?$`)
+	bedrockInvokePathPattern   = regexp.MustCompile(`/model/[^/]+/invoke(-with-response-stream)?$`)
+)
+
 type bedrockProviderInitializer struct{}
 
 func (b *bedrockProviderInitializer) ValidateConfig(config *ProviderConfig) error {
@@ -630,13 +635,24 @@ func (b *bedrockProvider) GetProviderType() string {
 	return providerTypeBedrock
 }
 
+func (b *bedrockProvider) GetApiName(path string) ApiName {
+	switch {
+	case bedrockConversePathPattern.MatchString(path):
+		return ApiNameChatCompletion
+	case bedrockInvokePathPattern.MatchString(path):
+		return ApiNameImageGeneration
+	default:
+		return ""
+	}
+}
+
 func (b *bedrockProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiName) error {
 	b.config.handleRequestHeaders(b, ctx, apiName)
 	return nil
 }
 
 func (b *bedrockProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
-	util.OverwriteRequestHostHeader(headers, fmt.Sprintf(bedrockDefaultDomain, b.config.awsRegion))
+	util.OverwriteRequestHostHeader(headers, fmt.Sprintf(bedrockDefaultDomain, strings.TrimSpace(b.config.awsRegion)))
 
 	// If apiTokens is configured, set Bearer token authentication here
 	// This follows the same pattern as other providers (qwen, zhipuai, etc.)
@@ -647,6 +663,15 @@ func (b *bedrockProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiNa
 }
 
 func (b *bedrockProvider) OnRequestBody(ctx wrapper.HttpContext, apiName ApiName, body []byte) (types.Action, error) {
+	// In original protocol mode (e.g. /model/{modelId}/converse-stream), keep the body/path untouched
+	// and only apply auth headers.
+	if b.config.IsOriginal() {
+		headers := util.GetRequestHeaders()
+		b.setAuthHeaders(body, headers)
+		util.ReplaceRequestHeaders(headers)
+		return types.ActionContinue, replaceRequestBody(body)
+	}
+
 	if !b.config.isSupportedAPI(apiName) {
 		return types.ActionContinue, errUnsupportedApiName
 	}
@@ -654,14 +679,25 @@ func (b *bedrockProvider) OnRequestBody(ctx wrapper.HttpContext, apiName ApiName
 }
 
 func (b *bedrockProvider) TransformRequestBodyHeaders(ctx wrapper.HttpContext, apiName ApiName, body []byte, headers http.Header) ([]byte, error) {
+	var transformedBody []byte
+	var err error
 	switch apiName {
 	case ApiNameChatCompletion:
-		return b.onChatCompletionRequestBody(ctx, body, headers)
+		transformedBody, err = b.onChatCompletionRequestBody(ctx, body, headers)
 	case ApiNameImageGeneration:
-		return b.onImageGenerationRequestBody(ctx, body, headers)
+		transformedBody, err = b.onImageGenerationRequestBody(ctx, body, headers)
 	default:
-		return b.config.defaultTransformRequestBody(ctx, apiName, body)
+		transformedBody, err = b.config.defaultTransformRequestBody(ctx, apiName, body)
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Always apply auth after request body/path are finalized.
+	// For Bearer token mode this is a no-op; for AK/SK mode this generates SigV4 headers.
+	b.setAuthHeaders(transformedBody, headers)
+	return transformedBody, nil
 }
 
 func (b *bedrockProvider) TransformResponseBody(ctx wrapper.HttpContext, apiName ApiName, body []byte) ([]byte, error) {
@@ -715,9 +751,7 @@ func (b *bedrockProvider) buildBedrockImageGenerationRequest(origRequest *imageG
 			Quality:        origRequest.Quality,
 		},
 	}
-	requestBytes, err := json.Marshal(request)
-	b.setAuthHeaders(requestBytes, headers)
-	return requestBytes, err
+	return json.Marshal(request)
 }
 
 func (b *bedrockProvider) buildBedrockImageGenerationResponse(bedrockResponse *bedrockImageGenerationResponse) *imageGenerationResponse {
@@ -847,9 +881,7 @@ func (b *bedrockProvider) buildBedrockTextGenerationRequest(origRequest *chatCom
 		request.AdditionalModelRequestFields[key] = value
 	}
 
-	requestBytes, err := json.Marshal(request)
-	b.setAuthHeaders(requestBytes, headers)
-	return requestBytes, err
+	return json.Marshal(request)
 }
 
 func (b *bedrockProvider) buildChatCompletionResponse(ctx wrapper.HttpContext, bedrockResponse *bedrockConverseResponse) *chatCompletionResponse {
@@ -1163,43 +1195,86 @@ func (b *bedrockProvider) setAuthHeaders(body []byte, headers http.Header) {
 	}
 
 	// Use AWS Signature V4 authentication
+	accessKey := strings.TrimSpace(b.config.awsAccessKey)
+	region := strings.TrimSpace(b.config.awsRegion)
 	t := time.Now().UTC()
 	amzDate := t.Format("20060102T150405Z")
 	dateStamp := t.Format("20060102")
 	path := headers.Get(":path")
 	signature := b.generateSignature(path, amzDate, dateStamp, body)
 	headers.Set("X-Amz-Date", amzDate)
-	util.OverwriteRequestAuthorizationHeader(headers, fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s/%s/%s/aws4_request, SignedHeaders=%s, Signature=%s", b.config.awsAccessKey, dateStamp, b.config.awsRegion, awsService, bedrockSignedHeaders, signature))
+	util.OverwriteRequestAuthorizationHeader(headers, fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s/%s/%s/aws4_request, SignedHeaders=%s, Signature=%s", accessKey, dateStamp, region, awsService, bedrockSignedHeaders, signature))
 }
 
 func (b *bedrockProvider) generateSignature(path, amzDate, dateStamp string, body []byte) string {
-	path = encodeSigV4Path(path)
+	canonicalURI := encodeSigV4Path(path)
 	hashedPayload := sha256Hex(body)
+	region := strings.TrimSpace(b.config.awsRegion)
+	secretKey := strings.TrimSpace(b.config.awsSecretKey)
 
-	endpoint := fmt.Sprintf(bedrockDefaultDomain, b.config.awsRegion)
+	endpoint := fmt.Sprintf(bedrockDefaultDomain, region)
 	canonicalHeaders := fmt.Sprintf("host:%s\nx-amz-date:%s\n", endpoint, amzDate)
 	canonicalRequest := fmt.Sprintf("%s\n%s\n\n%s\n%s\n%s",
-		httpPostMethod, path, canonicalHeaders, bedrockSignedHeaders, hashedPayload)
+		httpPostMethod, canonicalURI, canonicalHeaders, bedrockSignedHeaders, hashedPayload)
 
-	credentialScope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, b.config.awsRegion, awsService)
+	credentialScope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, region, awsService)
 	hashedCanonReq := sha256Hex([]byte(canonicalRequest))
 	stringToSign := fmt.Sprintf("AWS4-HMAC-SHA256\n%s\n%s\n%s",
 		amzDate, credentialScope, hashedCanonReq)
 
-	signingKey := getSignatureKey(b.config.awsSecretKey, dateStamp, b.config.awsRegion, awsService)
+	signingKey := getSignatureKey(secretKey, dateStamp, region, awsService)
 	signature := hmacHex(signingKey, stringToSign)
 	return signature
 }
 
 func encodeSigV4Path(path string) string {
+	// Keep only the URI path for canonical URI. Query string is handled separately in SigV4,
+	// and this implementation uses an empty canonical query string.
+	if queryIndex := strings.Index(path, "?"); queryIndex >= 0 {
+		path = path[:queryIndex]
+	}
+
 	segments := strings.Split(path, "/")
 	for i, seg := range segments {
 		if seg == "" {
 			continue
 		}
-		segments[i] = url.PathEscape(seg)
+		// Normalize to "single-encoded" form:
+		// - raw ":" -> %3A
+		// - already encoded "%3A" -> still %3A (not %253A)
+		decoded, err := url.PathUnescape(seg)
+		if err == nil {
+			segments[i] = sigV4EscapePathSegment(decoded)
+		} else {
+			// If segment has invalid escape sequence, fall back to escaping raw segment.
+			segments[i] = sigV4EscapePathSegment(seg)
+		}
 	}
 	return strings.Join(segments, "/")
+}
+
+func sigV4EscapePathSegment(segment string) string {
+	const upperHex = "0123456789ABCDEF"
+	var b strings.Builder
+	b.Grow(len(segment) * 3)
+	for i := 0; i < len(segment); i++ {
+		c := segment[i]
+		if isSigV4Unreserved(c) {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('%')
+		b.WriteByte(upperHex[c>>4])
+		b.WriteByte(upperHex[c&0x0F])
+	}
+	return b.String()
+}
+
+func isSigV4Unreserved(c byte) bool {
+	return (c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= '0' && c <= '9') ||
+		c == '-' || c == '_' || c == '.' || c == '~'
 }
 
 func getSignatureKey(key, dateStamp, region, service string) []byte {

--- a/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
@@ -25,6 +25,76 @@ var basicBedrockConfig = func() json.RawMessage {
 	return data
 }()
 
+// Test config: Bedrock original protocol config with AWS Access Key/Secret Key
+var bedrockOriginalAkSkConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":         "bedrock",
+			"protocol":     "original",
+			"awsAccessKey": "test-ak-for-unit-test",
+			"awsSecretKey": "test-sk-for-unit-test",
+			"awsRegion":    "us-east-1",
+		},
+	})
+	return data
+}()
+
+// Test config: Bedrock original protocol config with api token
+var bedrockOriginalApiTokenConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":      "bedrock",
+			"protocol":  "original",
+			"awsRegion": "us-east-1",
+			"apiTokens": []string{
+				"test-token-for-unit-test",
+			},
+		},
+	})
+	return data
+}()
+
+// Test config: Bedrock original protocol config with AWS Access Key/Secret Key and custom settings
+var bedrockOriginalAkSkWithCustomSettingsConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":         "bedrock",
+			"protocol":     "original",
+			"awsAccessKey": "test-ak-for-unit-test",
+			"awsSecretKey": "test-sk-for-unit-test",
+			"awsRegion":    "us-east-1",
+			"customSettings": []map[string]interface{}{
+				{
+					"name":      "foo",
+					"value":     "\"bar\"",
+					"mode":      "raw",
+					"overwrite": true,
+				},
+			},
+		},
+	})
+	return data
+}()
+
+// Test config: Bedrock config with embeddings capability to verify generic SigV4 flow
+var bedrockEmbeddingsCapabilityConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":         "bedrock",
+			"awsAccessKey": "test-ak-for-unit-test",
+			"awsSecretKey": "test-sk-for-unit-test",
+			"awsRegion":    "us-east-1",
+			"capabilities": map[string]string{
+				"openai/v1/embeddings": "/model/amazon.titan-embed-text-v2:0/invoke",
+			},
+			"modelMapping": map[string]string{
+				"*": "amazon.titan-embed-text-v2:0",
+			},
+		},
+	})
+	return data
+}()
+
 // Test config: Bedrock config with Bearer Token authentication
 var bedrockApiTokenConfig = func() json.RawMessage {
 	data, _ := json.Marshal(map[string]interface{}{
@@ -350,6 +420,169 @@ func RunBedrockOnHttpRequestBodyTests(t *testing.T) {
 			require.True(t, hasPath, "Path header should exist")
 			require.Contains(t, pathValue, "/model/", "Path should contain Bedrock model path")
 			require.Contains(t, pathValue, "/converse", "Path should contain converse endpoint")
+		})
+
+		// Test Bedrock generic request body processing with AWS Signature V4 authentication
+		t.Run("bedrock embeddings request body with ak/sk should use sigv4", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockEmbeddingsCapabilityConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/embeddings"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "text-embedding-3-small",
+				"input": "Hello from embeddings"
+			}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist")
+			require.Contains(t, authValue, "AWS4-HMAC-SHA256", "Authorization should use AWS4-HMAC-SHA256 signature")
+			require.Contains(t, authValue, "Credential=", "Authorization should contain Credential")
+			require.Contains(t, authValue, "Signature=", "Authorization should contain Signature")
+
+			dateValue, hasDate := test.GetHeaderValue(requestHeaders, "X-Amz-Date")
+			require.True(t, hasDate, "X-Amz-Date header should exist for AWS Signature V4")
+			require.NotEmpty(t, dateValue, "X-Amz-Date should not be empty")
+		})
+
+		// Test Bedrock original converse-stream path with AWS Signature V4 authentication
+		t.Run("bedrock original converse-stream with ak/sk should use sigv4", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockOriginalAkSkConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			originalPath := "/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/converse-stream"
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", originalPath},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"messages": [
+					{
+						"role": "user",
+						"content": [{"text": "Hello from original bedrock path"}]
+					}
+				],
+				"inferenceConfig": {
+					"maxTokens": 64
+				}
+			}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist")
+			require.Contains(t, authValue, "AWS4-HMAC-SHA256", "Authorization should use AWS4-HMAC-SHA256 signature")
+			require.Contains(t, authValue, "Credential=", "Authorization should contain Credential")
+			require.Contains(t, authValue, "Signature=", "Authorization should contain Signature")
+
+			dateValue, hasDate := test.GetHeaderValue(requestHeaders, "X-Amz-Date")
+			require.True(t, hasDate, "X-Amz-Date header should exist for AWS Signature V4")
+			require.NotEmpty(t, dateValue, "X-Amz-Date should not be empty")
+
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath, "Path header should exist")
+			require.Equal(t, originalPath, pathValue, "Original Bedrock path should be kept unchanged")
+		})
+
+		// Test Bedrock original converse-stream path with Bearer Token authentication
+		t.Run("bedrock original converse-stream with api token should pass bearer auth", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockOriginalApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			originalPath := "/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/converse-stream"
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", originalPath},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"messages": [
+					{
+						"role": "user",
+						"content": [{"text": "Hello from original bedrock path"}]
+					}
+				]
+			}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist")
+			require.Contains(t, authValue, "Bearer ", "Authorization should use Bearer token")
+			require.Contains(t, authValue, "test-token-for-unit-test", "Authorization should contain configured token")
+
+			_, hasDate := test.GetHeaderValue(requestHeaders, "X-Amz-Date")
+			require.False(t, hasDate, "X-Amz-Date should not be set in Bearer token mode")
+
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath, "Path header should exist")
+			require.Equal(t, originalPath, pathValue, "Original Bedrock path should be kept unchanged")
+		})
+
+		// Test Bedrock original converse-stream path keeps signed body consistent with custom settings
+		t.Run("bedrock original converse-stream with custom settings should replace body before forwarding", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockOriginalAkSkWithCustomSettingsConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			originalPath := "/model/amazon.nova-2-lite-v1:0/converse-stream"
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", originalPath},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"messages": [
+					{
+						"role": "user",
+						"content": [{"text": "Hello"}]
+					}
+				]
+			}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.NotNil(t, processedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(processedBody, &bodyMap)
+			require.NoError(t, err)
+			require.Equal(t, "\"bar\"", bodyMap["foo"], "Custom settings should be applied to forwarded body")
+
+			authValue, hasAuth := test.GetHeaderValue(host.GetRequestHeaders(), "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist")
+			require.Contains(t, authValue, "AWS4-HMAC-SHA256", "Authorization should use AWS4-HMAC-SHA256 signature")
 		})
 
 		// Test Bedrock streaming request


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

本 PR 修复了 ai-proxy 插件 Bedrock Provider 在 AWS AK/SK 鉴权模式下仅对部分 API 进行 SigV4 签名的问题。

### 背景

当前实现中，`setAuthHeaders`（SigV4 签名）只在 Bedrock 的 Chat Completion 和 Image Generation 请求构建函数中调用。  
这导致当 Bedrock 通过 `capabilities` 扩展支持其他 API（例如 `embeddings`）时，请求虽然会被处理，但不会进入 SigV4 鉴权链路，进而出现鉴权不一致问题。

### 主要变更

1. **统一 Bedrock 请求鉴权入口**（`provider/bedrock.go` - `TransformRequestBodyHeaders`）：
   - 对所有进入 `TransformRequestBodyHeaders` 的请求，先完成请求体转换与路径确定
   - 在统一出口调用 `setAuthHeaders`
   - 当配置为 `apiTokens`（Bearer）模式时，`setAuthHeaders` 内部保持 no-op；当配置为 AK/SK 时统一生成 SigV4

2. **支持 Bedrock 原生路径识别与鉴权**（`provider/bedrock.go`）：
   - 新增 `GetApiName(path string)`，识别：
     - `/model/{modelId}/converse`
     - `/model/{modelId}/converse-stream`
     - `/model/{modelId}/invoke`
   - 在 `protocol: original` 场景下，`OnRequestBody` 对原始请求体直接执行 `setAuthHeaders`，不改写 body/path
   - 在 `protocol: original` 场景下，`OnRequestBody` 在签名后显式回写请求体，确保“签名时 body”和“实际转发 body”一致
   - 对 `apiTokens` 场景保持 Bearer 鉴权透传到后端服务

3. **移除局部重复签名逻辑**（`provider/bedrock.go`）：
   - 删除 `buildBedrockTextGenerationRequest` 中的内联签名调用
   - 删除 `buildBedrockImageGenerationRequest` 中的内联签名调用
   - 避免签名逻辑分散，确保行为一致、易于维护

4. **修复 SigV4 Canonical URI 编码一致性**（`provider/bedrock.go`）：
   - 规范化 canonical URI 的路径编码，按 SigV4 规则对路径段进行百分号编码
   - 对 modelId 中的 `:`，统一编码为 `%3A`
   - 同时兼容输入路径中已编码 `%3A` 与未编码 `:` 的场景，避免出现双重编码或未编码导致的签名不一致

### 修复前后对比

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| Bedrock Chat Completion（AK/SK） | ✅ 会签名 | ✅ 会签名 |
| Bedrock Image Generation（AK/SK） | ✅ 会签名 | ✅ 会签名 |
| Bedrock 其他 capability（如 embeddings，AK/SK） | ❌ 不会签名 | ✅ 会签名 |
| Bedrock 原生路径 `/model/{modelId}/converse-stream`（AK/SK, original） | ❌ 不会签名 | ✅ 会签名 |
| Bedrock 原生路径 `/model/{modelId}/converse-stream`（apiTokens, original） | ⚠️ 无明确覆盖 | ✅ Bearer 鉴权透传 |
| Bedrock 原生路径中 modelId 含 `:`（AK/SK） | ❌ 可能因 canonical URI 编码不一致导致签名失败 | ✅ canonical URI 编码与 Bedrock 对齐 |
| Bedrock Bearer Token 模式 | ✅ Bearer 鉴权 | ✅ 保持 Bearer，不受影响 |

## Ⅱ. Does this pull request fix one issue?

修复 Bedrock Provider 在 AK/SK 模式下鉴权覆盖范围不完整的问题：  
`setAuthHeaders` 仅对 chat/image 生效，无法覆盖其他已支持的 Bedrock 请求体 API。

## Ⅲ. Why don't you add test cases (unit test/integration test)?

已添加单元测试，位于 `test/bedrock.go`：

- ✅ 新增配置 `bedrockEmbeddingsCapabilityConfig`
- ✅ 新增用例 `bedrock embeddings request body with ak/sk should use sigv4`
  - 验证 `Authorization` 包含 `AWS4-HMAC-SHA256`
  - 验证 `X-Amz-Date` 存在且非空
- ✅ 新增配置 `bedrockOriginalAkSkConfig` / `bedrockOriginalApiTokenConfig`
- ✅ 新增用例 `bedrock original converse-stream with ak/sk should use sigv4`
  - 验证原生路径下 AK/SK 会生成 SigV4
- ✅ 新增用例 `bedrock original converse-stream with api token should pass bearer auth`
  - 验证原生路径下 Bearer 鉴权头可透传到后端
- ✅ 新增用例 `bedrock original converse-stream with custom settings should replace body before forwarding`
  - 验证 original 场景下签名与转发使用同一份请求体（避免 payload hash 不一致）
  - 用例路径使用未编码 `:` 的 modelId，覆盖 canonical URI 规范化编码场景

同时回归执行了已有 Bedrock 测试，全部通过。

## Ⅳ. Describe how to verify it

### 方式一：运行单元测试

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test -gcflags="all=-N -l" -v -run TestBedrock ./...
```

### 方式二：手动验证

1. 配置 Bedrock Provider，使用 AK/SK，并开启 embeddings capability（示例）：

```yaml
provider:
  type: bedrock
  awsAccessKey: "YOUR_AK"
  awsSecretKey: "YOUR_SK"
  awsRegion: "us-east-1"
  capabilities:
    openai/v1/embeddings: "/model/amazon.titan-embed-text-v2:0/invoke"
  modelMapping:
    "*": "amazon.titan-embed-text-v2:0"
```

2. 发送请求：

```bash
curl -X POST http://your-gateway/v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{
    "model": "text-embedding-3-small",
    "input": "hello"
  }'
```

3. 验证转发请求头中包含：
   - `Authorization: AWS4-HMAC-SHA256 ...`
   - `X-Amz-Date: ...`

4. 配置 Bedrock Provider 为 `protocol: original`，请求原生路径 `/model/{modelId}/converse-stream`，验证：
   - AK/SK 模式：存在 `Authorization: AWS4-HMAC-SHA256 ...` 和 `X-Amz-Date`
   - apiTokens 模式：存在 `Authorization: Bearer ...`

## Ⅴ. Special notes for reviews

1. **行为兼容**：Bearer Token 模式不变，仍由 `TransformRequestHeaders` 设置 `Authorization: Bearer ...`
2. **统一出口**：SigV4 逻辑集中在 `TransformRequestBodyHeaders` 的统一返回路径，避免后续新增 API 时漏签名
3. **原生路径支持**：`protocol: original` + `/model/.../converse-stream` 场景下也进入鉴权链路
4. **签名一致性**：补充了 canonical URI 路径编码规范化，确保 modelId 含 `:` 时签名与 Bedrock 端计算一致

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have included the AI Coding summary below

### AI Coding Summary

**问题根因：**
1. Bedrock 的 SigV4 调用点分散在 chat/image 请求构建函数中
2. 其他 capability API 走默认请求体转换分支时不会触发签名
3. original 路径中 modelId 含 `:` 时，canonical URI 编码与 Bedrock 计算不一致，导致签名校验失败

**修复方案：**
1. 将 SigV4 调用迁移到 `TransformRequestBodyHeaders` 的统一出口
2. 在所有分支完成请求体转换后统一调用 `setAuthHeaders`
3. 删除 chat/image 构建函数中的重复签名调用
4. 新增 Bedrock 原生路径 API 识别（`/model/.../converse-stream` 等）
5. 在 original 协议场景下直接对原始请求执行鉴权（不改写 body/path）
6. 新增 embeddings 与 original converse-stream 的 AK/SK 与 apiTokens 测试覆盖
7. 统一 canonical URI 路径段编码，确保 `:` 始终规范编码为 `%3A` 且避免双重编码
8. 问题定位完成后移除临时 SigV4 调试日志，保留必要业务日志

**影响范围：**
1. `provider/bedrock.go`：`GetApiName`、`OnRequestBody`、`TransformRequestBodyHeaders`、`buildBedrockTextGenerationRequest`、`buildBedrockImageGenerationRequest`、`encodeSigV4Path`
2. `test/bedrock.go`：新增 embeddings/original converse-stream 场景测试

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Ⅰ. Describe what this PR did

This PR fixes the problem that the ai-proxy plug-in Bedrock Provider only performs SigV4 signing on some APIs in AWS AK/SK authentication mode.

### Background

In the current implementation, `setAuthHeaders` (SigV4 signature) is only called in Bedrock's Chat Completion and Image Generation request build functions.  
This results in that when Bedrock supports other APIs (such as `embeddings`) through `capabilities` extension, although the request will be processed, it will not enter the SigV4 authentication link, resulting in authentication inconsistency issues.

### Major changes

1. **Unified Bedrock request authentication entrance** (`provider/bedrock.go` - `TransformRequestBodyHeaders`):
   - For all requests entering `TransformRequestBodyHeaders`, first complete the request body conversion and path determination
   - Call `setAuthHeaders` on unified exit
   - When configured as `apiTokens` (Bearer) mode, `setAuthHeaders` internally maintains no-op; when configured as AK/SK, SigV4 is generated uniformly

2. **Support Bedrock native path identification and authentication** (`provider/bedrock.go`):
   - Added `GetApiName(path string)` to identify:
     - `/model/{modelId}/converse`
     - `/model/{modelId}/converse-stream`
     - `/model/{modelId}/invoke`
   - In the `protocol: original` scenario, `OnRequestBody` directly executes `setAuthHeaders` on the original request body without rewriting body/path
   - In the `protocol: original` scenario, `OnRequestBody` explicitly writes back the request body after signing to ensure that the "signing body" and the "actual forwarding body" are consistent
   - Keep Bearer authentication transparently transmitted to the back-end service for the `apiTokens` scenario

3. **Remove partial duplicate signature logic** (`provider/bedrock.go`):
   - Removed inline signature call in `buildBedrockTextGenerationRequest`
   - Remove inline signature call in `buildBedrockImageGenerationRequest`
   - Avoid dispersion of signature logic to ensure consistent behavior and easy maintenance

4. **Fix SigV4 Canonical URI encoding consistency** (`provider/bedrock.go`):
   - Normalize the path encoding of canonical URI, and percent-encode the path segments according to SigV4 rules
   - For `:` in modelId, the unified encoding is `%3A`
   - Compatible with both encoded `%3A` and unencoded `:` scenarios in the input path to avoid signature inconsistencies caused by double encoding or unencoding

### Comparison before and after repair

| Scene | Before restoration | After restoration |
|------|--------|--------|
| Bedrock Chat Completion（AK/SK） | ✅ Will sign | ✅ Will sign |
| Bedrock Image Generation (AK/SK) | ✅ Will sign | ✅ Will sign |
| Bedrock other capabilities (such as embeddings, AK/SK) | ❌ Can’t sign | ✅ Can sign |
| Bedrock native path `/model/{modelId}/converse-stream` (AK/SK, original) | ❌ Can’t sign | ✅ Can sign |
| Bedrock native path `/model/{modelId}/converse-stream` (apiTokens, original) | ⚠️ No explicit coverage | ✅ Bearer authentication transparent transmission |
| The modelId in Bedrock's native path contains `:` (AK/SK) | ❌ The signature may fail due to inconsistent canonical URI encoding | ✅ The canonical URI encoding is aligned with Bedrock |
| Bedrock Bearer Token Mode | ✅ Bearer Authentication | ✅ Keep Bearer Unaffected |

## Ⅱ. Does this pull request fix one issue?

Fixed the problem of incomplete authentication coverage of Bedrock Provider in AK/SK mode:
`setAuthHeaders` only takes effect for chat/image and cannot cover other supported Bedrock request body APIs.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Unit tests have been added, located at `test/bedrock.go`:

- ✅ New configuration `bedrockEmbeddingsCapabilityConfig`
- ✅ New use case `bedrock embeddings request body with ak/sk should use sigv4`
  - Verify that `Authorization` contains `AWS4-HMAC-SHA256`
  - Verify that `X-Amz-Date` exists and is not empty
- ✅ New configuration `bedrockOriginalAkSkConfig` / `bedrockOriginalApiTokenConfig`
- ✅ New use case `bedrock original converse-stream with ak/sk should use sigv4`
  - Verify that AK/SK under the native path will generate SigV4
- ✅ New use case `bedrock original converse-stream with api token should pass bearer auth`
  - Verify that the Bearer authentication header under the native path can be transparently transmitted to the backend
- ✅ New use case `bedrock original converse-stream with custom settings should replace body before forwarding`
  - Verify that signature and forwarding use the same request body in the original scenario (to avoid payload hash inconsistency)
  - The use case path uses unencoded `:` modelId, covering the canonical URI canonical encoding scenario

At the same time, the existing Bedrock tests were re-executed and all passed.

## Ⅳ. Describe how to verify it

### Method 1: Run unit tests

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test -gcflags="all=-N -l" -v -run TestBedrock ./...
```

### Method 2: Manual verification

1. Configure Bedrock Provider, use AK/SK, and enable embeddings capability (example):

```yaml
provider:
  type: bedrock
  awsAccessKey: "YOUR_AK"
  awsSecretKey: "YOUR_SK"
  awsRegion: "us-east-1"
  capabilities:
    openai/v1/embeddings: "/model/amazon.titan-embed-text-v2:0/invoke"
  modelMapping:
    "*": "amazon.titan-embed-text-v2:0"
```

2. Send a request:

```bash
curl -X POST http://your-gateway/v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{
    "model": "text-embedding-3-small",
    "input": "hello"
  }'
```

3. Verify that the forwarding request header contains:
   - `Authorization: AWS4-HMAC-SHA256 ...`
   - `X-Amz-Date: ...`

4. Configure Bedrock Provider as `protocol: original`, request the native path `/model/{modelId}/converse-stream`, and verify:
   - AK/SK mode: `Authorization: AWS4-HMAC-SHA256 ...` and `X-Amz-Date` present
   - apiTokens mode: `Authorization: Bearer ...` exists

## Ⅴ. Special notes for reviews

1. **Behavior Compatibility**: Bearer Token mode remains unchanged and is still set by `TransformRequestHeaders` `Authorization: Bearer...`
2. **Unified export**: SigV4 logic is concentrated on the unified return path of `TransformRequestBodyHeaders` to avoid missing signatures when adding subsequent APIs.
3. **Original path support**: `protocol: original` + `/model/.../converse-stream` also enters the authentication link in the scenario
4. **Signature consistency**: Supplemented the canonical URI path encoding standardization to ensure that the signature is consistent with the Bedrock calculation when the modelId contains `:`

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have included the AI Coding summary below

### AI Coding Summary

**Root cause of the problem:**
1. Bedrock’s SigV4 call points are scattered in the chat/image request build function
2. Other capability APIs will not trigger signatures when taking the default request body conversion branch.
3. When the modelId in the original path contains `:`, the canonical URI encoding is inconsistent with the Bedrock calculation, causing the signature verification to fail.

**Fix:**
1. Migrate SigV4 calls to the unified exit of `TransformRequestBodyHeaders`
2. Call `setAuthHeaders` uniformly after all branches complete the request body conversion.
3. Remove duplicate signature calls in chat/image build function
4. Added Bedrock native path API recognition (`/model/.../converse-stream`, etc.)
5. Directly perform authentication on the original request in the original protocol scenario (without rewriting body/path)
6. Added AK/SK and apiTokens test coverage for embeddings and original converse-stream
7. Unify the encoding of canonical URI path segments to ensure that `:` is always canonically encoded as `%3A` and avoid double encoding
8. After the problem is located, remove the temporary SigV4 debugging log and keep the necessary business logs.

**Scope of influence:**
1. `provider/bedrock.go`: `GetApiName`, `OnRequestBody`, `TransformRequestBodyHeaders`, `buildBedrockTextGenerationRequest`, `buildBedrockImageGenerationRequest`, `encodeSigV4Path`
2. `test/bedrock.go`: Added embeddings/original converse-stream scenario test
