### PR TITLE
fix(vertex): inject api key for express raw endpoints

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
@@ -56,6 +56,10 @@ const (
 // 允许任意 basePath 前缀，兼容 basePathHandling 配置
 var vertexRawPathRegex = regexp.MustCompile(`^.*/([^/]+)/projects/([^/]+)/locations/([^/]+)/publishers/([^/]+)/models/([^/:]+):([^/?]+)`)
 
+// vertexExpressRawPathRegex 匹配 Vertex AI Express Mode 专用 REST API 路径
+// 格式: [任意前缀]/{api-version}/publishers/{publisher}/models/{model}:{action}
+var vertexExpressRawPathRegex = regexp.MustCompile(`^.*/(v[^/]+)/publishers/([^/]+)/models/([^/:]+):([^/?]+)`)
+
 type vertexProviderInitializer struct{}
 
 func (v *vertexProviderInitializer) ValidateConfig(config *ProviderConfig) error {
@@ -158,7 +162,7 @@ func (v *vertexProvider) GetApiName(path string) ApiName {
 	// 优先匹配原生 Vertex AI REST API 路径，支持任意 basePath 前缀
 	// 格式: [任意前缀]/{api-version}/projects/{project}/locations/{location}/publishers/{publisher}/models/{model}:{action}
 	// 必须在其他 action 检查之前，因为 :predict、:generateContent 等 action 会被其他规则匹配
-	if vertexRawPathRegex.MatchString(path) {
+	if vertexRawPathRegex.MatchString(path) || (v.isExpressMode() && vertexExpressRawPathRegex.MatchString(path)) {
 		return ApiNameVertexRaw
 	}
 	if strings.HasSuffix(path, vertexChatCompletionAction) || strings.HasSuffix(path, vertexChatCompletionStreamAction) {

--- a/plugins/wasm-go/extensions/ai-proxy/test/vertex.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/vertex.go
@@ -2280,6 +2280,27 @@ func RunVertexRawModeOnHttpRequestHeadersTests(t *testing.T) {
 				"Host header should be changed to vertex domain without region prefix")
 		})
 
+		// 测试 Vertex Raw 模式请求头处理（Express Mode 专用路径，无 project/location）
+		t.Run("vertex raw mode express - request headers with express endpoint path", func(t *testing.T) {
+			host, status := test.NewTestHost(vertexRawModeExpressConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/publishers/google/models/gemini-3.1-flash-lite-preview:streamGenerateContent"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			require.NotNil(t, requestHeaders)
+			require.True(t, test.HasHeaderWithValue(requestHeaders, ":authority", "aiplatform.googleapis.com"),
+				"Host header should be changed to vertex domain without region prefix")
+		})
+
 		// 测试 Vertex Raw 模式请求头处理（标准模式 + 原生 Vertex API 路径）
 		t.Run("vertex raw mode standard - request headers with native vertex path", func(t *testing.T) {
 			host, status := test.NewTestHost(vertexRawModeStandardConfig)
@@ -2412,6 +2433,43 @@ func RunVertexRawModeOnHttpRequestBodyTests(t *testing.T) {
 				"API key should be appended to path as query parameter")
 
 			// 验证 Authorization header 被删除
+			require.False(t, test.HasHeaderWithValue(requestHeaders, "Authorization", "Bearer some-token"),
+				"Authorization header should be removed in Express Mode")
+		})
+
+		// 测试 Vertex Raw 模式请求体处理（Express Mode 专用路径 + API Key 认证）
+		t.Run("vertex raw mode express - express endpoint request body with api key", func(t *testing.T) {
+			host, status := test.NewTestHost(vertexRawModeExpressConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/publishers/google/models/gemini-3.1-flash-lite-preview:streamGenerateContent"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+				{"Authorization", "Bearer some-token"},
+			})
+
+			requestBody := `{"contents":[{"role":"user","parts":[{"text":"Tell me a story"}]}]}`
+			action := host.CallOnHttpRequestBody([]byte(requestBody))
+
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.NotNil(t, processedBody)
+			require.Equal(t, requestBody, string(processedBody), "Request body should be passed through unchanged")
+
+			requestHeaders := host.GetRequestHeaders()
+			var pathHeader string
+			for _, header := range requestHeaders {
+				if header[0] == ":path" {
+					pathHeader = header[1]
+					break
+				}
+			}
+			require.Equal(t, "/v1/publishers/google/models/gemini-3.1-flash-lite-preview:streamGenerateContent?key=test-api-key-for-raw-mode", pathHeader,
+				"API key should be appended to express endpoint path as query parameter")
 			require.False(t, test.HasHeaderWithValue(requestHeaders, "Authorization", "Bearer some-token"),
 				"Authorization header should be removed in Express Mode")
 		})


### PR DESCRIPTION
## I. Describe what this PR did

This PR fixes Vertex AI Express Mode raw REST endpoint handling in the ai-proxy plugin.

Vertex AI Express Mode supports REST endpoints without project/location segments, for example:

```text
https://aiplatform.googleapis.com/v1/publishers/google/models/{model}:streamGenerateContent?key={API_KEY}
```

Previously, ai-proxy only recognized Vertex raw REST paths that included /projects/{project}/locations/{location}/.... Requests to Express Mode native paths such as /v1/publishers/google/models/{model}:streamGenerateContent were not routed through the Vertex raw handling
branch, so the configured API key was not injected and upstream returned 401 Request is missing required authentication credential.

Changes:

- Add recognition for Vertex Express Mode raw REST paths: /{api-version}/publishers/{publisher}/models/{model}:{action}.
- Restrict the new raw path recognition to Vertex Express Mode (apiTokens configured).
- Reuse the existing API key injection logic so raw Express requests receive key=<apiToken> in the query string.
- Keep the request body unchanged for native REST requests.
- Add regression tests for Express Mode raw endpoint header/body handling.

## II. Does this pull request fix one issue?

No linked issue.

## III. Why don't you add test cases (unit test/integration test)?

Test cases were added in test/vertex.go for:

- Recognizing /v1/publishers/google/models/{model}:streamGenerateContent as a Vertex raw request in Express Mode.
- Injecting the configured API key into the Express Mode raw endpoint path.
- Preserving the native Vertex request body unchanged.
- Removing the incoming Authorization header for Express Mode API key authentication.

## IV. Describe how to verify it

Ran:

go test . -run TestVertex

Result:

ok  github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy  51.746s

## V. Special notes for reviews

The new raw path regex is only applied when Vertex Express Mode is enabled, so standard Vertex OAuth paths and existing OpenAI-protocol conversion behavior are unchanged.

Reference: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview

### AI Coding Prompts (for regular updates)

User asked to fix Vertex AI Provider Express Mode native REST endpoint API key injection, based on the latest main, with reference to the official Express Mode endpoint format:

Endpoint URL in express mode: https://aiplatform.googleapis.com/v1/publishers/google/models/{model}:streamGenerateContent?key={API_KEY}

### AI Coding Summary

- Key decision: Treat Express Mode native REST paths without project/location as Vertex raw requests only when apiTokens are configured.
- Major changes implemented: Added Express raw path recognition in provider/vertex.go and regression tests in test/vertex.go.
- Important considerations: Existing standard Vertex raw paths, OAuth behavior, and OpenAI-protocol conversion paths remain unchanged.