### PR TITLE
wasm-cpp model_mapper support /v1/responses

### DIFF
--- a/plugins/wasm-cpp/extensions/model_mapper/plugin.h
+++ b/plugins/wasm-cpp/extensions/model_mapper/plugin.h
@@ -45,7 +45,7 @@ struct ModelMapperConfigRule {
       "/completions",     "/embeddings",       "/images/generations",
       "/audio/speech",    "/fine_tuning/jobs", "/moderations",
       "/image-synthesis", "/video-synthesis",  "/rerank",
-      "/messages"};
+      "/messages",        "/responses"};
 };
 
 // PluginRootContext is the root context for all streams processed by the


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

Fix model-mapper model name mapping error. No translation was performed when accessing `/v1/responses`.

request model name: **qwen3.5-27b-opus**
backent model name: **qwen3.5-27b-claude-4.6-opus-reasoning-distilled**

Request:
```bash
curl -k http://local_host/v1/responses
 -H "Content-Type: application/json"   \
 -H "Authorization: Bearer $GPUSTACK_API_KEY"   \
  -d '{
    "model": "qwen3.5-27b-opus",
    "input": "世界最高峰!",
    "store": true
  }'
{"error":{"message":"**Model not found**","code":404,"type":"NotFound"}}
```

### Before Fix
#### model-mapper gateway.log
```bash
026-04-02T14:10:41.718994Z     debug   envoy wasm external/envoy/source/extensions/common/wasm/context.cc:1433 wasm log higress-system.gpustack-model-mapper: [extensions/model_mapper/plugin.cc:159]::onHeader() vm memory size is 524288     thread=309
```

#### ai-proxy gateway.log
```bash
2026-04-02T14:10:41.764569Z     debug   envoy wasm external/envoy/source/extensions/common/wasm/context.cc:1433 wasm log higress-system.gpustack-ai-proxy: [ai-proxy] [nil] [34f52308-cad8-42c5-8624-3e080311ebc9] [onHttpRequestBody] newBody={
    "model": "qwen3.5-27b-opus",
    "input": "世界最高峰!",
    "store": true
  }     thread=309
```

### After Fix
#### model-mapper gateway.log
```bash
2026-04-02T14:17:48.770980Z     debug   envoy wasm external/envoy/source/extensions/common/wasm/context.cc:1433 wasm log higress-system.gpustack-model-mapper: [extensions/model_mapper/plugin.cc:159]::onHeader() vm memory size is 196608     thread=283
2026-04-02T14:17:48.771009Z     info    envoy wasm external/envoy/source/extensions/common/wasm/context.cc:1436 wasm log higress-system.gpustack-model-mapper: [extensions/model_mapper/plugin.cc:201]::onHeader() SetRequestBodyBufferLimit: 104857600 thread=283
2026-04-02T14:17:48.771216Z     debug   envoy wasm external/envoy/source/extensions/common/wasm/context.cc:1433 wasm log higress-system.gpustack-model-mapper: [extensions/model_mapper/plugin.cc:239]::onBody() model mapped, before:qwen3.5-27b-opus, after:qwen3.5-27b-claude-4.6-opus-reasoning-distilled   thread=283
2026-04-02T14:17:48.771488Z     debug   envoy wasm external/envoy/source/extensions/common/wasm/context.cc:1433 wasm log higress-system.gpustack-llm-ext-auth: check has request body: contentType:application/json, contentLengthStr:, transferEncodingStr:    thread=283
```
#### ai-proxy gateway.log
```bash
2026-04-02T14:17:48.779155Z     debug   envoy wasm external/envoy/source/extensions/common/wasm/context.cc:1433 wasm log higress-system.gpustack-ai-proxy: [ai-proxy] [nil] [506dffd4-866c-4d96-acc0-6bb6ab9b121f] [onHttpRequestBody] newBody={"input":"世界最高峰!","model":"qwen3.5-27b-claude-4.6-opus-reasoning-distilled","store":true}   thread=283
```

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


## Ⅲ. Why don't you add test cases (unit test/integration test)? 
This is merely an enhancement of existing functionality. It has been thoroughly tested in real-world environments.

```bash
curl -k http://local_host/v1/responses   
  -H "Content-Type: application/json"   \
  -H "Authorization: Bearer $GPUSTACK_API_KEY"  \
  -d '{
    "model": "qwen3.5-27b-opus",
    "input": "世界最高峰!",
    "store": true
  }'
data: {"id":"resp_a15fcb08de060304","created_at":1775186568,"incomplete_details":null,"instructions":null,"metadata":null,"model":"Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled","object":"response","output":[{"id":"rs_ab49f4bb9d795cf6","summary":[],"type":"reasoning","content":[{"text":"1.  **Identify the Subject:** The user is asking for the \"World's Highest Peak\" (世界最高峰).\n2.  **Define \"Highest\":** In standard geographical terms, \"highest\" refers to elevation above mean sea level.\n3.  **Identify the Mountain:** The mountain with the highest elevation above sea level is Mount Everest (also known as Chomolungma or Qomolangma in Chinese).\n4.  **Retrieve Data:**\n    *   **Name:** Feiji Feng / Mount Everest (珠穆朗玛峰).\n    *   **Location:** The border between China (Tibet Autonomous Region) and Nepal, in the Himalayas.\n    *   **Height:** The most officially recognized and recent height is **8848.86 meters**. (Previously often cited as 8844.43m or 8848m).\n5.  **Contextual Verification (Alternative Definitions):**\n    *   *From center of the Earth:* Mount Chimborazo (Ecuador) is the furthest point from the center due to the Earth's equatorial bulge.\n    *   *From base to peak:* Mauna Kea (Hawaii) is the tallest if measured from its underwater base.\n6.  **Synthesize Answer:** Focus on the standard definition (Sea Level) which is what is colloquially meant without further qualification.\n    *   Name: 珠穆朗玛峰 (Mount Everest).\n    *   Height: 8848.86 meters.\n    *   Location: Himalayas.\n","type":"reasoning_text"}],"encrypted_content":null,"status":null},{"id":"msg_bd13a6d18760f5b5","content":[{"annotations":[],"text":"\n\n世界最高峰是位于中国西藏自治区与尼泊尔交界处的**珠穆朗玛峰**（英语：Mount Everest，藏语：Chomolungma），简称“珠峰”。\n\n关键信息如下：\n\n1.  **高度**：根据中国和尼泊尔共同宣布的最新测量结果，珠峰的海拔高度为 **8848.86米**。\n2.  **地理位置**：位于喜马拉雅山脉中段，北坡在中国境内，南坡在尼泊尔境内。\n3.  **其他定义下的“最高”**：\n    *   如果按**离地心距离**算最高：是位于厄瓜多尔的**钦博拉索山**（由于地球赤道隆起，它离地心比珠峰更远）。\n    *   如果按**从山脚到山顶的相对高度**算最高：是位于夏威夷的**莫纳克亚山**（若算上海底基座，总高度超过10,000米）。\n\n在通常的地理常识和日常生活中，**珠穆朗玛峰**是公认的“世界最高峰”。","type":"output_text","logprobs":null}],"role":"assistant","status":"completed","type":"message","phase":null}],"parallel_tool_calls":true,"temperature":1.0,"tool_choice":"auto","tools":[],"top_p":1.0,"background":false,"max_output_tokens":262130,"max_tool_calls":null,"previous_response_id":null,"prompt":null,"reasoning":null,"service_tier":"auto","status":"completed","text":null,"top_logprobs":null,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0,"input_tokens_per_turn":[],"cached_tokens_per_turn":[]},"output_tokens":571,"output_tokens_details":{"reasoning_tokens":0,"tool_output_tokens":0,"output_tokens_per_turn":[],"tool_output_tokens_per_turn":[]},"total_tokens":585,"time_per_output_token_ms":0,"tokens_per_second":570000,"time_to_first_token_ms":21636},"user":null,"input_messages":null,"output_messages":null}
```


## Ⅳ. Describe how to verify it


## Ⅴ. Special notes for reviews


## Ⅵ. AI Coding Tool Usage Checklist (if applicable)
<!-- 
**IMPORTANT**: If you used AI Coding tools (e.g., Cursor, GitHub Copilot, etc.) to generate this PR, please check the following items.
PRs that don't meet these requirements will have **LOWER REVIEW PRIORITY** and we **CANNOT GUARANTEE** timely reviews.

If you did NOT use AI Coding tools, you can skip this section entirely.
-->

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [ ] **For regular updates/changes** (not new plugins):
  - [ ] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [ ] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)
<!-- Paste the prompts/instructions you provided to the AI Coding tool -->


### AI Coding Summary
<!-- 
AI Coding tool should provide a summary after completing the work, including:
- Key decisions made
- Major changes implemented  
- Important considerations or limitations
-->



