### PR TITLE
feat: add CI workflow to build and push plugin-server image on release

### DIFF
--- a/.github/workflows/build-and-push-plugin-server-image.yml
+++ b/.github/workflows/build-and-push-plugin-server-image.yml
@@ -1,0 +1,106 @@
+name: Build Plugin Server Image and Push
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      plugin_server_ref:
+        description: "plugin-server repo ref (branch/tag/commit, default: main)"
+        required: false
+        default: "main"
+        type: string
+      version:
+        description: "Version tag (optional, without leading v)"
+        required: false
+        type: string
+
+jobs:
+  build-plugin-server-image:
+    runs-on: ubuntu-latest
+    environment:
+      name: image-registry-plugin-server
+    env:
+      IMAGE_REGISTRY: ${{ vars.IMAGE_REGISTRY || 'higress-registry.cn-hangzhou.cr.aliyuncs.com' }}
+      IMAGE_NAME: ${{ vars.PLUGIN_SERVER_IMAGE_NAME || 'higress/plugin-server' }}
+    steps:
+      - name: "Clone plugin-server repository"
+        uses: actions/checkout@v4
+        with:
+          repository: higress-group/plugin-server
+          ref: ${{ github.event.inputs.plugin_server_ref || 'main' }}
+          path: plugin-server
+          fetch-depth: 1
+
+      - name: Free Up GitHub Actions Ubuntu Runner Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-plugin-server-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-plugin-server-
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.version }}" ]]; then
+            echo "manual_version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Calculate Docker metadata
+        id: docker-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=raw,value=${{ steps.version.outputs.manual_version }},enable=${{ steps.version.outputs.manual_version != '' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build Docker Image and Push
+        run: |
+          BUILT_IMAGE=""
+          readarray -t IMAGES <<< "${{ steps.docker-meta.outputs.tags }}"
+          for image in "${IMAGES[@]}"; do
+            echo "Image: $image"
+            if [ "$BUILT_IMAGE" == "" ]; then
+              docker buildx build \
+                  --platform linux/amd64,linux/arm64 \
+                  -t "$image" \
+                  -f plugin-server/Dockerfile \
+                  --push \
+                  plugin-server
+              BUILT_IMAGE="$image"
+            else
+              docker buildx imagetools create "$BUILT_IMAGE" --tag "$image"
+            fi
+          done


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add a new GitHub Actions workflow that automatically builds and pushes the `plugin-server` Docker image when a higress release tag (`v*.*.*`) is pushed.

Key changes to the workflow (originally copied from `higress-group/plugin-server`):
- **Checkout**: Clone `higress-group/plugin-server` repo (main branch by default) instead of the higress repo itself
- **New input `plugin_server_ref`**: Allow specifying plugin-server branch/tag/commit in `workflow_dispatch`
- **Version handling**: Added `Determine version` step to bridge `workflow_dispatch` manual version input to Docker metadata
- **Docker metadata tags**: Aligned with existing workflow patterns; `latest` enabled only on tag pushes
- **Build context**: Updated Dockerfile path and build context to `plugin-server/` subdirectory
- **Cache key**: Prefixed with `plugin-server` to avoid collision with other workflows

Image tags by trigger:

| Trigger | Tags |
|---------|------|
| Tag push `v1.5.0` | `sha-xxx`, `v1.5.0`, `1.5.0`, `latest` |
| `workflow_dispatch` version=1.5.0 | `sha-xxx`, `1.5.0` |
| `workflow_dispatch` no version | `sha-xxx` |

## Ⅱ. Does this pull request fix one issue?

No

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This is a CI workflow file. It can be verified by triggering `workflow_dispatch` manually after merge.

## Ⅳ. Describe how to verify it

1. After merge, use `workflow_dispatch` to manually trigger the workflow and verify:
   - plugin-server repo is cloned successfully
   - Docker image builds and pushes to registry
2. On next release tag push, verify automatic trigger

## Ⅴ. Special notes for reviews

- Requires `image-registry-plugin-server` environment with `REGISTRY_USERNAME`/`REGISTRY_PASSWORD` secrets configured in repo settings
- `higress-group/plugin-server` must be a public repo (otherwise checkout needs a token)

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Adapt the plugin-server image build workflow (copied from higress-group/plugin-server) for the higress repo: clone plugin-server main branch on higress release tag push, add plugin_server_ref input for workflow_dispatch, align with existing workflow patterns.

### AI Coding Summary

- Replaced checkout step to clone external `higress-group/plugin-server` repo instead of higress itself
- Added `plugin_server_ref` input parameter for flexibility in manual triggers
- Added `Determine version` step to handle `workflow_dispatch` version input via `$GITHUB_OUTPUT`
- Adjusted Docker metadata tags: added manual version raw tag, simplified `latest` condition to `startsWith(github.ref, 'refs/tags/')`
- Updated Dockerfile path and build context to `plugin-server/` subdirectory
- Prefixed cache key with `plugin-server` to avoid conflicts

🤖 Generated with [Qoder][https://qoder.com]