### PR TITLE
docs: add MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,38 @@
+# Higress Maintainers
+
+This file lists the current maintainers of the Higress project.
+
+A maintainer is a contributor who is actively responsible for guiding the
+direction of the project, reviewing and merging contributions, and
+participating in project governance.
+
+For the day-to-day code-review ownership of individual subdirectories,
+see [`CODEOWNERS`](./CODEOWNERS).
+
+## Maintainers
+
+| Name           | GitHub                                                  | Affiliation       |
+| -------------- | ------------------------------------------------------- | ----------------- |
+| Yiquan Dong    | [@CH3CHO](https://github.com/CH3CHO)                    | Trip.com          |
+| Yuanxiao Zhao  | [@EndlessSeeker](https://github.com/EndlessSeeker)      | Alibaba Cloud     |
+| Leilei Geng    | [@gengleilei](https://github.com/gengleilei)            | Alibaba Cloud     |
+| Xiantao Han    | [@hanxiantao](https://github.com/hanxiantao)            | XinYe Technology  |
+| Zhiwei Cheng   | [@cr7258](https://github.com/cr7258)                    | NVIDIA            |
+| Tianyi Zhang   | [@johnlanni](https://github.com/johnlanni)              | Alibaba Cloud     |
+| Jingfeng Xu    | [@lexburner](https://github.com/lexburner)              | Alibaba Cloud     |
+
+## Becoming a maintainer
+
+Higress follows the contribution and graduation paths described in
+[`CONTRIBUTING_EN.md`](./CONTRIBUTING_EN.md). Active and sustained
+contributors who consistently demonstrate good technical judgement and
+community stewardship can be nominated as maintainers by an existing
+maintainer; nominations are accepted by lazy consensus among the current
+maintainers.
+
+## Reporting issues
+
+* For security issues, please follow [`SECURITY.md`](./SECURITY.md).
+* For all other questions, please use
+  [GitHub Issues](https://github.com/higress-group/higress/issues) or our
+  community channels listed in the [README](./README.md).


### PR DESCRIPTION
## Summary

Add a top-level `MAINTAINERS.md` file enumerating the current Higress
project maintainers.

This is in preparation for the CNCF Sandbox onboarding checklist item in
[cncf/sandbox#481](https://github.com/cncf/sandbox/issues/481):

> Create a maintainer list and add it to the [aggregated CNCF maintainer list](https://maintainers.cncf.io) via pull request.

A follow-up PR to [cncf/foundation](https://github.com/cncf/foundation/blob/main/project-maintainers.csv)
will reference this file as Higress's source of truth for maintainers.

The list mirrors the existing maintainers reflected in `CODEOWNERS` and
recent project governance discussions; please call out any corrections
inline.

## Test plan

- Render check on GitHub.
