### PR TITLE
fix(ai-proxy): harden Claude stream conversion compatibility

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
@@ -424,6 +424,13 @@ func (c *ClaudeToOpenAIConverter) ConvertOpenAIStreamResponseToClaude(ctx wrappe
 				continue
 			}
 
+			// Some providers keep sending duplicate usage chunks after the stream
+			// has already been finalized. Ignore those trailing chunks.
+			if c.messageStopSent {
+				log.Debugf("[OpenAI->Claude] Ignoring chunk after message_stop: %s", data)
+				continue
+			}
+
 			var openaiStreamResponse chatCompletionResponse
 			if err := json.Unmarshal([]byte(data), &openaiStreamResponse); err != nil {
 				log.Debugf("unable to unmarshal openai stream response: %v, data: %s", err, data)
@@ -451,6 +458,19 @@ func (c *ClaudeToOpenAIConverter) ConvertOpenAIStreamResponseToClaude(ctx wrappe
 	return claudeChunk, nil
 }
 
+func normalizeFinishReason(finishReason *string) (string, bool) {
+	if finishReason == nil {
+		return "", false
+	}
+
+	normalized := strings.TrimSpace(*finishReason)
+	if normalized == "" || strings.EqualFold(normalized, "null") {
+		return "", false
+	}
+
+	return normalized, true
+}
+
 // buildClaudeStreamResponse builds Claude streaming responses from OpenAI streaming response
 func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpContext, openaiResponse *chatCompletionResponse) []*claudeTextGenStreamResponse {
 	var choice chatCompletionChoice
@@ -469,7 +489,7 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 	// Log what we're processing
 	hasRole := choice.Delta != nil && choice.Delta.Role != ""
 	hasContent := choice.Delta != nil && choice.Delta.Content != ""
-	hasFinishReason := choice.FinishReason != nil
+	finishReason, hasFinishReason := normalizeFinishReason(choice.FinishReason)
 	hasUsage := openaiResponse.Usage != nil
 
 	log.Debugf("[OpenAI->Claude] Processing OpenAI chunk - Role: %v, Content: %v, FinishReason: %v, Usage: %v",
@@ -688,9 +708,9 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 	}
 
 	// Handle finish reason
-	if choice.FinishReason != nil {
-		claudeFinishReason := openAIFinishReasonToClaude(*choice.FinishReason)
-		log.Debugf("[OpenAI->Claude] Processing finish_reason: %s -> %s", *choice.FinishReason, claudeFinishReason)
+	if hasFinishReason {
+		claudeFinishReason := openAIFinishReasonToClaude(finishReason)
+		log.Debugf("[OpenAI->Claude] Processing finish_reason: %s -> %s", finishReason, claudeFinishReason)
 
 		// Send content_block_stop for any active content blocks
 		if c.thinkingBlockStarted && !c.thinkingBlockStopped {
@@ -764,6 +784,7 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 	// Note: Some providers may send usage in the same chunk as finish_reason,
 	// so we check for usage regardless of whether finish_reason is present
 	if openaiResponse.Usage != nil {
+		stopReasonIncluded := false
 		log.Debugf("[OpenAI->Claude] Processing usage info - input: %d, output: %d",
 			openaiResponse.Usage.PromptTokens, openaiResponse.Usage.CompletionTokens)
 
@@ -784,13 +805,15 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 			log.Debugf("[OpenAI->Claude] Combining cached stop_reason %s with usage", *c.pendingStopReason)
 			messageDelta.Delta.StopReason = c.pendingStopReason
 			c.pendingStopReason = nil // Clear cache
+			stopReasonIncluded = true
 		}
 
 		log.Debugf("[OpenAI->Claude] Generated message_delta event with usage and stop_reason")
 		responses = append(responses, messageDelta)
 
-		// Send message_stop after combined message_delta
-		if !c.messageStopSent {
+		// Send message_stop only when this usage chunk carries a real stop_reason.
+		// Some providers report incremental usage in every chunk before finishing.
+		if stopReasonIncluded && !c.messageStopSent {
 			c.messageStopSent = true
 			log.Debugf("[OpenAI->Claude] Generated message_stop event")
 			responses = append(responses, &claudeTextGenStreamResponse{

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/higress-group/wasm-go/pkg/log"
@@ -977,4 +978,189 @@ func TestStripCchFromBillingHeader(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestNormalizeFinishReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      *string
+		wantReason string
+		wantValid  bool
+	}{
+		{
+			name:      "nil finish reason",
+			input:     nil,
+			wantValid: false,
+		},
+		{
+			name:      "empty finish reason",
+			input:     stringPtr(""),
+			wantValid: false,
+		},
+		{
+			name:      "whitespace finish reason",
+			input:     stringPtr("   "),
+			wantValid: false,
+		},
+		{
+			name:      "string null finish reason",
+			input:     stringPtr("null"),
+			wantValid: false,
+		},
+		{
+			name:      "uppercase string null finish reason",
+			input:     stringPtr("NULL"),
+			wantValid: false,
+		},
+		{
+			name:       "valid finish reason",
+			input:      stringPtr("length"),
+			wantReason: "length",
+			wantValid:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReason, gotValid := normalizeFinishReason(tt.input)
+			assert.Equal(t, tt.wantReason, gotReason)
+			assert.Equal(t, tt.wantValid, gotValid)
+		})
+	}
+}
+
+func TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_Compatibility(t *testing.T) {
+	t.Run("finish_reason empty string should not stop stream", func(t *testing.T) {
+		converter := &ClaudeToOpenAIConverter{}
+
+		chunk1 := `data: {"id":"stream-1","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":""}],"created":1,"model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		out1, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(chunk1))
+		require.NoError(t, err)
+		events1 := parseClaudeSSEEvents(t, out1)
+		require.Len(t, events1, 1)
+		assert.Equal(t, "message_start", events1[0].Name)
+
+		chunk2 := `data: {"id":"stream-1","choices":[{"index":0,"delta":{"reasoning_content":"Let"},"finish_reason":""}],"created":1,"model":"m","object":"chat.completion.chunk","usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}` + "\n\n"
+		out2, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(chunk2))
+		require.NoError(t, err)
+		events2 := parseClaudeSSEEvents(t, out2)
+		require.Len(t, events2, 3)
+		assert.Equal(t, "content_block_start", events2[0].Name)
+		assert.Equal(t, "content_block_delta", events2[1].Name)
+		assert.Equal(t, "message_delta", events2[2].Name)
+		assert.Nil(t, events2[2].Payload.Delta.StopReason, "usage chunk without real finish_reason must not carry stop_reason")
+
+		eventNames := []string{events2[0].Name, events2[1].Name, events2[2].Name}
+		assert.NotContains(t, eventNames, "content_block_stop")
+		assert.NotContains(t, eventNames, "message_stop")
+	})
+
+	t.Run("usage in every chunk should not trigger early message_stop", func(t *testing.T) {
+		converter := &ClaudeToOpenAIConverter{}
+
+		chunkStart := `data: {"id":"stream-2","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"created":1,"model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		_, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(chunkStart))
+		require.NoError(t, err)
+
+		chunkThinking1 := `data: {"id":"stream-2","choices":[{"index":0,"delta":{"reasoning_content":"Let"},"finish_reason":null}],"created":1,"model":"m","object":"chat.completion.chunk","usage":{"prompt_tokens":10,"completion_tokens":1,"total_tokens":11}}` + "\n\n"
+		outThinking1, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(chunkThinking1))
+		require.NoError(t, err)
+		eventsThinking1 := parseClaudeSSEEvents(t, outThinking1)
+		require.Len(t, eventsThinking1, 3)
+		assert.Equal(t, "message_delta", eventsThinking1[2].Name)
+		assert.Nil(t, eventsThinking1[2].Payload.Delta.StopReason)
+
+		chunkThinking2 := `data: {"id":"stream-2","choices":[{"index":0,"delta":{"reasoning_content":" me"},"finish_reason":null}],"created":1,"model":"m","object":"chat.completion.chunk","usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}` + "\n\n"
+		outThinking2, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(chunkThinking2))
+		require.NoError(t, err)
+		eventsThinking2 := parseClaudeSSEEvents(t, outThinking2)
+		require.Len(t, eventsThinking2, 2)
+		assert.Equal(t, "content_block_delta", eventsThinking2[0].Name)
+		assert.Equal(t, "message_delta", eventsThinking2[1].Name)
+		assert.Nil(t, eventsThinking2[1].Payload.Delta.StopReason)
+
+		chunkFinishNoUsage := `data: {"id":"stream-2","choices":[{"index":0,"delta":{"content":"","reasoning_content":""},"finish_reason":"length"}],"created":1,"model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		outFinishNoUsage, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(chunkFinishNoUsage))
+		require.NoError(t, err)
+		eventsFinishNoUsage := parseClaudeSSEEvents(t, outFinishNoUsage)
+		require.Len(t, eventsFinishNoUsage, 1)
+		assert.Equal(t, "content_block_stop", eventsFinishNoUsage[0].Name)
+
+		chunkFinalUsage := `data: {"id":"stream-2","choices":[],"created":1,"model":"m","object":"chat.completion.chunk","usage":{"prompt_tokens":10,"completion_tokens":100,"total_tokens":110}}` + "\n\n"
+		outFinalUsage, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(chunkFinalUsage))
+		require.NoError(t, err)
+		eventsFinalUsage := parseClaudeSSEEvents(t, outFinalUsage)
+		require.Len(t, eventsFinalUsage, 2)
+		assert.Equal(t, "message_delta", eventsFinalUsage[0].Name)
+		require.NotNil(t, eventsFinalUsage[0].Payload.Delta.StopReason)
+		assert.Equal(t, "max_tokens", *eventsFinalUsage[0].Payload.Delta.StopReason)
+		assert.Equal(t, "message_stop", eventsFinalUsage[1].Name)
+
+		chunkDuplicateUsage := `data: {"id":"stream-2","choices":[],"created":1,"model":"m","object":"chat.completion.chunk","usage":{"prompt_tokens":10,"completion_tokens":100,"total_tokens":110}}` + "\n\n"
+		outDuplicateUsage, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(chunkDuplicateUsage))
+		require.NoError(t, err)
+		assert.Empty(t, strings.TrimSpace(string(outDuplicateUsage)), "duplicate trailing chunks after message_stop should be ignored")
+
+		doneChunk := "data: [DONE]\n\n"
+		outDone, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(doneChunk))
+		require.NoError(t, err)
+		assert.Empty(t, strings.TrimSpace(string(outDone)))
+
+		nextRequestChunk := `data: {"id":"stream-3","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}],"created":1,"model":"m","object":"chat.completion.chunk"}` + "\n\n"
+		outNextRequest, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(nextRequestChunk))
+		require.NoError(t, err)
+		eventsNextRequest := parseClaudeSSEEvents(t, outNextRequest)
+		require.Len(t, eventsNextRequest, 1)
+		assert.Equal(t, "message_start", eventsNextRequest[0].Name)
+	})
+}
+
+type parsedClaudeSSEEvent struct {
+	Name    string
+	Payload claudeTextGenStreamResponse
+}
+
+func parseClaudeSSEEvents(t *testing.T, raw []byte) []parsedClaudeSSEEvent {
+	t.Helper()
+
+	text := strings.TrimSpace(string(raw))
+	if text == "" {
+		return nil
+	}
+
+	blocks := strings.Split(text, "\n\n")
+	events := make([]parsedClaudeSSEEvent, 0, len(blocks))
+	for _, block := range blocks {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+
+		var eventName string
+		var dataPayload string
+		for _, line := range strings.Split(block, "\n") {
+			if strings.HasPrefix(line, "event: ") {
+				eventName = strings.TrimPrefix(line, "event: ")
+			}
+			if strings.HasPrefix(line, "data: ") {
+				dataPayload = strings.TrimPrefix(line, "data: ")
+			}
+		}
+
+		require.NotEmpty(t, eventName)
+		require.NotEmpty(t, dataPayload)
+
+		var payload claudeTextGenStreamResponse
+		require.NoError(t, json.Unmarshal([]byte(dataPayload), &payload))
+		events = append(events, parsedClaudeSSEEvent{
+			Name:    eventName,
+			Payload: payload,
+		})
+	}
+
+	return events
+}
+
+func stringPtr(value string) *string {
+	return &value
 }


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

本 PR 修复了 Claude 协议自动转换链路（OpenAI -> Claude streaming）在非标准上游流式响应下的兼容性问题，重点解决以下三类异常：

1. `finish_reason` 为空字符串（`""`）被误判为“结束信号”
2. 上游每个 chunk 都携带 `usage` 时，过早发送 `message_stop`
3. `message_stop` 后仍继续处理后续重复 chunk，导致事件乱序

### 背景

在 `/v1/messages` 自动协议转换路径中，`provider/claude_to_openai.go` 会将 OpenAI 风格流式 chunk 重建为 Claude SSE 事件。

部分 provider（如 GLM/OpenAI-compatible 服务）会返回非标准 chunk 形态：

- `finish_reason: ""`（而不是 `null`）
- 每个 chunk 都携带非空 `usage`
- 结束后还会重复发送 usage chunk

现有实现将上述输入误当作结束流程，导致：

- `content_block_stop` 在中间提前出现
- `message_stop` 在流未结束时出现
- `message_stop` 后还出现 `message_delta`

### 主要变更

1. **新增 finish_reason 归一化逻辑**（`provider/claude_to_openai.go`）
   - 新增 `normalizeFinishReason(*string) (string, bool)`
   - 将 `nil`、空字符串、空白字符串、`"null"`（大小写不敏感）统一视为“无结束信号”
   - 仅当 `finish_reason` 为真实有效值时，才进入 stop_reason/block_stop 处理分支

2. **`usage` 与 `message_stop` 解耦**
   - 仍允许输出 usage 对应的 `message_delta`
   - 仅当该 usage chunk 同时承载了真实 `stop_reason` 时，才发送 `message_stop`
   - 兼容“每个 chunk 都有 usage”但尚未结束的流

3. **增加流结束后保护约束**
   - 若已发送 `message_stop`，则忽略后续非 `[DONE]` chunk
   - 防止重复 usage chunk 造成 `message_stop` 之后仍有 `message_delta`
   - `[DONE]` 仍会被处理，用于状态重置，确保下一个请求不受污染

### 修复前后对比

| 场景 | 变更前 | 变更后 |
|------|--------|--------|
| `finish_reason=""` | ❌ 被当作结束信号，可能提前发 `content_block_stop` | ✅ 视为无结束信号，不触发结束逻辑 |
| 每个 chunk 都有 usage | ❌ 可能提前发 `message_stop` | ✅ 仅输出 usage `message_delta`，不提前终止 |
| 结束后重复 usage chunk | ❌ `message_stop` 后仍可能输出 `message_delta` | ✅ 直接忽略重复尾部 chunk |
| `[DONE]` 后下一请求 | ⚠️ 有状态污染风险 | ✅ 状态正确 reset，下一请求正常 |

## Ⅱ. Does this pull request fix one issue?

是。修复了 Claude 自动协议转换在非标准 OpenAI-compatible 流式返回下的提前结束与事件乱序问题，覆盖：

- 空字符串 finish_reason 误判
- usage 误触发 message_stop
- message_stop 后续 chunk 污染

## Ⅲ. Why don't you add test cases (unit test/integration test)?

已补充充分单元测试，覆盖本次变更/新增代码的关键分支：

- ✅ `TestNormalizeFinishReason`
  - 覆盖 `nil`、`""`、空白、`"null"`、`"NULL"`、有效值
- ✅ `TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_Compatibility`
  - `finish_reason=""` 不应触发 stop
  - 每 chunk usage 不应提前 `message_stop`
  - 真正结束后（有效 finish_reason + usage）才发送 `message_stop`
  - `message_stop` 后重复 chunk 被忽略
  - `[DONE]` 后状态 reset，下一请求可正常开始

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test ./provider -gcflags="all=-N -l"
```

也可只跑新增用例：

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test ./provider -run "TestNormalizeFinishReason|TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_Compatibility" -gcflags="all=-N -l"
```

## Ⅴ. Special notes for reviews

1. 本次改动为兼容性增强，不改变标准 OpenAI 流式（`finish_reason` 规范、final usage chunk）的既有行为。
2. `normalizeFinishReason` 仅过滤“伪结束值”（空串/`"null"`），真实结束值仍按原逻辑映射到 Claude `stop_reason`。
3. “忽略 `message_stop` 后续 chunk”是防御性约束，用于处理非标准或重复尾包，不影响 `[DONE]` 的状态回收。

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have included the AI Coding summary below

### AI Coding Summary

**关键决策：**
1. 引入 finish_reason 归一化，将空字符串视为无效结束信号。
2. 将 usage 处理与 message_stop 触发条件解耦，仅在携带真实 stop_reason 时终止。
3. 增加 `message_stop` 后的 chunk 丢弃保护，避免乱序事件。

**主要改动范围：**
1. `provider/claude_to_openai.go`
   - 增加 `normalizeFinishReason`
   - 调整 finish_reason 入口判断
   - 调整 usage -> message_stop 触发条件
   - 增加 message_stop 后 chunk 忽略逻辑
2. `provider/claude_to_openai_test.go`
   - 新增 finish_reason 归一化单测
   - 新增流式兼容性行为单测与 SSE 解析测试辅助函数

**验证结果：**
1. `go test ./provider -run "TestNormalizeFinishReason|TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_Compatibility" -gcflags="all=-N -l"` 通过
2. `go test ./provider -gcflags="all=-N -l"` 通过
