### PR TITLE
fix: remove non-standard thinking/reasoning_max_tokens from Claude-to…

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main_test.go
@@ -228,3 +228,11 @@ func TestConsumerAffinity(t *testing.T) {
 	test.RunConsumerAffinityParseConfigTests(t)
 	test.RunConsumerAffinityOnHttpRequestHeadersTests(t)
 }
+
+func TestOpenRouter(t *testing.T) {
+	test.RunOpenRouterClaudeAutoConversionTests(t)
+}
+
+func TestZhipuAI(t *testing.T) {
+	test.RunZhipuAIClaudeAutoConversionTests(t)
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
@@ -187,14 +187,16 @@ func (c *ClaudeToOpenAIConverter) ConvertClaudeRequestToOpenAI(body []byte) ([]b
 	}
 
 	// Convert thinking configuration if present
+	// Only set standard OpenAI fields (reasoning_effort). Non-standard fields like
+	// "thinking" and "reasoning_max_tokens" are NOT set here because they are not
+	// recognized by OpenAI/Azure and will cause 400 errors. Providers that need
+	// these non-standard fields (e.g., ZhipuAI) should handle them in their own
+	// OnRequestBody implementation.
 	if claudeRequest.Thinking != nil {
 		log.Debugf("[Claude->OpenAI] Found thinking config: type=%s, budget_tokens=%d",
 			claudeRequest.Thinking.Type, claudeRequest.Thinking.BudgetTokens)
 
 		if claudeRequest.Thinking.Type == "enabled" {
-			openaiRequest.ReasoningMaxTokens = claudeRequest.Thinking.BudgetTokens
-			openaiRequest.Thinking = &thinkingParam{Type: "enabled", BudgetToken: claudeRequest.Thinking.BudgetTokens}
-
 			// Set ReasoningEffort based on budget_tokens
 			// low: <4096, medium: >=4096 and <16384, high: >=16384
 			if claudeRequest.Thinking.BudgetTokens < 4096 {
@@ -205,14 +207,9 @@ func (c *ClaudeToOpenAIConverter) ConvertClaudeRequestToOpenAI(body []byte) ([]b
 				openaiRequest.ReasoningEffort = "high"
 			}
 
-			log.Debugf("[Claude->OpenAI] Converted thinking config: budget_tokens=%d, reasoning_effort=%s, reasoning_max_tokens=%d",
-				claudeRequest.Thinking.BudgetTokens, openaiRequest.ReasoningEffort, openaiRequest.ReasoningMaxTokens)
+			log.Debugf("[Claude->OpenAI] Converted thinking config: budget_tokens=%d, reasoning_effort=%s",
+				claudeRequest.Thinking.BudgetTokens, openaiRequest.ReasoningEffort)
 		}
-	} else {
-		// Explicitly disable thinking when not configured in Claude request
-		// This prevents providers like ZhipuAI from enabling thinking by default
-		openaiRequest.Thinking = &thinkingParam{Type: "disabled"}
-		log.Debugf("[Claude->OpenAI] No thinking config found, explicitly disabled")
 	}
 
 	result, err := json.Marshal(openaiRequest)

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
@@ -642,11 +642,9 @@ func TestClaudeToOpenAIConverter_ConvertThinkingConfig(t *testing.T) {
 	converter := &ClaudeToOpenAIConverter{}
 
 	tests := []struct {
-		name                 string
-		claudeRequest        string
-		expectedMaxTokens    int
-		expectedEffort       string
-		expectThinkingConfig bool
+		name           string
+		claudeRequest  string
+		expectedEffort string
 	}{
 		{
 			name: "thinking_enabled_low",
@@ -656,9 +654,7 @@ func TestClaudeToOpenAIConverter_ConvertThinkingConfig(t *testing.T) {
 				"messages": [{"role": "user", "content": "Hello"}],
 				"thinking": {"type": "enabled", "budget_tokens": 2048}
 			}`,
-			expectedMaxTokens:    2048,
-			expectedEffort:       "low",
-			expectThinkingConfig: true,
+			expectedEffort: "low",
 		},
 		{
 			name: "thinking_enabled_medium",
@@ -668,9 +664,7 @@ func TestClaudeToOpenAIConverter_ConvertThinkingConfig(t *testing.T) {
 				"messages": [{"role": "user", "content": "Hello"}],
 				"thinking": {"type": "enabled", "budget_tokens": 8192}
 			}`,
-			expectedMaxTokens:    8192,
-			expectedEffort:       "medium",
-			expectThinkingConfig: true,
+			expectedEffort: "medium",
 		},
 		{
 			name: "thinking_enabled_high",
@@ -680,9 +674,7 @@ func TestClaudeToOpenAIConverter_ConvertThinkingConfig(t *testing.T) {
 				"messages": [{"role": "user", "content": "Hello"}],
 				"thinking": {"type": "enabled", "budget_tokens": 20480}
 			}`,
-			expectedMaxTokens:    20480,
-			expectedEffort:       "high",
-			expectThinkingConfig: true,
+			expectedEffort: "high",
 		},
 		{
 			name: "thinking_disabled",
@@ -692,9 +684,7 @@ func TestClaudeToOpenAIConverter_ConvertThinkingConfig(t *testing.T) {
 				"messages": [{"role": "user", "content": "Hello"}],
 				"thinking": {"type": "disabled"}
 			}`,
-			expectedMaxTokens:    0,
-			expectedEffort:       "",
-			expectThinkingConfig: false,
+			expectedEffort: "",
 		},
 		{
 			name: "no_thinking",
@@ -703,9 +693,7 @@ func TestClaudeToOpenAIConverter_ConvertThinkingConfig(t *testing.T) {
 				"max_tokens": 1000,
 				"messages": [{"role": "user", "content": "Hello"}]
 			}`,
-			expectedMaxTokens:    0,
-			expectedEffort:       "",
-			expectThinkingConfig: false,
+			expectedEffort: "",
 		},
 	}
 
@@ -719,13 +707,23 @@ func TestClaudeToOpenAIConverter_ConvertThinkingConfig(t *testing.T) {
 			err = json.Unmarshal(result, &openaiRequest)
 			assert.NoError(t, err)
 
-			if tt.expectThinkingConfig {
-				assert.Equal(t, tt.expectedMaxTokens, openaiRequest.ReasoningMaxTokens)
-				assert.Equal(t, tt.expectedEffort, openaiRequest.ReasoningEffort)
-			} else {
-				assert.Equal(t, 0, openaiRequest.ReasoningMaxTokens)
-				assert.Equal(t, "", openaiRequest.ReasoningEffort)
-			}
+			assert.Equal(t, tt.expectedEffort, openaiRequest.ReasoningEffort)
+
+			// Verify non-standard fields are NEVER set in the converted request.
+			// These fields are not recognized by OpenAI/Azure and would cause 400 errors.
+			assert.Equal(t, 0, openaiRequest.ReasoningMaxTokens,
+				"reasoning_max_tokens must not be set - it is not a standard OpenAI parameter")
+			assert.Nil(t, openaiRequest.Thinking,
+				"thinking must not be set - it is not a standard OpenAI parameter")
+
+			// Also verify at the raw JSON level to catch any serialization issues
+			var rawJSON map[string]interface{}
+			err = json.Unmarshal(result, &rawJSON)
+			require.NoError(t, err)
+			assert.NotContains(t, rawJSON, "thinking",
+				"raw JSON must not contain 'thinking' field")
+			assert.NotContains(t, rawJSON, "reasoning_max_tokens",
+				"raw JSON must not contain 'reasoning_max_tokens' field")
 		})
 	}
 }
@@ -930,7 +928,6 @@ func TestClaudeToOpenAIConverter_StripCchFromSystemMessage(t *testing.T) {
 		assert.Equal(t, "You are a helpful assistant.", systemMsg.Content)
 	})
 }
-
 func TestStripCchFromBillingHeader(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/plugins/wasm-go/extensions/ai-proxy/provider/openrouter.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openrouter.go
@@ -79,6 +79,22 @@ func (o *openrouterProvider) TransformRequestBody(ctx wrapper.HttpContext, apiNa
 	// Check if ReasoningMaxTokens exists in the request body
 	reasoningMaxTokens := gjson.GetBytes(body, "reasoning_max_tokens")
 	if !reasoningMaxTokens.Exists() || reasoningMaxTokens.Int() == 0 {
+		// Check if budget_tokens was stored in context (from Claude auto-conversion path)
+		// Only use it when thinking was explicitly enabled, to avoid dirty input
+		if thinkingType, _ := ctx.GetContext(ctxKeyClaudeThinkingType).(string); thinkingType == "enabled" {
+			if budgetTokens, ok := ctx.GetContext(ctxKeyClaudeBudgetTokens).(int); ok && budgetTokens > 0 {
+				// Use budget_tokens from Claude thinking config
+				modifiedBody, err := sjson.DeleteBytes(body, "reasoning_effort")
+				if err != nil {
+					modifiedBody = body
+				}
+				modifiedBody, err = sjson.SetBytes(modifiedBody, "reasoning.max_tokens", budgetTokens)
+				if err != nil {
+					return nil, err
+				}
+				return o.config.defaultTransformRequestBody(ctx, apiName, modifiedBody)
+			}
+		}
 		// No reasoning_max_tokens, use default transformation
 		return o.config.defaultTransformRequestBody(ctx, apiName, body)
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -168,6 +168,8 @@ const (
 	finishReasonLength   = "length"
 	finishReasonToolCall = "tool_calls"
 
+	ctxKeyClaudeBudgetTokens     = "claudeBudgetTokens"
+	ctxKeyClaudeThinkingType     = "claudeThinkingType"
 	ctxKeyIncrementalStreaming   = "incrementalStreaming"
 	ctxKeyApiKey                 = "apiKey"
 	CtxKeyApiName                = "apiName"
@@ -1155,6 +1157,21 @@ func (c *ProviderConfig) handleRequestBody(
 	// If main.go detected a Claude request that needs conversion, convert the body
 	needClaudeConversion, _ := ctx.GetContext("needClaudeResponseConversion").(bool)
 	if needClaudeConversion {
+		// Extract thinking config from original Claude body before conversion,
+		// so downstream providers (OpenRouter, ZhipuAI) can access it.
+		thinkingType := gjson.GetBytes(body, "thinking.type").String()
+		if thinkingType == "" {
+			// Claude request had no thinking field at all - treat as disabled
+			thinkingType = "disabled"
+		}
+		ctx.SetContext(ctxKeyClaudeThinkingType, thinkingType)
+		// Only extract budget_tokens when thinking is explicitly enabled
+		if thinkingType == "enabled" {
+			if budgetTokens := gjson.GetBytes(body, "thinking.budget_tokens").Int(); budgetTokens > 0 {
+				ctx.SetContext(ctxKeyClaudeBudgetTokens, int(budgetTokens))
+			}
+		}
+
 		// Convert Claude protocol to OpenAI protocol
 		converter := &ClaudeToOpenAIConverter{}
 		body, err = converter.ConvertClaudeRequestToOpenAI(body)

--- a/plugins/wasm-go/extensions/ai-proxy/provider/zhipuai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/zhipuai.go
@@ -95,6 +95,10 @@ func (m *zhipuAiProvider) TransformRequestBody(ctx wrapper.HttpContext, apiName 
 		body, _ = sjson.SetBytes(body, "thinking", map[string]string{"type": "enabled"})
 		// Remove reasoning_effort field as ZhipuAI doesn't recognize it
 		body, _ = sjson.DeleteBytes(body, "reasoning_effort")
+	} else if thinkingType, ok := ctx.GetContext(ctxKeyClaudeThinkingType).(string); ok && thinkingType != "enabled" {
+		// Request came from Claude auto-conversion with thinking explicitly disabled or absent.
+		// Explicitly set thinking=disabled to prevent ZhipuAI from enabling it by default.
+		body, _ = sjson.SetBytes(body, "thinking", map[string]string{"type": "disabled"})
 	}
 
 	return m.config.defaultTransformRequestBody(ctx, apiName, body)

--- a/plugins/wasm-go/extensions/ai-proxy/test/openrouter.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/openrouter.go
@@ -1,0 +1,148 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var basicOpenRouterConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":      "openrouter",
+			"apiTokens": []string{"sk-openrouter-test"},
+		},
+	})
+	return data
+}()
+
+func RunOpenRouterClaudeAutoConversionTests(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		t.Run("claude thinking budget_tokens is converted to reasoning.max_tokens", func(t *testing.T) {
+			host, status := test.NewTestHost(basicOpenRouterConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			// Send request with Claude /v1/messages path to trigger auto-conversion
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			// Claude request body with thinking enabled
+			requestBody := `{
+				"model": "anthropic/claude-sonnet-4",
+				"max_tokens": 8000,
+				"messages": [{"role": "user", "content": "Hello"}],
+				"thinking": {"type": "enabled", "budget_tokens": 10000}
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			transformedBody := host.GetRequestBody()
+			require.NotNil(t, transformedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(transformedBody, &bodyMap)
+			require.NoError(t, err)
+
+			// reasoning.max_tokens should be set from budget_tokens
+			reasoning, ok := bodyMap["reasoning"].(map[string]interface{})
+			require.True(t, ok, "reasoning field should be present")
+			assert.Equal(t, float64(10000), reasoning["max_tokens"],
+				"reasoning.max_tokens should preserve the original budget_tokens value")
+
+			// reasoning_effort should be removed (OpenRouter uses reasoning.max_tokens instead)
+			assert.NotContains(t, bodyMap, "reasoning_effort",
+				"reasoning_effort should be removed")
+
+			// Non-standard fields should not be present
+			assert.NotContains(t, bodyMap, "thinking",
+				"thinking should not be in the final request")
+			assert.NotContains(t, bodyMap, "reasoning_max_tokens",
+				"reasoning_max_tokens should not be in the final request")
+		})
+
+		t.Run("claude without thinking uses default transformation", func(t *testing.T) {
+			host, status := test.NewTestHost(basicOpenRouterConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "anthropic/claude-sonnet-4",
+				"max_tokens": 1000,
+				"messages": [{"role": "user", "content": "Hello"}]
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			transformedBody := host.GetRequestBody()
+			require.NotNil(t, transformedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(transformedBody, &bodyMap)
+			require.NoError(t, err)
+
+			// No reasoning fields should be present
+			assert.NotContains(t, bodyMap, "reasoning")
+			assert.NotContains(t, bodyMap, "reasoning_effort")
+			assert.NotContains(t, bodyMap, "thinking")
+			assert.NotContains(t, bodyMap, "reasoning_max_tokens")
+		})
+
+		t.Run("claude thinking disabled does not set reasoning", func(t *testing.T) {
+			host, status := test.NewTestHost(basicOpenRouterConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			// thinking disabled with budget_tokens (dirty input)
+			requestBody := `{
+				"model": "anthropic/claude-sonnet-4",
+				"max_tokens": 1000,
+				"messages": [{"role": "user", "content": "Hello"}],
+				"thinking": {"type": "disabled", "budget_tokens": 5000}
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			transformedBody := host.GetRequestBody()
+			require.NotNil(t, transformedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(transformedBody, &bodyMap)
+			require.NoError(t, err)
+
+			// Should NOT have reasoning.max_tokens since thinking was disabled
+			assert.NotContains(t, bodyMap, "reasoning",
+				"reasoning should not be set when thinking is disabled")
+			assert.NotContains(t, bodyMap, "thinking")
+			assert.NotContains(t, bodyMap, "reasoning_max_tokens")
+		})
+	})
+}

--- a/plugins/wasm-go/extensions/ai-proxy/test/zhipuai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/zhipuai.go
@@ -1,0 +1,138 @@
+package test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var basicZhipuAIConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":      "zhipuai",
+			"apiTokens": []string{"sk-zhipuai-test"},
+		},
+	})
+	return data
+}()
+
+func RunZhipuAIClaudeAutoConversionTests(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		t.Run("claude thinking enabled sets thinking enabled for zhipuai", func(t *testing.T) {
+			host, status := test.NewTestHost(basicZhipuAIConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "glm-4",
+				"max_tokens": 1000,
+				"messages": [{"role": "user", "content": "Hello"}],
+				"thinking": {"type": "enabled", "budget_tokens": 8192}
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			transformedBody := host.GetRequestBody()
+			require.NotNil(t, transformedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(transformedBody, &bodyMap)
+			require.NoError(t, err)
+
+			// ZhipuAI should have thinking=enabled (converted from reasoning_effort)
+			thinking, ok := bodyMap["thinking"].(map[string]interface{})
+			require.True(t, ok, "thinking field should be present")
+			assert.Equal(t, "enabled", thinking["type"])
+
+			// reasoning_effort should be removed (ZhipuAI doesn't recognize it)
+			assert.NotContains(t, bodyMap, "reasoning_effort")
+		})
+
+		t.Run("claude without thinking sets thinking disabled for zhipuai", func(t *testing.T) {
+			host, status := test.NewTestHost(basicZhipuAIConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "glm-4",
+				"max_tokens": 1000,
+				"messages": [{"role": "user", "content": "Hello"}]
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			transformedBody := host.GetRequestBody()
+			require.NotNil(t, transformedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(transformedBody, &bodyMap)
+			require.NoError(t, err)
+
+			// ZhipuAI should explicitly set thinking=disabled
+			thinking, ok := bodyMap["thinking"].(map[string]interface{})
+			require.True(t, ok, "thinking field should be present for disabled state")
+			assert.Equal(t, "disabled", thinking["type"])
+		})
+
+		t.Run("claude thinking disabled sets thinking disabled for zhipuai", func(t *testing.T) {
+			host, status := test.NewTestHost(basicZhipuAIConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "glm-4",
+				"max_tokens": 1000,
+				"messages": [{"role": "user", "content": "Hello"}],
+				"thinking": {"type": "disabled"}
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			transformedBody := host.GetRequestBody()
+			require.NotNil(t, transformedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(transformedBody, &bodyMap)
+			require.NoError(t, err)
+
+			// ZhipuAI should explicitly set thinking=disabled
+			thinking, ok := bodyMap["thinking"].(map[string]interface{})
+			require.True(t, ok, "thinking field should be present for disabled state")
+			assert.Equal(t, "disabled", thinking["type"])
+
+			// No reasoning fields
+			assert.NotContains(t, bodyMap, "reasoning_effort")
+		})
+	})
+}


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

本 PR 修复了 ai-proxy 的 Claude-to-OpenAI 协议转换中，非标准字段 `thinking` 和 `reasoning_max_tokens` 被错误地写入转换后的 OpenAI 请求体，导致 Azure 等标准 OpenAI 兼容 provider 返回 HTTP 400 的问题。同时确保 OpenRouter 和 ZhipuAI 在 Claude 自动转换路径上的行为不发生回归。

### 背景

当客户端使用 Anthropic `/v1/messages` 协议请求 Azure provider 时，ai-proxy 会自动将 Claude 格式转换为 OpenAI 格式。转换逻辑中对 Claude `thinking` 配置的处理存在以下问题：

1. 转换时同时设置了 `reasoning_effort`（OpenAI 标准）、`thinking` 和 `reasoning_max_tokens`（非标准）三个字段
2. 即使 Claude 请求未携带 thinking 配置，也会显式设置 `"thinking": {"type": "disabled"}`
3. Azure/OpenAI API 不认识 `thinking` 和 `reasoning_max_tokens`，直接返回 400 错误：`Unknown parameter: 'thinking'`

### 主要变更

1. **移除非标准字段设置**（`provider/claude_to_openai.go`）
   - 不再设置 `openaiRequest.Thinking`（`thinking` 字段）
   - 不再设置 `openaiRequest.ReasoningMaxTokens`（`reasoning_max_tokens` 字段）
   - 移除无 thinking 时显式设置 `Thinking = disabled` 的逻辑
   - 仅保留标准的 `reasoning_effort` 字段（`low`/`medium`/`high`）

2. **通过 HTTP context 透传 Claude thinking 配置**（`provider/provider.go`）
   - 转换前从原始 Claude body 中提取 `thinking.type` 和 `thinking.budget_tokens`
   - 存入 `ctxKeyClaudeThinkingType` 和 `ctxKeyClaudeBudgetTokens`
   - 无 thinking 字段时，`thinkingType` 默认设为 `"disabled"`
   - `budget_tokens` 仅在 `type == "enabled"` 时提取，防止脏输入误开启推理

3. **OpenRouter 从 context 读取 budget_tokens**（`provider/openrouter.go`）
   - 当 body 中无 `reasoning_max_tokens` 时，检查 context 中的 `claudeBudgetTokens`
   - 仅在 `ctxKeyClaudeThinkingType == "enabled"` 时使用，避免异常输入误开启 reasoning
   - 将 `budget_tokens` 转为 OpenRouter 的 `reasoning.max_tokens` 格式

4. **ZhipuAI 显式处理 thinking disabled**（`provider/zhipuai.go`）
   - 当 context 中 `ctxKeyClaudeThinkingType` 存在且不为 `"enabled"` 时，显式设置 `thinking=disabled`
   - 防止 ZhipuAI 在 Claude 转换路径上默认开启 thinking

5. **更新单元测试并新增集成测试**
   - `provider/claude_to_openai_test.go`：更新 `TestClaudeToOpenAIConverter_ConvertThinkingConfig`，struct 层 + raw JSON 层双重验证非标准字段不出现
   - `test/openrouter.go`（新增）：3 个集成测试覆盖 OpenRouter 在 Claude 自动转换路径上的 budget_tokens 透传、无 thinking、thinking disabled + 脏输入
   - `test/zhipuai.go`（新增）：3 个集成测试覆盖 ZhipuAI 在 Claude 自动转换路径上的 thinking enabled/disabled/absent
   - `main_test.go`：注册 `TestOpenRouter` 和 `TestZhipuAI`

### 修复前后对比

| 场景 | 变更前 | 变更后 |
|------|--------|--------|
| Claude thinking enabled -> Azure | ❌ 请求体包含 `thinking`/`reasoning_max_tokens`，Azure 返回 400 | ✅ 仅包含 `reasoning_effort`，Azure 正常处理 |
| Claude thinking disabled -> Azure | ❌ 请求体包含 `"thinking":{"type":"disabled"}`，Azure 返回 400 | ✅ 不包含非标准字段 |
| Claude 无 thinking -> Azure | ❌ 请求体包含 `"thinking":{"type":"disabled"}`，Azure 返回 400 | ✅ 不包含非标准字段 |
| Claude thinking enabled -> OpenRouter | ✅ `reasoning_max_tokens` 在 body 中 | ✅ `budget_tokens` 通过 context 透传，转为 `reasoning.max_tokens` |
| Claude 无 thinking -> ZhipuAI | ⚠️ converter 设置 `thinking=disabled` | ✅ ZhipuAI 从 context 读取并显式设置 `thinking=disabled` |
| 脏输入（disabled + budget_tokens）-> OpenRouter | ⚠️ 可能误开启 reasoning | ✅ 仅 `type==enabled` 时提取 budget_tokens |

## Ⅱ. Does this pull request fix one issue?

修复 Claude-to-OpenAI 协议转换在 Azure provider 上因非标准参数导致 HTTP 400 的问题，同时防止 OpenRouter 和 ZhipuAI 的行为回归。

## Ⅲ. Why don't you add test cases (unit test/integration test)?

已补充并更新测试，覆盖变更逻辑的所有主链路分支：

- ✅ `provider/claude_to_openai_test.go`
  - `TestClaudeToOpenAIConverter_ConvertThinkingConfig`：5 个子用例，struct + raw JSON 双重验证
- ✅ `test/openrouter.go`（新增集成测试，使用 `test.NewTestHost` 走真实请求链路）
  - `claude_thinking_budget_tokens_is_converted_to_reasoning.max_tokens`
  - `claude_without_thinking_uses_default_transformation`
  - `claude_thinking_disabled_does_not_set_reasoning`
- ✅ `test/zhipuai.go`（新增集成测试，使用 `test.NewTestHost` 走真实请求链路）
  - `claude_thinking_enabled_sets_thinking_enabled_for_zhipuai`
  - `claude_without_thinking_sets_thinking_disabled_for_zhipuai`
  - `claude_thinking_disabled_sets_thinking_disabled_for_zhipuai`
- ✅ `main_test.go`
  - 注册 `TestOpenRouter` 和 `TestZhipuAI`

覆盖率说明：变更代码中有 4 行防御性错误处理（`provider.go` 的 converter error 分支、`openrouter.go` 的 sjson 操作失败 fallback）在正常链路中不可达，其余变更行均已 100% 覆盖。

## Ⅳ. Describe how to verify it

### 方式一：运行变更相关用例

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test ./... -run "TestClaudeToOpenAIConverter_ConvertThinkingConfig|TestOpenRouter|TestZhipuAI" -v
```

### 方式二：运行全量测试

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test ./... -v
```

### 方式三：覆盖率检查（跨包）

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test ./... -coverpkg=./provider/... -coverprofile=/tmp/cover.out
go tool cover -func=/tmp/cover.out | grep -E "claude_to_openai\.go|openrouter\.go|zhipuai\.go|provider\.go:.*handleRequestBody"
```

## Ⅴ. Special notes for reviews

1. **`NonOpenAIStyleOptions` 的定位**：`thinking` 和 `reasoning_max_tokens` 定义在 `NonOpenAIStyleOptions` 结构体中，本身就是为非标准 provider 设计的。Claude-to-OpenAI 转换作为通用转换层，不应设置这些字段。
2. **context 透传设计**：通过 `ctxKeyClaudeThinkingType` 和 `ctxKeyClaudeBudgetTokens` 将原始 Claude thinking 配置传递给下游 provider，避免在通用转换层写入非标准 JSON 字段。
3. **防御性设计**：`budget_tokens` 仅在 `thinking.type == "enabled"` 时提取到 context；OpenRouter 也仅在 `thinkingType == "enabled"` 时使用。双重校验防止脏输入误开启 reasoning。
4. **ZhipuAI 兼容**：无 thinking 的 Claude 请求在 `provider.go` 中被标记为 `thinkingType = "disabled"`，ZhipuAI 据此显式禁用 thinking，保持与变更前一致的行为。
5. **Azure OpenAI API 官方确认**：根据 Azure OpenAI API spec（2025-03-01-preview），chat completions 请求仅支持 `reasoning_effort` 和 `max_completion_tokens`，不支持 `thinking` 和 `reasoning_max_tokens`。
6. **集成测试使用 `test.NewTestHost`**：走真实的 `CallOnHttpRequestHeaders` -> `CallOnHttpRequestBody` -> `GetRequestBody` 链路，覆盖从 Claude 自动协议检测到 provider body 转换的完整流程。

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have included the AI Coding summary below

### AI Coding Summary

**关键决策：**
1. 通用 Claude-to-OpenAI 转换层只设置标准 OpenAI 字段（`reasoning_effort`），非标准字段由各 provider 自行处理。
2. 通过 HTTP context 透传原始 Claude thinking 配置（type + budget_tokens），供下游 provider 按需使用。
3. `budget_tokens` 仅在 `type==enabled` 时提取，OpenRouter 也仅在 `type==enabled` 时使用，双重防御脏输入。
4. 无 thinking 的 Claude 请求默认标记为 `disabled`，确保 ZhipuAI 显式禁用 thinking。
5. 通过 Azure OpenAI API spec 和 OpenAI Python SDK 确认了标准参数范围。
6. 使用 `test.NewTestHost` 集成测试替代模拟 provider 逻辑的单测，覆盖真实请求链路。

**主要改动范围：**
1. `provider/claude_to_openai.go` - 移除非标准字段
2. `provider/claude_to_openai_test.go` - 更新 converter 单测
3. `provider/provider.go` - 转换前提取 thinking config 到 context
4. `provider/openrouter.go` - 从 context 读取 budget_tokens
5. `provider/zhipuai.go` - 从 context 读取 thinking type 做 disabled 处理
6. `test/openrouter.go` - 新增 OpenRouter 集成测试
7. `test/zhipuai.go` - 新增 ZhipuAI 集成测试
8. `main_test.go` - 注册新测试入口

**验证结果：**
1. `go test ./... -run "TestClaudeToOpenAI|TestOpenRouter|TestZhipuAI" -v` 全部通过
2. `go test ./... -v` 全量测试通过
3. 变更代码主链路行覆盖率 100%，4 行防御性错误处理（不可达）未覆盖
