### PR TITLE
bugfix: map bedrock tool-call indexes and tool_choice

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
@@ -47,6 +47,8 @@ const (
 	bedrockCachePointPositionSystemPrompt    = "systemPrompt"
 	bedrockCachePointPositionLastUserMessage = "lastUserMessage"
 	bedrockCachePointPositionLastMessage     = "lastMessage"
+
+	ctxKeyBedrockToolCallState = "bedrock_tool_call_state"
 )
 
 var (
@@ -121,11 +123,13 @@ func (b *bedrockProvider) convertEventFromBedrockToOpenAI(ctx wrapper.HttpContex
 		chatChoice.Delta.Role = *bedrockEvent.Role
 	}
 	if bedrockEvent.Start != nil {
+		toolCallIndex := getBedrockOpenAIToolCallIndex(ctx, bedrockEvent.ContentBlockIndex)
 		chatChoice.Delta.Content = nil
 		chatChoice.Delta.ToolCalls = []toolCall{
 			{
-				Id:   bedrockEvent.Start.ToolUse.ToolUseID,
-				Type: "function",
+				Index: toolCallIndex,
+				Id:    bedrockEvent.Start.ToolUse.ToolUseID,
+				Type:  "function",
 				Function: functionCall{
 					Name:      bedrockEvent.Start.ToolUse.Name,
 					Arguments: "",
@@ -152,9 +156,11 @@ func (b *bedrockProvider) convertEventFromBedrockToOpenAI(ctx wrapper.HttpContex
 			chatChoice.Delta = &chatMessage{Content: &content}
 		}
 		if bedrockEvent.Delta.ToolUse != nil {
+			toolCallIndex := getBedrockOpenAIToolCallIndex(ctx, bedrockEvent.ContentBlockIndex)
 			chatChoice.Delta.ToolCalls = []toolCall{
 				{
-					Type: "function",
+					Index: toolCallIndex,
+					Type:  "function",
 					Function: functionCall{
 						Arguments: bedrockEvent.Delta.ToolUse.Input,
 					},
@@ -190,6 +196,28 @@ func (b *bedrockProvider) convertEventFromBedrockToOpenAI(ctx wrapper.HttpContex
 	openAIChunk.WriteString(string(openAIFormattedChunkBytes))
 	openAIChunk.WriteString("\n\n")
 	return []byte(openAIChunk.String()), nil
+}
+
+type bedrockToolCallState struct {
+	indexes map[int]int
+	next    int
+}
+
+func getBedrockOpenAIToolCallIndex(ctx wrapper.HttpContext, contentBlockIndex int) int {
+	state, _ := ctx.GetContext(ctxKeyBedrockToolCallState).(*bedrockToolCallState)
+	if state == nil {
+		state = &bedrockToolCallState{indexes: make(map[int]int)}
+		ctx.SetContext(ctxKeyBedrockToolCallState, state)
+	}
+
+	if toolCallIndex, ok := state.indexes[contentBlockIndex]; ok {
+		return toolCallIndex
+	}
+
+	toolCallIndex := state.next
+	state.indexes[contentBlockIndex] = toolCallIndex
+	state.next++
+	return toolCallIndex
 }
 
 type ConverseStreamEvent struct {
@@ -870,22 +898,25 @@ func (b *bedrockProvider) buildBedrockTextGenerationRequest(origRequest *chatCom
 		}
 	}
 
-	if origRequest.Tools != nil {
+	if origRequest.Tools != nil && origRequest.getToolChoiceType() != "none" {
 		request.ToolConfig = &bedrockToolConfig{}
-		if origRequest.ToolChoice == nil {
-			request.ToolConfig.ToolChoice.Auto = &struct{}{}
-		} else if choice_type, ok := origRequest.ToolChoice.(string); ok {
+		request.ToolConfig.ToolChoice.Auto = &struct{}{}
+		if choice_type := origRequest.getToolChoiceType(); choice_type != "" {
 			switch choice_type {
-			case "required":
+			// "any" is accepted for direct Anthropic-compatible callers; OpenAI
+			// uses "required" for the same "must call at least one tool" behavior.
+			case "required", "any":
+				request.ToolConfig.ToolChoice.Auto = nil
 				request.ToolConfig.ToolChoice.Any = &struct{}{}
 			case "auto":
 				request.ToolConfig.ToolChoice.Auto = &struct{}{}
-			case "none":
-				request.ToolConfig.ToolChoice.Auto = &struct{}{}
-			}
-		} else if choice, ok := origRequest.ToolChoice.(toolChoice); ok {
-			request.ToolConfig.ToolChoice.Tool = &bedrockToolSpecification{
-				Name: choice.Function.Name,
+			case "function":
+				if choice := origRequest.getToolChoiceObject(); choice != nil && choice.Function.Name != "" {
+					request.ToolConfig.ToolChoice.Auto = nil
+					request.ToolConfig.ToolChoice.Tool = &bedrockSpecificToolChoice{
+						Name: choice.Function.Name,
+					}
+				}
 			}
 		}
 		request.ToolConfig.Tools = []bedrockTool{}
@@ -1151,9 +1182,13 @@ type bedrockTool struct {
 }
 
 type bedrockToolChoice struct {
-	Any  *struct{}                 `json:"any,omitempty"`
-	Auto *struct{}                 `json:"auto,omitempty"`
-	Tool *bedrockToolSpecification `json:"tool,omitempty"`
+	Any  *struct{}                  `json:"any,omitempty"`
+	Auto *struct{}                  `json:"auto,omitempty"`
+	Tool *bedrockSpecificToolChoice `json:"tool,omitempty"`
+}
+
+type bedrockSpecificToolChoice struct {
+	Name string `json:"name"`
 }
 
 type bedrockToolSpecification struct {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -672,11 +672,30 @@ func (c *claudeProvider) buildClaudeTextGenRequest(origRequest *chatCompletionRe
 		claudeRequest.Tools = append(claudeRequest.Tools, claudeTool)
 	}
 
-	if tc := origRequest.getToolChoiceObject(); tc != nil {
-		claudeRequest.ToolChoice = &claudeToolChoice{
-			Name:                   tc.Function.Name,
-			Type:                   tc.Type,
-			DisableParallelToolUse: !origRequest.ParallelToolCalls,
+	if origRequest.ToolChoice != nil {
+		parallelToolCalls := true
+		if origRequest.ParallelToolCalls != nil {
+			parallelToolCalls = *origRequest.ParallelToolCalls
+		}
+
+		choiceType := origRequest.getToolChoiceType()
+		if tc := origRequest.getToolChoiceObject(); tc != nil && tc.Type == "function" && tc.Function.Name != "" {
+			claudeRequest.ToolChoice = &claudeToolChoice{
+				Name:                   tc.Function.Name,
+				Type:                   "tool",
+				DisableParallelToolUse: !parallelToolCalls,
+			}
+		} else if choiceType != "" {
+			switch choiceType {
+			case "required":
+				choiceType = "any"
+			}
+			claudeRequest.ToolChoice = &claudeToolChoice{
+				Type: choiceType,
+			}
+			if choiceType != "none" {
+				claudeRequest.ToolChoice.DisableParallelToolUse = !parallelToolCalls
+			}
 		}
 	}
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
@@ -183,6 +183,87 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 		assert.False(t, claudeReq.System.IsArray)
 		assert.Equal(t, "You are a helpful assistant.", claudeReq.System.StringValue)
 	})
+
+	t.Run("maps_openai_function_tool_choice_to_claude_tool_choice", func(t *testing.T) {
+		request := &chatCompletionRequest{
+			Model:     "claude-sonnet-4-5-20250929",
+			MaxTokens: 8192,
+			Messages: []chatMessage{
+				{Role: roleUser, Content: "Search."},
+			},
+			Tools: []tool{{
+				Type: "function",
+				Function: function{
+					Name:        "web_search",
+					Description: "Search the web.",
+					Parameters:  map[string]interface{}{"type": "object"},
+				},
+			}},
+			ToolChoice: map[string]interface{}{
+				"type": "function",
+				"function": map[string]interface{}{
+					"name": "web_search",
+				},
+			},
+		}
+
+		claudeReq := provider.buildClaudeTextGenRequest(request)
+
+		require.NotNil(t, claudeReq.ToolChoice)
+		assert.Equal(t, "tool", claudeReq.ToolChoice.Type)
+		assert.Equal(t, "web_search", claudeReq.ToolChoice.Name)
+	})
+
+	t.Run("maps_openai_string_required_tool_choice_to_claude_any", func(t *testing.T) {
+		parallelToolCalls := false
+		request := &chatCompletionRequest{
+			Model:     "claude-sonnet-4-5-20250929",
+			MaxTokens: 8192,
+			Messages: []chatMessage{
+				{Role: roleUser, Content: "Search."},
+			},
+			Tools: []tool{{
+				Type: "function",
+				Function: function{
+					Name:       "web_search",
+					Parameters: map[string]interface{}{"type": "object"},
+				},
+			}},
+			ToolChoice:        "required",
+			ParallelToolCalls: &parallelToolCalls,
+		}
+
+		claudeReq := provider.buildClaudeTextGenRequest(request)
+
+		require.NotNil(t, claudeReq.ToolChoice)
+		assert.Equal(t, "any", claudeReq.ToolChoice.Type)
+		assert.Empty(t, claudeReq.ToolChoice.Name)
+		assert.True(t, claudeReq.ToolChoice.DisableParallelToolUse)
+	})
+
+	t.Run("maps_openai_string_none_tool_choice_to_claude_none", func(t *testing.T) {
+		request := &chatCompletionRequest{
+			Model:     "claude-sonnet-4-5-20250929",
+			MaxTokens: 8192,
+			Messages: []chatMessage{
+				{Role: roleUser, Content: "Answer without tools."},
+			},
+			Tools: []tool{{
+				Type: "function",
+				Function: function{
+					Name:       "web_search",
+					Parameters: map[string]interface{}{"type": "object"},
+				},
+			}},
+			ToolChoice: "none",
+		}
+
+		claudeReq := provider.buildClaudeTextGenRequest(request)
+
+		require.NotNil(t, claudeReq.ToolChoice)
+		assert.Equal(t, "none", claudeReq.ToolChoice.Type)
+		assert.Empty(t, claudeReq.ToolChoice.Name)
+	})
 }
 
 func TestClaudeProvider_BuildClaudeTextGenRequest_ClaudeCodeMode(t *testing.T) {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
@@ -178,12 +178,19 @@ func (c *ClaudeToOpenAIConverter) ConvertClaudeRequestToOpenAI(body []byte) ([]b
 				},
 			}
 		} else {
-			// For other types like "auto", "none", etc.
-			openaiRequest.ToolChoice = claudeRequest.ToolChoice.Type
+			// Anthropic's "any" means the model must call at least one tool.
+			// OpenAI-compatible requests express the same behavior as "required".
+			if claudeRequest.ToolChoice.Type == "any" {
+				openaiRequest.ToolChoice = "required"
+			} else {
+				// For other types like "auto", "none", etc.
+				openaiRequest.ToolChoice = claudeRequest.ToolChoice.Type
+			}
 		}
 
 		// Handle parallel tool calls
-		openaiRequest.ParallelToolCalls = !claudeRequest.ToolChoice.DisableParallelToolUse
+		parallelToolCalls := !claudeRequest.ToolChoice.DisableParallelToolUse
+		openaiRequest.ParallelToolCalls = &parallelToolCalls
 	}
 
 	// Convert thinking configuration if present

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
@@ -35,6 +35,66 @@ func init() {
 func TestClaudeToOpenAIConverter_ConvertClaudeRequestToOpenAI(t *testing.T) {
 	converter := &ClaudeToOpenAIConverter{}
 
+	t.Run("convert_tool_choice_any_to_required", func(t *testing.T) {
+		claudeRequest := `{
+			"model": "claude-sonnet-4",
+			"max_tokens": 1000,
+			"messages": [{"role": "user", "content": "Run a search."}],
+			"tools": [{
+				"name": "web_search",
+				"description": "Search the web.",
+				"input_schema": {
+					"type": "object",
+					"properties": {"query": {"type": "string"}},
+					"required": ["query"]
+				}
+			}],
+			"tool_choice": {"type": "any"}
+		}`
+
+		result, err := converter.ConvertClaudeRequestToOpenAI([]byte(claudeRequest))
+		require.NoError(t, err)
+
+		var openaiRequest chatCompletionRequest
+		err = json.Unmarshal(result, &openaiRequest)
+		require.NoError(t, err)
+
+		require.Equal(t, "required", openaiRequest.ToolChoice)
+		require.NotNil(t, openaiRequest.ParallelToolCalls)
+		require.True(t, *openaiRequest.ParallelToolCalls)
+		require.Contains(t, string(result), `"parallel_tool_calls":true`)
+	})
+
+	t.Run("convert_tool_choice_any_preserves_disable_parallel_tool_use", func(t *testing.T) {
+		claudeRequest := `{
+			"model": "claude-sonnet-4",
+			"max_tokens": 1000,
+			"messages": [{"role": "user", "content": "Run a search."}],
+			"tools": [{
+				"name": "web_search",
+				"description": "Search the web.",
+				"input_schema": {
+					"type": "object",
+					"properties": {"query": {"type": "string"}},
+					"required": ["query"]
+				}
+			}],
+			"tool_choice": {"type": "any", "disable_parallel_tool_use": true}
+		}`
+
+		result, err := converter.ConvertClaudeRequestToOpenAI([]byte(claudeRequest))
+		require.NoError(t, err)
+
+		var openaiRequest chatCompletionRequest
+		err = json.Unmarshal(result, &openaiRequest)
+		require.NoError(t, err)
+
+		require.Equal(t, "required", openaiRequest.ToolChoice)
+		require.NotNil(t, openaiRequest.ParallelToolCalls)
+		require.False(t, *openaiRequest.ParallelToolCalls)
+		require.Contains(t, string(result), `"parallel_tool_calls":false`)
+	})
+
 	t.Run("convert_multiple_text_content_blocks", func(t *testing.T) {
 		// Test case: multiple text content blocks should remain as separate array elements with cache control support
 		// Both system and user messages should handle array content format

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -70,7 +70,7 @@ type chatCompletionRequest struct {
 	TopP                 float64                `json:"top_p,omitempty"`
 	Tools                []tool                 `json:"tools,omitempty"`
 	ToolChoice           interface{}            `json:"tool_choice,omitempty"`
-	ParallelToolCalls    bool                   `json:"parallel_tool_calls,omitempty"`
+	ParallelToolCalls    *bool                  `json:"parallel_tool_calls,omitempty"`
 	User                 string                 `json:"user,omitempty"`
 }
 
@@ -92,15 +92,33 @@ func (c *chatCompletionRequest) getToolChoiceString() string {
 	return ""
 }
 
-func (c *chatCompletionRequest) getToolChoiceObject() *toolChoice {
-	if c.ToolChoice == nil {
-		return nil
-	}
-
-	if tc, ok := c.ToolChoice.(*toolChoice); ok {
+func (c *chatCompletionRequest) getToolChoiceType() string {
+	if tc := c.getToolChoiceString(); tc != "" {
 		return tc
 	}
-	return nil
+	if tc := c.getToolChoiceObject(); tc != nil {
+		return tc.Type
+	}
+	return ""
+}
+
+func (c *chatCompletionRequest) getToolChoiceObject() *toolChoice {
+	switch tc := c.ToolChoice.(type) {
+	case nil, string:
+		return nil
+	case *toolChoice:
+		return tc
+	}
+
+	body, err := json.Marshal(c.ToolChoice)
+	if err != nil {
+		return nil
+	}
+	var parsed toolChoice
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil
+	}
+	return &parsed
 }
 
 type CompletionRequest struct {
@@ -474,7 +492,7 @@ type toolCall struct {
 
 type functionCall struct {
 	Id        string `json:"id,omitempty"`
-	Name      string `json:"name"`
+	Name      string `json:"name,omitempty"`
 	Arguments string `json:"arguments"`
 }
 

--- a/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
@@ -1365,6 +1365,177 @@ func RunBedrockToolCallTests(t *testing.T) {
 			require.Equal(t, "call_002", secondResult["toolUseId"])
 		})
 
+		t.Run("bedrock maps any tool choice to converse any tool choice", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "gpt-4",
+				"messages": [{"role": "user", "content": "Run a search."}],
+				"tool_choice": "any",
+				"tools": [{
+					"type": "function",
+					"function": {
+						"name": "web_search",
+						"description": "Search the web.",
+						"parameters": {
+							"type": "object",
+							"properties": {"query": {"type": "string"}},
+							"required": ["query"]
+						}
+					}
+				}]
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.NotNil(t, processedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(processedBody, &bodyMap)
+			require.NoError(t, err)
+
+			toolConfig := bodyMap["toolConfig"].(map[string]interface{})
+			toolChoice := toolConfig["toolChoice"].(map[string]interface{})
+			require.Contains(t, toolChoice, "any")
+			require.Equal(t, map[string]interface{}{}, toolChoice["any"])
+		})
+
+		t.Run("bedrock maps object tool choice to converse tool choice", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "gpt-4",
+				"messages": [{"role": "user", "content": "Run a search."}],
+				"tool_choice": {"type":"function","function":{"name":"web_search"}},
+				"tools": [{
+					"type": "function",
+					"function": {
+						"name": "web_search",
+						"description": "Search the web.",
+						"parameters": {
+							"type": "object",
+							"properties": {"query": {"type": "string"}},
+							"required": ["query"]
+						}
+					}
+				}]
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.NotNil(t, processedBody)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(processedBody, &bodyMap)
+			require.NoError(t, err)
+
+			toolConfig := bodyMap["toolConfig"].(map[string]interface{})
+			toolChoice := toolConfig["toolChoice"].(map[string]interface{})
+			tool := toolChoice["tool"].(map[string]interface{})
+			require.Equal(t, "web_search", tool["name"])
+			require.Len(t, tool, 1, "Bedrock specific tool choice should only include name")
+		})
+
+		t.Run("bedrock maps object any tool choice to converse any tool choice", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "gpt-4",
+				"messages": [{"role": "user", "content": "Run a search."}],
+				"tool_choice": {"type":"any"},
+				"tools": [{
+					"type": "function",
+					"function": {
+						"name": "web_search",
+						"description": "Search the web.",
+						"parameters": {"type": "object"}
+					}
+				}]
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(host.GetRequestBody(), &bodyMap)
+			require.NoError(t, err)
+
+			toolConfig := bodyMap["toolConfig"].(map[string]interface{})
+			toolChoice := toolConfig["toolChoice"].(map[string]interface{})
+			require.Contains(t, toolChoice, "any")
+			require.NotContains(t, toolChoice, "tool")
+		})
+
+		t.Run("bedrock maps none tool choice by omitting tools", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "gpt-4",
+				"messages": [{"role": "user", "content": "Answer without tools."}],
+				"tool_choice": {"type":"none"},
+				"tools": [{
+					"type": "function",
+					"function": {
+						"name": "web_search",
+						"description": "Search the web.",
+						"parameters": {"type": "object"}
+					}
+				}]
+			}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			var bodyMap map[string]interface{}
+			err := json.Unmarshal(host.GetRequestBody(), &bodyMap)
+			require.NoError(t, err)
+			require.NotContains(t, bodyMap, "toolConfig")
+		})
+
 		// Test tool call with text content mixed
 		t.Run("bedrock tool call with text content mixed", func(t *testing.T) {
 			host, status := test.NewTestHost(bedrockApiTokenConfig)
@@ -1667,6 +1838,138 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 		t.Run("extract first data payload should return empty when no data line", func(t *testing.T) {
 			payload := extractFirstDataPayload([]byte("event: ping\n\n"))
 			require.Equal(t, "", payload)
+		})
+
+		t.Run("bedrock streaming parallel tool calls should use dense OpenAI indexes", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "gpt-4",
+				"messages": [{"role": "user", "content": "Run three independent searches."}],
+				"stream": true,
+				"tools": [{
+					"type": "function",
+					"function": {
+						"name": "web_search",
+						"description": "Search the web.",
+						"parameters": {
+							"type": "object",
+							"properties": {"query": {"type": "string"}},
+							"required": ["query"]
+						}
+					}
+				}]
+			}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			host.SetProperty([]string{"response", "code_details"}, []byte("via_upstream"))
+			action = host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"Content-Type", "application/vnd.amazon.eventstream"},
+			})
+			require.Equal(t, types.ActionContinue, action)
+
+			extractFirstToolCallIndex := func(body []byte) int {
+				dataPayload := extractFirstDataPayload(body)
+				require.NotEmpty(t, dataPayload, "streaming chunk should contain one SSE data payload")
+
+				var responseMap map[string]interface{}
+				err := json.Unmarshal([]byte(dataPayload), &responseMap)
+				require.NoError(t, err)
+
+				choices := responseMap["choices"].([]interface{})
+				require.Len(t, choices, 1, "streaming chunk should contain one choice")
+				delta := choices[0].(map[string]interface{})["delta"].(map[string]interface{})
+				toolCalls := delta["tool_calls"].([]interface{})
+				require.Len(t, toolCalls, 1, "streaming chunk should contain one tool call delta")
+
+				index, ok := toolCalls[0].(map[string]interface{})["index"].(float64)
+				require.True(t, ok, "tool call delta should include an index")
+				return int(index)
+			}
+			extractFirstToolCall := func(body []byte) map[string]interface{} {
+				dataPayload := extractFirstDataPayload(body)
+				require.NotEmpty(t, dataPayload, "streaming chunk should contain one SSE data payload")
+
+				var responseMap map[string]interface{}
+				err := json.Unmarshal([]byte(dataPayload), &responseMap)
+				require.NoError(t, err)
+
+				choices := responseMap["choices"].([]interface{})
+				require.Len(t, choices, 1, "streaming chunk should contain one choice")
+				delta := choices[0].(map[string]interface{})["delta"].(map[string]interface{})
+				toolCalls := delta["tool_calls"].([]interface{})
+				require.Len(t, toolCalls, 1, "streaming chunk should contain one tool call delta")
+
+				toolCall, ok := toolCalls[0].(map[string]interface{})
+				require.True(t, ok, "tool call delta should be an object")
+				return toolCall
+			}
+
+			for expectedIndex, item := range []struct {
+				contentBlockIndex int
+				toolUseId         string
+			}{
+				{contentBlockIndex: 1, toolUseId: "tooluse_first"},
+				{contentBlockIndex: 3, toolUseId: "tooluse_second"},
+				{contentBlockIndex: 4, toolUseId: "tooluse_third"},
+			} {
+				toolCallStart := buildBedrockEventStreamMessage(t, map[string]interface{}{
+					"contentBlockIndex": item.contentBlockIndex,
+					"start": map[string]interface{}{
+						"toolUse": map[string]interface{}{
+							"toolUseId": item.toolUseId,
+							"name":      "web_search",
+						},
+					},
+				})
+				action = host.CallOnHttpStreamingResponseBody(toolCallStart, false)
+				require.Equal(t, types.ActionContinue, action)
+				toolCall := extractFirstToolCall(host.GetResponseBody())
+				require.Equal(t, expectedIndex, extractFirstToolCallIndex(host.GetResponseBody()))
+				require.Equal(t, item.toolUseId, toolCall["id"])
+				require.Equal(t, "function", toolCall["type"])
+				function := toolCall["function"].(map[string]interface{})
+				require.Equal(t, "web_search", function["name"])
+				require.Equal(t, "", function["arguments"])
+			}
+
+			for expectedIndex, item := range []struct {
+				contentBlockIndex int
+				query             string
+			}{
+				{contentBlockIndex: 1, query: "first synthetic query"},
+				{contentBlockIndex: 3, query: "second synthetic query"},
+				{contentBlockIndex: 4, query: "third synthetic query"},
+			} {
+				toolCallDelta := buildBedrockEventStreamMessage(t, map[string]interface{}{
+					"contentBlockIndex": item.contentBlockIndex,
+					"delta": map[string]interface{}{
+						"toolUse": map[string]interface{}{
+							"input": "{\"query\":\"" + item.query + "\"}",
+						},
+					},
+				})
+				action = host.CallOnHttpStreamingResponseBody(toolCallDelta, false)
+				require.Equal(t, types.ActionContinue, action)
+				toolCall := extractFirstToolCall(host.GetResponseBody())
+				require.Equal(t, expectedIndex, extractFirstToolCallIndex(host.GetResponseBody()))
+				require.NotContains(t, toolCall, "id")
+				function := toolCall["function"].(map[string]interface{})
+				require.NotContains(t, function, "name")
+				require.Equal(t, "{\"query\":\""+item.query+"\"}", function["arguments"])
+			}
 		})
 
 		t.Run("bedrock streaming usage should map cached_tokens", func(t *testing.T) {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

This PR fixes Bedrock Claude tool-call compatibility issues in `ai-proxy`.

### Problem 1: parallel streamed tool calls can be merged incorrectly

Bedrock `ConverseStream` emits `contentBlockIndex` for each streamed content block. That index covers all Bedrock content block types, such as text, reasoning, and tool use.

OpenAI-compatible streaming responses use `tool_calls[].index` differently: it is the dense 0-based index within the current assistant message's `tool_calls` array. Downstream clients merge streamed tool-call chunks by that OpenAI index.

Before this change, Bedrock streamed tool-use chunks did not carry a valid OpenAI-compatible dense tool-call index. Parallel tool calls could therefore be merged incorrectly by downstream clients.

This change keeps a per-request mapping from Bedrock `contentBlockIndex` to dense OpenAI `tool_calls[].index`, allocating the next OpenAI tool index when a Bedrock tool block first appears and reusing it for later deltas from the same Bedrock content block.

### Problem 2: tool_choice mapping was incomplete across Anthropic, OpenAI-compatible, and Bedrock

Anthropic Messages uses `tool_choice: {"type":"any"}` for required tool use. OpenAI-compatible requests use `tool_choice: "required"`. Bedrock Converse expects `toolConfig.toolChoice.any`.

This change:

- Normalizes Anthropic `tool_choice.type = "any"` to OpenAI-compatible `tool_choice = "required"`.
- Preserves `disable_parallel_tool_use: true` as explicit `parallel_tool_calls: false`.
- Maps OpenAI object-form `tool_choice: {"type":"function","function":{"name":"..."}}` to Anthropic `{"type":"tool","name":"..."}`.
- Maps OpenAI string `required`, `auto`, and `none` to the corresponding Anthropic tool_choice values.
- Handles Bedrock object-form `any` and `function` tool choices without generating an empty tool name.
- Treats `tool_choice: "none"` / `{"type":"none"}` for Bedrock by omitting `toolConfig`, so Bedrock receives no callable tools.

## Ⅱ. Does this pull request fix one issue?

No GitHub issue yet.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Regression tests are included:

- Bedrock EventStream tests cover multiple tool-use blocks whose Bedrock `contentBlockIndex` values are non-dense (`1`, `3`, `4`) and verify OpenAI-compatible indexes are dense (`0`, `1`, `2`) for both start and argument delta chunks.
- Bedrock request tests cover string and object-form `any`, object-form `function`, and object-form `none` tool choices.
- Claude provider tests cover OpenAI object-form `function` to Anthropic `tool`, string `required` to Anthropic `any`, string `none`, and `parallel_tool_calls: false`.
- Claude-to-OpenAI tests cover Anthropic `any` conversion and explicit `parallel_tool_calls: false` serialization.

## Ⅳ. Describe how to verify it

From `plugins/wasm-go/extensions/ai-proxy`:

```bash
go test ./provider -count=1
go test ./... -run 'TestBedrock' -count=1
go test ./... -count=1
```

Verified locally.

## Ⅴ. Special notes for reviews

The streaming index fix does not copy Bedrock `contentBlockIndex` directly into OpenAI output. It maps Bedrock content block indexes to dense OpenAI tool-call indexes because OpenAI-compatible clients expect `tool_calls[].index` to be scoped to the tool_calls array, not the full Bedrock content block list.

This PR is intentionally separate from #3788, which handles Bedrock reasoning/thinking preservation.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

The AI coding tool was instructed to investigate production Bedrock/Claude parallel tool-call corruption, compare Bedrock `ConverseStream` output with Higress OpenAI-compatible output, fix the index mapping and tool_choice protocol differences, and add regression coverage following Higress contribution requirements.

### AI Coding Summary

- Key decision: map Bedrock content block indexes to dense OpenAI tool-call indexes instead of copying them directly.
- Key decision: normalize tool_choice semantics across Anthropic, OpenAI-compatible, and Bedrock request formats.
- Major changes: Bedrock stream conversion now emits stable dense tool indexes; tool_choice conversion now handles required/any/auto/none/function forms; tests cover streaming merge behavior and request mapping edge cases.
- Considerations: provider selection and non-tool response behavior are unchanged.
