### PR TITLE
fix: Skip TLS certificate verification for HTTPS upstreams

### DIFF
--- a/pkg/ingress/kube/annotations/upstreamtls.go
+++ b/pkg/ingress/kube/annotations/upstreamtls.go
@@ -170,6 +170,9 @@ func processMTLS(config *Ingress) *networking.ClientTLSSettings {
 func processSimple(config *Ingress) *networking.ClientTLSSettings {
 	tls := &networking.ClientTLSSettings{
 		Mode: networking.ClientTLSSettings_SIMPLE,
+		InsecureSkipVerify: &wrappers.BoolValue{
+			Value: true,
+		},
 	}
 
 	if config.UpstreamTLS.EnableSNI && config.UpstreamTLS.SNI != "" {

--- a/pkg/ingress/kube/annotations/upstreamtls_test.go
+++ b/pkg/ingress/kube/annotations/upstreamtls_test.go
@@ -17,8 +17,10 @@ package annotations
 import (
 	"testing"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
 	networking "istio.io/api/networking/v1alpha3"
 )
 
@@ -129,6 +131,9 @@ func TestApplyTrafficPolicy(t *testing.T) {
 				Tls: &networking.ClientTLSSettings{
 					Mode: networking.ClientTLSSettings_SIMPLE,
 					Sni:  "SNI",
+					InsecureSkipVerify: &wrappers.BoolValue{
+						Value: true,
+					},
 				},
 			},
 		},
@@ -158,7 +163,9 @@ func TestApplyTrafficPolicy(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run("", func(t *testing.T) {
 			parser.ApplyTrafficPolicy(nil, testCase.input, testCase.config)
-			if diff := cmp.Diff(testCase.expect, testCase.input, cmpopts.IgnoreUnexported(unexportedIgnoredTypes...)); diff != "" {
+			if diff := cmp.Diff(testCase.expect, testCase.input, protocmp.Transform(),
+				cmpopts.IgnoreUnexported(unexportedIgnoredTypes...),
+			); diff != "" {
 				t.Fatalf("TestApplyTrafficPolicy() mismatch (-want +got): \n%s", diff)
 			}
 		})


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

Skip TLS certificate verification to support HTTPS upstreams with self-signed certificates.

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/higress-group/higress/issues/3768

## Ⅲ. Why don't you add test cases (unit test/integration test)? 


## Ⅳ. Describe how to verify it


## Ⅴ. Special notes for reviews

https://istio.io/latest/news/releases/1.21.x/announcing-1.21/#easing-upgrades-with-compatibility-versions
> - Automatic SNI for SIMPLE TLS origination in DestinationRule
> - Default-on TLS verification for TLS origination in DestinationRule

So upgrading Istio from 1.19 to 1.27 brings this default value change. So if we want to keep the original behavior, the change in this PR is needed.
