### PR TITLE
support gemini & claude domain setting

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -323,7 +323,8 @@ func (c *claudeProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 
 func (c *claudeProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
 	util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), c.config.capabilities)
-	util.OverwriteRequestHostHeader(headers, claudeDomain)
+	domain := c.config.resolveDomain("", claudeDomain)
+	util.OverwriteRequestHostHeader(headers, domain)
 
 	if c.config.apiVersion == "" {
 		c.config.apiVersion = claudeDefaultVersion

--- a/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
@@ -62,7 +62,7 @@ func (g *geminiProviderInitializer) DefaultCapabilities() map[string]string {
 
 func (g *geminiProviderInitializer) CreateProvider(config ProviderConfig) (Provider, error) {
 	config.setDefaultCapabilities(g.DefaultCapabilities())
-	domain := config.resolveDomain(config.geminiDomain, geminiDomain)
+	domain := config.resolveDomain("", geminiDomain)
 	return &geminiProvider{
 		config:       config,
 		contextCache: createContextCache(&config),
@@ -90,7 +90,7 @@ func (g *geminiProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 }
 
 func (g *geminiProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
-	domain := g.config.resolveDomain(g.config.geminiDomain, geminiDomain)
+	domain := g.config.resolveDomain("", geminiDomain)
 	util.OverwriteRequestHostHeader(headers, domain)
 	headers.Set(geminiApiKeyHeader, g.config.GetApiTokenInUse(ctx))
 	util.OverwriteRequestAuthorizationHeader(headers, "")

--- a/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/gemini.go
@@ -62,11 +62,12 @@ func (g *geminiProviderInitializer) DefaultCapabilities() map[string]string {
 
 func (g *geminiProviderInitializer) CreateProvider(config ProviderConfig) (Provider, error) {
 	config.setDefaultCapabilities(g.DefaultCapabilities())
+	domain := config.resolveDomain(config.geminiDomain, geminiDomain)
 	return &geminiProvider{
 		config:       config,
 		contextCache: createContextCache(&config),
 		client: wrapper.NewClusterClient(wrapper.RouteCluster{
-			Host: geminiDomain,
+			Host: domain,
 		}),
 	}, nil
 }
@@ -89,7 +90,8 @@ func (g *geminiProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 }
 
 func (g *geminiProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
-	util.OverwriteRequestHostHeader(headers, geminiDomain)
+	domain := g.config.resolveDomain(g.config.geminiDomain, geminiDomain)
+	util.OverwriteRequestHostHeader(headers, domain)
 	headers.Set(geminiApiKeyHeader, g.config.GetApiTokenInUse(ctx))
 	util.OverwriteRequestAuthorizationHeader(headers, "")
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -387,6 +387,9 @@ type ProviderConfig struct {
 	// @Title zh-CN Gemini Thinking Budget 配置
 	// @Description zh-CN 仅适用于 Gemini AI 服务，用于控制思考预算
 	geminiThinkingBudget int64 `required:"false" yaml:"geminiThinkingBudget" json:"geminiThinkingBudget"`
+	// @Title zh-CN Gemini 服务域名
+	// @Description zh-CN 仅适用于 Gemini AI 服务。默认域名为 generativelanguage.googleapis.com，当使用代理服务器时可配置为代理服务器域名
+	geminiDomain string `required:"false" yaml:"geminiDomain" json:"geminiDomain"`
 	// @Title zh-CN Vertex AI访问区域
 	// @Description zh-CN 仅适用于Vertex AI服务。如需查看支持的区域的完整列表，请参阅https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations?hl=zh-cn#available-regions
 	vertexRegion string `required:"false" yaml:"vertexRegion" json:"vertexRegion"`
@@ -468,6 +471,9 @@ type ProviderConfig struct {
 	// @Title zh-CN 合并连续同角色消息
 	// @Description zh-CN 开启后，若请求的 messages 中存在连续的同角色消息（如连续两条 user 消息），将其内容合并为一条，以满足要求严格轮流交替（user→assistant→user→...）的模型服务商的要求。
 	mergeConsecutiveMessages bool `required:"false" yaml:"mergeConsecutiveMessages" json:"mergeConsecutiveMessages"`
+	// @Title zh-CN 通用 Provider 域名
+	// @Description zh-CN 通用的 Provider 服务域名配置，适用于所有 Provider。当配置此字段时，将优先使用此域名覆盖默认的硬编码域名。常用于代理服务器场景
+	providerDomain string `required:"false" yaml:"providerDomain" json:"providerDomain"`
 }
 
 func (c *ProviderConfig) GetId() string {
@@ -480,6 +486,20 @@ func (c *ProviderConfig) GetType() string {
 
 func (c *ProviderConfig) GetProtocol() string {
 	return c.protocol
+}
+
+// resolveDomain resolves the domain to use based on priority:
+// 1. providerDomain (generic override for all providers)
+// 2. provider-specific domain config (e.g., geminiDomain, doubaoDomain)
+// 3. default hardcoded domain
+func (c *ProviderConfig) resolveDomain(providerSpecificDomain, defaultDomain string) string {
+	if c.providerDomain != "" {
+		return c.providerDomain
+	}
+	if providerSpecificDomain != "" {
+		return providerSpecificDomain
+	}
+	return defaultDomain
 }
 
 func (c *ProviderConfig) GetVllmCustomUrl() string {
@@ -676,6 +696,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 		c.basePathHandling = basePathHandlingRemovePrefix
 	}
 	c.genericHost = json.Get("genericHost").String()
+	c.geminiDomain = json.Get("geminiDomain").String()
 	c.vllmServerHost = json.Get("vllmServerHost").String()
 	c.vllmCustomUrl = json.Get("vllmCustomUrl").String()
 	c.doubaoDomain = json.Get("doubaoDomain").String()
@@ -689,6 +710,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 		}
 	}
 	c.mergeConsecutiveMessages = json.Get("mergeConsecutiveMessages").Bool()
+	c.providerDomain = json.Get("providerDomain").String()
 }
 
 func (c *ProviderConfig) Validate() error {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -395,9 +395,6 @@ type ProviderConfig struct {
 	// @Title zh-CN Gemini Thinking Budget 配置
 	// @Description zh-CN 仅适用于 Gemini AI 服务，用于控制思考预算
 	geminiThinkingBudget int64 `required:"false" yaml:"geminiThinkingBudget" json:"geminiThinkingBudget"`
-	// @Title zh-CN Gemini 服务域名
-	// @Description zh-CN 仅适用于 Gemini AI 服务。默认域名为 generativelanguage.googleapis.com，当使用代理服务器时可配置为代理服务器域名
-	geminiDomain string `required:"false" yaml:"geminiDomain" json:"geminiDomain"`
 	// @Title zh-CN Vertex AI访问区域
 	// @Description zh-CN 仅适用于Vertex AI服务。如需查看支持的区域的完整列表，请参阅https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations?hl=zh-cn#available-regions
 	vertexRegion string `required:"false" yaml:"vertexRegion" json:"vertexRegion"`
@@ -714,7 +711,6 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 		c.basePathHandling = basePathHandlingRemovePrefix
 	}
 	c.genericHost = json.Get("genericHost").String()
-	c.geminiDomain = json.Get("geminiDomain").String()
 	c.vllmServerHost = json.Get("vllmServerHost").String()
 	c.vllmCustomUrl = json.Get("vllmCustomUrl").String()
 	c.doubaoDomain = json.Get("doubaoDomain").String()

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
@@ -133,11 +133,11 @@ func TestIsStatefulAPI(t *testing.T) {
 
 func TestGetTokenWithConsumerAffinity(t *testing.T) {
 	tests := []struct {
-		name       string
-		apiTokens  []string
-		consumer   string
-		wantEmpty  bool
-		wantToken  string // If not empty, expected specific token (for single token case)
+		name      string
+		apiTokens []string
+		consumer  string
+		wantEmpty bool
+		wantToken string // If not empty, expected specific token (for single token case)
 	}{
 		{
 			name:      "no_tokens_returns_empty",
@@ -273,55 +273,6 @@ func TestGetTokenWithConsumerAffinity_HashDistribution(t *testing.T) {
 			assert.Contains(t, config.apiTokens, result)
 		})
 	}
-}
-
-func TestGeminiDomain_Config(t *testing.T) {
-	t.Run("geminiDomain_field_exists", func(t *testing.T) {
-		config := ProviderConfig{}
-		config.FromJson(gjson.Result{})
-		assert.Equal(t, "", config.geminiDomain)
-	})
-
-	t.Run("geminiDomain_parsed_from_json", func(t *testing.T) {
-		config := ProviderConfig{}
-		jsonStr := `{"geminiDomain": "custom-proxy.example.com"}`
-		config.FromJson(gjson.Parse(jsonStr))
-		assert.Equal(t, "custom-proxy.example.com", config.geminiDomain)
-	})
-}
-
-func TestGeminiProvider_WithGeminiDomain(t *testing.T) {
-	t.Run("default_domain_when_geminiDomain_not_set", func(t *testing.T) {
-		config := ProviderConfig{
-			typ:       providerTypeGemini,
-			apiTokens: []string{"test-token"},
-		}
-		provider, err := CreateProvider(config)
-		assert.NoError(t, err)
-		assert.NotNil(t, provider)
-
-		geminiProv, ok := provider.(*geminiProvider)
-		assert.True(t, ok)
-		// Verify the client is created with default domain
-		assert.NotNil(t, geminiProv.client)
-	})
-
-	t.Run("custom_domain_when_geminiDomain_is_set", func(t *testing.T) {
-		customDomain := "my-proxy-server.com"
-		config := ProviderConfig{
-			typ:        providerTypeGemini,
-			apiTokens:  []string{"test-token"},
-			geminiDomain: customDomain,
-		}
-		provider, err := CreateProvider(config)
-		assert.NoError(t, err)
-		assert.NotNil(t, provider)
-
-		geminiProv, ok := provider.(*geminiProvider)
-		assert.True(t, ok)
-		// Verify the provider uses the custom domain
-		assert.NotNil(t, geminiProv.client)
-	})
 }
 
 func TestProviderDomain_Config(t *testing.T) {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
 )
 
 func TestIsStatefulAPI(t *testing.T) {
@@ -272,4 +273,94 @@ func TestGetTokenWithConsumerAffinity_HashDistribution(t *testing.T) {
 			assert.Contains(t, config.apiTokens, result)
 		})
 	}
+}
+
+func TestGeminiDomain_Config(t *testing.T) {
+	t.Run("geminiDomain_field_exists", func(t *testing.T) {
+		config := ProviderConfig{}
+		config.FromJson(gjson.Result{})
+		assert.Equal(t, "", config.geminiDomain)
+	})
+
+	t.Run("geminiDomain_parsed_from_json", func(t *testing.T) {
+		config := ProviderConfig{}
+		jsonStr := `{"geminiDomain": "custom-proxy.example.com"}`
+		config.FromJson(gjson.Parse(jsonStr))
+		assert.Equal(t, "custom-proxy.example.com", config.geminiDomain)
+	})
+}
+
+func TestGeminiProvider_WithGeminiDomain(t *testing.T) {
+	t.Run("default_domain_when_geminiDomain_not_set", func(t *testing.T) {
+		config := ProviderConfig{
+			typ:       providerTypeGemini,
+			apiTokens: []string{"test-token"},
+		}
+		provider, err := CreateProvider(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, provider)
+
+		geminiProv, ok := provider.(*geminiProvider)
+		assert.True(t, ok)
+		// Verify the client is created with default domain
+		assert.NotNil(t, geminiProv.client)
+	})
+
+	t.Run("custom_domain_when_geminiDomain_is_set", func(t *testing.T) {
+		customDomain := "my-proxy-server.com"
+		config := ProviderConfig{
+			typ:        providerTypeGemini,
+			apiTokens:  []string{"test-token"},
+			geminiDomain: customDomain,
+		}
+		provider, err := CreateProvider(config)
+		assert.NoError(t, err)
+		assert.NotNil(t, provider)
+
+		geminiProv, ok := provider.(*geminiProvider)
+		assert.True(t, ok)
+		// Verify the provider uses the custom domain
+		assert.NotNil(t, geminiProv.client)
+	})
+}
+
+func TestProviderDomain_Config(t *testing.T) {
+	t.Run("providerDomain_field_exists", func(t *testing.T) {
+		config := ProviderConfig{}
+		config.FromJson(gjson.Result{})
+		assert.Equal(t, "", config.providerDomain)
+	})
+
+	t.Run("providerDomain_parsed_from_json", func(t *testing.T) {
+		config := ProviderConfig{}
+		jsonStr := `{"providerDomain": "universal-proxy.example.com"}`
+		config.FromJson(gjson.Parse(jsonStr))
+		assert.Equal(t, "universal-proxy.example.com", config.providerDomain)
+	})
+}
+
+func TestResolveDomain_Priority(t *testing.T) {
+	t.Run("providerDomain_takes_priority", func(t *testing.T) {
+		config := ProviderConfig{
+			providerDomain: "universal-proxy.com",
+		}
+		result := config.resolveDomain("specific-domain.com", "default.com")
+		assert.Equal(t, "universal-proxy.com", result)
+	})
+
+	t.Run("providerSpecificDomain_when_providerDomain_empty", func(t *testing.T) {
+		config := ProviderConfig{
+			providerDomain: "",
+		}
+		result := config.resolveDomain("specific-domain.com", "default.com")
+		assert.Equal(t, "specific-domain.com", result)
+	})
+
+	t.Run("defaultDomain_when_both_empty", func(t *testing.T) {
+		config := ProviderConfig{
+			providerDomain: "",
+		}
+		result := config.resolveDomain("", "default.com")
+		assert.Equal(t, "default.com", result)
+	})
 }


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

本 PR 为 ai-proxy 插件添加了可配置的域名功能，支持为 Gemini 和 Claude provider 配置自定义域名。

主要改动：
- provider.go:
  - 新增 providerDomain 通用配置字段，适用于所有 provider，优先级最高
  - 新增 resolveDomain() 辅助函数，实现域名解析的优先级逻辑：providerDomain > 特定 provider 域名 > 默认硬编码域名
  - 在 FromJson() 方法中添加新字段的 JSON 解析逻辑
- gemini.go:
  - CreateProvider() 和 TransformRequestHeaders() 方法中使用 resolveDomain() 处理域名
- claude.go:
  - TransformRequestHeaders() 方法中使用 resolveDomain() 处理域名
- provider_test.go:
  - 新增 TestProviderDomain_Config 测试 providerDomain 配置解析
  - 新增 TestResolveDomain_Priority 测试域名解析优先级逻辑

## Ⅱ. Does this pull request fix one issue?


## Ⅲ. Why don't you add test cases (unit test/integration test)?

已添加单元测试，覆盖以下场景：
- 配置字段的 JSON 解析测试
- 域名解析优先级测试（providerDomain > 特定域名 > 默认域名）

## Ⅳ. Describe how to verify it

1. 运行单元测试：

```bash
cd plugins/wasm-go/extensions/ai-proxy/provider
go test -v -run "TestProviderDomain|TestResolveDomain"
```

2. 配置验证 - 使用 providerDomain 通用配置：

```yaml
providers:
  - type: gemini
    providerDomain: "my-proxy-server.com"
    apiTokens: ["your-token"]
```

## Ⅴ. Special notes for reviews

- 域名优先级设计为：providerDomain > 特定 provider 域名（如 qwenDomain） > 默认硬编码域名
- 此 PR 目前仅应用于 Gemini 和 Claude 两个 provider，后续可根据需要扩展到其他 provider
- providerDomain 字段适用于所有 provider 的统一代理场景

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Ⅰ. Describe what this PR did

This PR adds a configurable domain name function to the ai-proxy plug-in and supports configuring custom domain names for Gemini and Claude providers.

Major changes:
- provider.go:
  - Added providerDomain general configuration field, applicable to all providers, with the highest priority
  - Added resolveDomain() auxiliary function to implement the priority logic of domain name resolution: providerDomain > specific provider domain name > default hard-coded domain name
  - Add JSON parsing logic for new fields in the FromJson() method
-gemini.go:
  - Use resolveDomain() in the CreateProvider() and TransformRequestHeaders() methods to handle domain names
- claude.go:
  - Use resolveDomain() in the TransformRequestHeaders() method to process domain names
- provider_test.go:
  - Added TestProviderDomain_Config test providerDomain configuration parsing
  - Added TestResolveDomain_Priority to test domain name resolution priority logic

## Ⅱ. Does this pull request fix one issue?


## Ⅲ. Why don't you add test cases (unit test/integration test)?

Unit tests have been added to cover the following scenarios:
- JSON parsing test of configuration fields
- Domain name resolution priority test (providerDomain > specific domain name > default domain name)

## Ⅳ. Describe how to verify it

1. Run unit tests:

```bash
cd plugins/wasm-go/extensions/ai-proxy/provider
go test -v -run "TestProviderDomain|TestResolveDomain"
```

2. Configuration verification - use providerDomain common configuration:

```yaml
providers:
  - type: gemini
    providerDomain: "my-proxy-server.com"
    apiTokens: ["your-token"]
```

## Ⅴ. Special notes for reviews

- Domain name priority is designed as: providerDomain > specific provider domain name (such as qwenDomain) > default hard-coded domain name
- This PR is currently only applied to Gemini and Claude providers, and can be expanded to other providers as needed in the future.
- providerDomain field applies to unified proxy scenarios for all providers
