### PR TITLE
feat(model-mapper): 新增 modelToHeader 配置项并优化 header 更新逻辑 || feat(model-mapper): Added modelToHeader configuration item and optimized header update logic

### DIFF
--- a/plugins/wasm-go/extensions/model-mapper/main.go
+++ b/plugins/wasm-go/extensions/model-mapper/main.go
@@ -42,12 +42,17 @@ type Config struct {
 	prefixModelMapping []ModelMapping
 	defaultModel       string
 	enableOnPathSuffix []string
+	modelToHeader      string
 }
 
 func parseConfig(json gjson.Result, config *Config) error {
 	config.modelKey = json.Get("modelKey").String()
 	if config.modelKey == "" {
 		config.modelKey = "model"
+	}
+	config.modelToHeader = json.Get("modelToHeader").String()
+	if config.modelToHeader == "" {
+		config.modelToHeader = "x-higress-llm-model"
 	}
 
 	modelMapping := json.Get("modelMapping")
@@ -144,6 +149,8 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config Config) types.Action {
 		return types.ActionContinue
 	}
 
+	// Disable re-route since the plugin may modify some headers related to the chosen route.
+	ctx.DisableReroute()
 	// Prepare for body processing
 	proxywasm.RemoveHttpRequestHeader("content-length")
 	// 100MB buffer limit
@@ -183,6 +190,12 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config Config, body []byte) type
 	}
 
 	if newModel != "" && newModel != oldModel {
+		// if x-higress-llm-model header is set, and it is not the same as the new model, update it
+		// this is to support fallback and token rate limit
+		model, _ := proxywasm.GetHttpRequestHeader(config.modelToHeader)
+		if model != "" && model != newModel {
+			proxywasm.ReplaceHttpRequestHeader(config.modelToHeader, newModel)
+		}
 		newBody, err := sjson.SetBytes(body, config.modelKey, newModel)
 		if err != nil {
 			log.Errorf("failed to update model: %v", err)

--- a/plugins/wasm-go/extensions/model-mapper/main_test.go
+++ b/plugins/wasm-go/extensions/model-mapper/main_test.go
@@ -42,6 +42,20 @@ var (
 		})
 		return data
 	}()
+
+	customHeaderConfig = func() json.RawMessage {
+		data, _ := json.Marshal(map[string]interface{}{
+			"modelKey":     "model",
+			"modelToHeader": "x-custom-model-header",
+			"modelMapping": map[string]string{
+				"gpt-3.5-turbo": "gpt-4",
+			},
+			"enableOnPathSuffix": []string{
+				"/v1/chat/completions",
+			},
+		})
+		return data
+	}()
 )
 
 func TestParseConfig(t *testing.T) {
@@ -93,6 +107,21 @@ func TestParseConfig(t *testing.T) {
 			require.Equal(t, 2, len(cfg.enableOnPathSuffix))
 			require.Contains(t, cfg.enableOnPathSuffix, "/v1/chat/completions")
 			require.Contains(t, cfg.enableOnPathSuffix, "/v1/embeddings")
+		})
+
+		t.Run("custom modelToHeader", func(t *testing.T) {
+			var cfg Config
+			jsonData := []byte(`{
+				"modelKey": "model",
+				"modelToHeader": "x-custom-model-header",
+				"modelMapping": {
+					"gpt-3.5-turbo": "gpt-4"
+				}
+			}`)
+			err := parseConfig(gjson.ParseBytes(jsonData), &cfg)
+			require.NoError(t, err)
+
+			require.Equal(t, "model", cfg.modelKey)
 		})
 
 		t.Run("modelMapping must be object", func(t *testing.T) {
@@ -245,6 +274,180 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			processed := host.GetRequestBody()
 			require.NotNil(t, processed)
 			require.Equal(t, "gpt-4-mini", gjson.GetBytes(processed, "request.model").String())
+		})
+
+		t.Run("update model header when model changes", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"x-higress-llm-model", "gpt-3.5-turbo-fallback"},
+			})
+
+			origBody := []byte(`{
+				"model": "gpt-3.5-turbo",
+				"messages": [{"role": "user", "content": "hello"}]
+			}`)
+			action := host.CallOnHttpRequestBody(origBody)
+			require.Equal(t, types.ActionContinue, action)
+
+			// verify x-higress-llm-model header was updated to the mapped target
+			newHeaders := host.GetRequestHeaders()
+			foundUpdatedHeader := false
+			for _, h := range newHeaders {
+				if strings.ToLower(h[0]) == "x-higress-llm-model" {
+					require.Equal(t, "gpt-4", h[1])
+					foundUpdatedHeader = true
+					break
+				}
+			}
+			require.True(t, foundUpdatedHeader, "x-higress-llm-model header should be updated")
+		})
+
+		t.Run("skip model header update when header not set", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+			})
+
+			origBody := []byte(`{
+				"model": "gpt-3.5-turbo",
+				"messages": [{"role": "user", "content": "hello"}]
+			}`)
+			action := host.CallOnHttpRequestBody(origBody)
+			require.Equal(t, types.ActionContinue, action)
+
+			// verify x-higress-llm-model header was NOT added (should not exist)
+			newHeaders := host.GetRequestHeaders()
+			for _, h := range newHeaders {
+				require.NotEqual(t, strings.ToLower(h[0]), "x-higress-llm-model")
+			}
+		})
+
+		t.Run("skip model header update when header already matches new model", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"x-higress-llm-model", "gpt-4"},
+			})
+
+			origBody := []byte(`{
+				"model": "gpt-3.5-turbo",
+				"messages": [{"role": "user", "content": "hello"}]
+			}`)
+			action := host.CallOnHttpRequestBody(origBody)
+			require.Equal(t, types.ActionContinue, action)
+
+			// verify x-higress-llm-model header has the correct value
+			newHeaders := host.GetRequestHeaders()
+			for _, h := range newHeaders {
+				if strings.ToLower(h[0]) == "x-higress-llm-model" {
+					require.Equal(t, "gpt-4", h[1])
+					break
+				}
+			}
+		})
+
+		t.Run("no model mapping keeps header unchanged", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"x-higress-llm-model", "some-other-model"},
+			})
+
+			origBody := []byte(`{
+				"model": "unknown-model",
+				"messages": [{"role": "user", "content": "hello"}]
+			}`)
+			action := host.CallOnHttpRequestBody(origBody)
+			require.Equal(t, types.ActionContinue, action)
+
+			// model should remain unchanged (no mapping)
+			processed := host.GetRequestBody()
+			require.NotNil(t, processed)
+			require.Equal(t, "unknown-model", gjson.GetBytes(processed, "model").String())
+		})
+
+		t.Run("use custom modelToHeader config", func(t *testing.T) {
+			host, status := test.NewTestHost(customHeaderConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"x-custom-model-header", "original-model"},
+			})
+
+			origBody := []byte(`{
+				"model": "gpt-3.5-turbo",
+				"messages": [{"role": "user", "content": "hello"}]
+			}`)
+			action := host.CallOnHttpRequestBody(origBody)
+			require.Equal(t, types.ActionContinue, action)
+
+			// verify custom header was updated to the mapped target
+			newHeaders := host.GetRequestHeaders()
+			foundUpdatedHeader := false
+			for _, h := range newHeaders {
+				if strings.ToLower(h[0]) == "x-custom-model-header" {
+					require.Equal(t, "gpt-4", h[1])
+					foundUpdatedHeader = true
+					break
+				}
+			}
+			require.True(t, foundUpdatedHeader, "x-custom-model-header should be updated")
+		})
+
+		t.Run("use custom modelToHeader with empty header value", func(t *testing.T) {
+			host, status := test.NewTestHost(customHeaderConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+			})
+
+			origBody := []byte(`{
+				"model": "gpt-3.5-turbo",
+				"messages": [{"role": "user", "content": "hello"}]
+			}`)
+			action := host.CallOnHttpRequestBody(origBody)
+			require.Equal(t, types.ActionContinue, action)
+
+			// verify custom header was NOT added when not present
+			newHeaders := host.GetRequestHeaders()
+			for _, h := range newHeaders {
+				require.NotEqual(t, strings.ToLower(h[0]), "x-custom-model-header")
+			}
 		})
 	})
 }


### PR DESCRIPTION
Ⅰ. Describe what this PR did
                                                                                           
本 PR 为 model-mapper 插件新增了可配置的模型头字段功能：                                                                                           
                                                                                                                                                    
1. 新增 modelToHeader 配置项：支持自定义模型映射后要更新的 HTTP 请求头名称，默认值为 x-higress-llm-model，保持向后兼容                                                                                                     
2. 优化 header 更新逻辑：当请求体中的模型发生映射变化时，如果对应的 header 已存在且值不匹配，则同步更新该 header                                   
  - 仅当 header 存在且值与新模型不同时才更新                                                                                                       
  - 不会主动添加新的 header                                                                                                                        
3. 补充单元测试：                                                                                                                                  
  - 新增 custom_modelToHeader 配置测试                                                                                                             
  - 新增 header 更新相关的边界条件测试                                                                                                             
  - 新增自定义 header 名称的功能测试                                                                                                               
                                                                                                                                                    
配置示例：          
```yaml                                                                                                                               
- name: model-mapper                                                                                                                               
  configs:                                                                                                                                         
    - modelKey: model                                                                                                                              
      modelToHeader: x-custom-model-header  # 可选，默认为 x-higress-llm-model                                                                     
      modelMapping:                                                                                                                                
        "gpt-3.5-turbo": "gpt-4"                                                                                                                   
        "gpt-4*": "gpt-4o"                                                                                                                         
```

Ⅱ. Does this pull request fix one issue?                                                                                                           
                                                                                                                                                    
无                                                                                                                                                 
                                                                                                                                                    
Ⅲ. Why don't you add test cases (unit test/integration test)?                                                                                      
  
已添加完整的单元测试，覆盖以下场景：         

- TestParseConfig/custom_modelToHeader - 配置解析测试
- TestOnHttpRequestBody_ModelMapping/update_model_header_when_model_changes - header 更新测试                                                      
- TestOnHttpRequestBody_ModelMapping/skip_model_header_update_when_header_not_set - header 不存在时跳过
- TestOnHttpRequestBody_ModelMapping/skip_model_header_update_when_header_already_matches_new_model - header 已匹配时跳过                          
- TestOnHttpRequestBody_ModelMapping/use_custom_modelToHeader_config - 自定义 header 名称测试                                                      
- TestOnHttpRequestBody_ModelMapping/use_custom_modelToHeader_with_empty_header_value - 自定义 header 空值测试                                     
                                                                                                                                                    
Ⅳ. Describe how to verify it                                                                                                                       
                                                                                                                                                    
1. 运行单元测试：      
```bash                                                                                                                            
cd plugins/wasm-go/extensions/model-mapper                                                                                                         
go test -v -run .                                                                                                                                  
```
                                                                                                                                                    
2. 本地测试配置示例：                                                                                                                              
```yaml
modelKey: model                                                                                                                                    
modelToHeader: x-custom-model-header                                                                                                               
modelMapping:                                                                                                                                      
  "gpt-3.5-turbo": "gpt-4"                                                                                                                         
```

3. 发送请求验证：                                                                                                                                  
```bash
curl -X POST http://localhost/v1/chat/completions \                                                                                                
  -H "x-custom-model-header: gpt-3.5-turbo-fallback" \                                                                                             
  -H "Content-Type: application/json" \                                                                                                            
  -d '{"model": "gpt-3.5-turbo", "messages": [...]}'                                                                                               
```

请求体中的 model 字段会被映射为 gpt-4，同时 x-custom-model-header 也会被更新为 gpt-4                                                               
                                                                                                                                                    
Ⅴ. Special notes for reviews                                                                                                                       
                                                                                                                                                    
- 该改动向后兼容，未配置 modelToHeader 时使用默认值 x-higress-llm-model                                                                            
- header 更新逻辑仅当 header 已存在且值不匹配时才执行，避免不必要的 header 操作                                                                    
- 该功能主要用于支持 fallback 和 token 限流场景，确保请求头与请求体中的模型一致
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Ⅰ. Describe what this PR did
                                                                                           
This PR adds a configurable model header field function to the model-mapper plug-in:
                                                                                                                                                    
1. Added modelToHeader configuration item: supports customizing the HTTP request header name to be updated after model mapping. The default value is x-higress-llm-model, maintaining backward compatibility.
2. Optimize header update logic: when the model in the request body changes mapping, if the corresponding header already exists and the value does not match, the header will be updated synchronously
  - Update only if header exists and value is different from new model
  - Will not actively add new headers
3. Supplementary unit testing:
  - Added custom_modelToHeader configuration test
  - Added boundary condition tests related to header update
  - Added function test for custom header name
                                                                                                                                                    
Configuration example:
```yaml
- name: model-mapper
  configs:
    - modelKey: model
      modelToHeader: x-custom-model-header # Optional, default is x-higress-llm-model
      modelMapping:
        "gpt-3.5-turbo": "gpt-4"
        "gpt-4*": "gpt-4o"
```

Ⅱ. Does this pull request fix one issue?
                                                                                                                                                    
None
                                                                                                                                                    
Ⅲ. Why don't you add test cases (unit test/integration test)?
  
Complete unit tests have been added, covering the following scenarios:

- TestParseConfig/custom_modelToHeader - configure parsing test
- TestOnHttpRequestBody_ModelMapping/update_model_header_when_model_changes - header update test
- TestOnHttpRequestBody_ModelMapping/skip_model_header_update_when_header_not_set - skip when header does not exist
- TestOnHttpRequestBody_ModelMapping/skip_model_header_update_when_header_already_matches_new_model - skip when header already matched
- TestOnHttpRequestBody_ModelMapping/use_custom_modelToHeader_config - Custom header name test
- TestOnHttpRequestBody_ModelMapping/use_custom_modelToHeader_with_empty_header_value - Custom header empty value test
                                                                                                                                                    
Ⅳ. Describe how to verify it
                                                                                                                                                    
1. Run unit tests:
```bash
cd plugins/wasm-go/extensions/model-mapper
go test -v -run .
```
                                                                                                                                                    
2. Local test configuration example:
```yaml
modelKey: model
modelToHeader: x-custom-model-header
modelMapping:
  "gpt-3.5-turbo": "gpt-4"
```

3. Send a request for verification:
```bash
curl -X POST http://localhost/v1/chat/completions \
  -H "x-custom-model-header: gpt-3.5-turbo-fallback" \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-3.5-turbo", "messages": [...]}'
```

The model field in the request body will be mapped to gpt-4, and the x-custom-model-header will also be updated to gpt-4.
                                                                                                                                                    
Ⅴ. Special notes for reviews
                                                                                                                                                    
- This change is backward compatible. When modelToHeader is not configured, the default value x-higress-llm-model is used.
- The header update logic is only executed when the header already exists and the value does not match, to avoid unnecessary header operations.
- This function is mainly used to support fallback and token current limiting scenarios to ensure that the request header is consistent with the model in the request body
