### PR TITLE
feat(ai-proxy): support Qwen reranks and conversations paths

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -69,6 +69,9 @@ var (
 		{provider.PathAnthropicComplete, provider.ApiNameAnthropicComplete},
 		// Cohere style
 		{provider.PathCohereV1Rerank, provider.ApiNameCohereV1Rerank},
+		// Qwen style
+		{provider.PathQwenV1Reranks, provider.ApiNameQwenV1Rerank},
+		{provider.PathQwenV1Conversations, provider.ApiNameQwenV1Conversations},
 	}
 	pathPatternToApiName = []pair[*regexp.Regexp, provider.ApiName]{
 		// OpenAI style

--- a/plugins/wasm-go/extensions/ai-proxy/main_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main_test.go
@@ -56,6 +56,9 @@ func Test_getApiName(t *testing.T) {
 		{"gemini stream generate content", "/v1beta/models/gemini-1.0-pro:streamGenerateContent", provider.ApiNameGeminiStreamGenerateContent},
 		// Cohere
 		{"cohere rerank", "/v1/rerank", provider.ApiNameCohereV1Rerank},
+		// Qwen
+		{"qwen reranks", "/v1/reranks", provider.ApiNameQwenV1Rerank},
+		{"qwen conversations", "/v1/conversations", provider.ApiNameQwenV1Conversations},
 		// Unknown
 		{"unknown", "/v1/unknown", ""},
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -71,6 +71,7 @@ const (
 	ApiNameQwenAsyncAIGC               ApiName = "qwen/v1/services/aigc"
 	ApiNameQwenAsyncTask               ApiName = "qwen/v1/tasks"
 	ApiNameQwenV1Rerank                ApiName = "qwen/v1/rerank"
+	ApiNameQwenV1Conversations         ApiName = "qwen/v1/conversations"
 	ApiNameGeminiGenerateContent       ApiName = "gemini/v1beta/generatecontent"
 	ApiNameGeminiStreamGenerateContent ApiName = "gemini/v1beta/streamgeneratecontent"
 	ApiNameAnthropicMessages           ApiName = "anthropic/v1/messages"
@@ -117,6 +118,10 @@ const (
 
 	// Cohere
 	PathCohereV1Rerank = "/v1/rerank"
+
+	// Qwen
+	PathQwenV1Reranks       = "/v1/reranks"
+	PathQwenV1Conversations = "/v1/conversations"
 
 	providerTypeMoonshot   = "moonshot"
 	providerTypeAzure      = "azure"

--- a/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/qwen.go
@@ -27,9 +27,11 @@ const (
 	qwenChatCompletionPath                = "/api/v1/services/aigc/text-generation/generation"
 	qwenTextEmbeddingPath                 = "/api/v1/services/embeddings/text-embedding/text-embedding"
 	qwenTextRerankPath                    = "/api/v1/services/rerank/text-rerank/text-rerank"
+	qwenCompatibleTextRerankPath          = "/compatible-api/v1/reranks"
 	qwenCompatibleChatCompletionPath      = "/compatible-mode/v1/chat/completions"
 	qwenCompatibleCompletionsPath         = "/compatible-mode/v1/completions"
 	qwenCompatibleTextEmbeddingPath       = "/compatible-mode/v1/embeddings"
+	qwenCompatibleConversationsPath       = "/compatible-mode/v1/conversations"
 	qwenCompatibleResponsesPath           = "/compatible-mode/v1/responses"
 	qwenCompatibleFilesPath               = "/compatible-mode/v1/files"
 	qwenCompatibleRetrieveFilePath        = "/compatible-mode/v1/files/{file_id}"
@@ -78,7 +80,8 @@ func (m *qwenProviderInitializer) DefaultCapabilities(qwenEnableCompatible bool)
 			string(ApiNameRetrieveBatch):       qwenCompatibleRetrieveBatchPath,
 			string(ApiNameQwenAsyncAIGC):       qwenAsyncAIGCPath,
 			string(ApiNameQwenAsyncTask):       qwenAsyncTaskPath,
-			string(ApiNameQwenV1Rerank):        qwenTextRerankPath,
+			string(ApiNameQwenV1Rerank):        qwenCompatibleTextRerankPath,
+			string(ApiNameQwenV1Conversations): qwenCompatibleConversationsPath,
 			string(ApiNameAnthropicMessages):   qwenAnthropicMessagesPath,
 		}
 	} else {
@@ -715,8 +718,11 @@ func (m *qwenProvider) GetApiName(path string) ApiName {
 		return ApiNameQwenAsyncAIGC
 	case strings.Contains(path, qwenAsyncTaskPath):
 		return ApiNameQwenAsyncTask
-	case strings.Contains(path, qwenTextRerankPath):
+	case strings.Contains(path, qwenTextRerankPath),
+		strings.Contains(path, qwenCompatibleTextRerankPath):
 		return ApiNameQwenV1Rerank
+	case strings.Contains(path, qwenCompatibleConversationsPath):
+		return ApiNameQwenV1Conversations
 	default:
 		return ""
 	}

--- a/plugins/wasm-go/extensions/ai-proxy/test/qwen.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/qwen.go
@@ -366,6 +366,29 @@ func RunQwenOnHttpRequestHeadersTests(t *testing.T) {
 			require.Contains(t, authValue, "sk-qwen-test123456789", "Authorization should contain qwen API token")
 		})
 
+		// 测试qwen请求头处理（reranks接口）
+		t.Run("qwen reranks request headers", func(t *testing.T) {
+			host, status := test.NewTestHost(basicQwenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/reranks"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath)
+			require.Contains(t, pathValue, "/api/v1/services/rerank/text-rerank/text-rerank", "Path should be converted to qwen rerank path")
+		})
+
 		// 测试qwen自定义域名请求头处理
 		t.Run("qwen custom domain request headers", func(t *testing.T) {
 			host, status := test.NewTestHost(qwenCustomDomainConfig)
@@ -450,6 +473,52 @@ func RunQwenOnHttpRequestHeadersTests(t *testing.T) {
 			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
 			require.True(t, hasPath)
 			require.Contains(t, pathValue, "/compatible-mode/v1/responses", "Path should use compatible mode responses path")
+		})
+
+		// 测试qwen兼容模式请求头处理（reranks接口）
+		t.Run("qwen compatible mode reranks request headers", func(t *testing.T) {
+			host, status := test.NewTestHost(qwenEnableCompatibleConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/reranks"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath)
+			require.Contains(t, pathValue, "/compatible-api/v1/reranks", "Path should use compatible API reranks path")
+		})
+
+		// 测试qwen兼容模式请求头处理（conversations接口）
+		t.Run("qwen compatible mode conversations request headers", func(t *testing.T) {
+			host, status := test.NewTestHost(qwenEnableCompatibleConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/conversations"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath)
+			require.Contains(t, pathValue, "/compatible-mode/v1/conversations", "Path should use compatible mode conversations path")
 		})
 	})
 }
@@ -581,6 +650,35 @@ func RunQwenOnHttpRequestBodyTests(t *testing.T) {
 				}
 			}
 			require.True(t, hasFileLogs, "Should have file processing logs")
+		})
+
+		// 测试qwen请求体处理（reranks接口）
+		t.Run("qwen reranks request body", func(t *testing.T) {
+			host, status := test.NewTestHost(qwenMultiModelConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/reranks"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			requestBody := `{
+				"model":"qwen3-rerank",
+				"documents":["doc1","doc2"],
+				"query":"test query",
+				"top_n":1
+			}`
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.NotNil(t, processedBody)
+			require.Contains(t, string(processedBody), "qwen3-rerank", "Reranks request model should be preserved")
+			require.Contains(t, string(processedBody), "documents", "Reranks request documents should be preserved")
 		})
 
 		// 测试qwen请求体处理（qwen-vl模型，多模态）
@@ -723,6 +821,63 @@ func RunQwenOnHttpRequestBodyTests(t *testing.T) {
 			require.Contains(t, string(processedBody), "qwen-turbo", "Model name should be preserved in responses request")
 		})
 
+		// 测试qwen请求体处理（兼容模式 reranks接口）
+		t.Run("qwen compatible mode reranks request body", func(t *testing.T) {
+			host, status := test.NewTestHost(qwenEnableCompatibleConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/reranks"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			requestBody := `{
+				"model":"qwen3-rerank",
+				"documents":["doc1","doc2"],
+				"query":"test query",
+				"top_n":1
+			}`
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.NotNil(t, processedBody)
+			require.Contains(t, string(processedBody), "qwen-turbo", "Reranks request model should be mapped by wildcard")
+			require.Contains(t, string(processedBody), "documents", "Reranks request documents should be preserved")
+		})
+
+		// 测试qwen请求体处理（兼容模式 conversations接口）
+		t.Run("qwen compatible mode conversations request body", func(t *testing.T) {
+			host, status := test.NewTestHost(qwenEnableCompatibleConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/conversations"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			requestBody := `{
+				"metadata":{"topic":"demo"},
+				"items":[{"type":"message","role":"system","content":"test content"}]
+			}`
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.NotNil(t, processedBody)
+			require.Contains(t, string(processedBody), "\"metadata\"", "Conversations metadata should be preserved")
+			require.Contains(t, string(processedBody), "\"items\"", "Conversations items should be preserved")
+			require.NotContains(t, string(processedBody), "\"model\":", "Conversations request should not inject model field")
+		})
+
 		// 测试qwen请求体处理（非兼容模式 responses接口应报不支持）
 		t.Run("qwen non-compatible mode responses request body unsupported", func(t *testing.T) {
 			host, status := test.NewTestHost(basicQwenConfig)
@@ -755,9 +910,11 @@ func RunQwenOnHttpRequestBodyTests(t *testing.T) {
 		// 覆盖 qwen.GetApiName 中以下分支：
 		// - qwenCompatibleTextEmbeddingPath => ApiNameEmbeddings
 		// - qwenCompatibleResponsesPath => ApiNameResponses
+		// - qwenCompatibleTextRerankPath => ApiNameQwenV1Rerank
+		// - qwenCompatibleConversationsPath => ApiNameQwenV1Conversations
 		// - qwenAsyncAIGCPath => ApiNameQwenAsyncAIGC
 		// - qwenAsyncTaskPath => ApiNameQwenAsyncTask
-		t.Run("qwen original protocol get api name coverage for compatible embeddings responses and async paths", func(t *testing.T) {
+		t.Run("qwen original protocol get api name coverage for compatible paths and async paths", func(t *testing.T) {
 			cases := []struct {
 				name string
 				path string
@@ -769,6 +926,14 @@ func RunQwenOnHttpRequestBodyTests(t *testing.T) {
 				{
 					name: "compatible responses path",
 					path: "/compatible-mode/v1/responses",
+				},
+				{
+					name: "compatible reranks path",
+					path: "/compatible-api/v1/reranks",
+				},
+				{
+					name: "compatible conversations path",
+					path: "/compatible-mode/v1/conversations",
 				},
 				{
 					name: "async aigc path",


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

This PR adds Qwen path support for the newly introduced rerank and conversations APIs, and adds regression tests for both path recognition and provider routing.

### Background

Qwen now provides:

- `POST /compatible-api/v1/reranks`
- `POST /compatible-mode/v1/conversations`

The ai-proxy plugin should support corresponding client-facing paths and route them to the correct Qwen upstream paths in compatible mode.

### Main Changes

1. **Add new API names and path constants** (`provider/provider.go`)
   - Added `ApiNameQwenV1Conversations`
   - Added `PathQwenV1Reranks = "/v1/reranks"`
   - Added `PathQwenV1Conversations = "/v1/conversations"`

2. **Add main path recognition** (`main.go`)
   - `getApiName` now maps:
     - `/v1/reranks` -> `ApiNameQwenV1Rerank`
     - `/v1/conversations` -> `ApiNameQwenV1Conversations`

3. **Add Qwen provider capability/path mapping** (`provider/qwen.go`)
   - Added `qwenCompatibleTextRerankPath = "/compatible-api/v1/reranks"`
   - Added `qwenCompatibleConversationsPath = "/compatible-mode/v1/conversations"`
   - In compatible mode:
     - `ApiNameQwenV1Rerank` maps to `/compatible-api/v1/reranks`
     - `ApiNameQwenV1Conversations` maps to `/compatible-mode/v1/conversations`
   - Extended `GetApiName` to recognize compatible reranks/conversations paths in original protocol mode.

4. **Add/extend tests**
   - `main_test.go`
     - Added `getApiName` cases for `/v1/reranks` and `/v1/conversations`
   - `test/qwen.go`
     - Added request-header tests for `/v1/reranks` and `/v1/conversations` in compatible mode
     - Added request-body tests for compatible reranks and conversations
     - Added request-header and request-body coverage for `/v1/reranks` in non-compatible mode
     - Extended original-protocol `GetApiName` coverage to include:
       - `/compatible-api/v1/reranks`
       - `/compatible-mode/v1/conversations`

## Ⅱ. Does this pull request fix one issue?

This PR addresses a Qwen API compatibility requirement and path support gap.  
It is a capability enhancement and is not tied to a single issue ID.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Test cases are added in this PR:

- `main_test.go`: new API path recognition cases
- `test/qwen.go`: new Qwen reranks/conversations routing and body-handling cases

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test . -run "Test_getApiName|TestQwen" -gcflags="all=-N -l"
go test ./provider -gcflags="all=-N -l"
```

## Ⅴ. Special notes for reviews

1. This change is scoped to Qwen path recognition/routing and related tests only.
2. Existing Qwen non-compatible rerank routing (`/api/v1/services/rerank/...`) remains unchanged.
3. Qwen compatible rerank path is switched to the new endpoint `/compatible-api/v1/reranks`.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] For regular updates/changes (not new plugins), AI coding summary is included.

### AI Coding Summary

**Key decisions:**
1. Introduce `/v1/reranks` and `/v1/conversations` as explicit path constants and route entries.
2. Keep non-compatible rerank behavior unchanged to avoid regressions.
3. Add compatible-mode conversations support only in compatible capability mapping.

**Main change scope:**
1. `provider/provider.go`
2. `main.go`
3. `provider/qwen.go`
4. `main_test.go`
5. `test/qwen.go`

**Validation result:**
1. `go test . -run "Test_getApiName|TestQwen" -gcflags="all=-N -l"` passed.
2. `go test ./provider -gcflags="all=-N -l"` passed.
