### PR TITLE
fix(ai-proxy): fix capability path placeholder replacement for custom templates

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/test/util.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/util.go
@@ -110,6 +110,15 @@ func RunMapRequestPathByCapabilityTests(t *testing.T) {
 			},
 			expected: "/v1/videos",
 		},
+		{
+			name:    "video placeholder maps to custom nested path",
+			apiName: "openai/v1/retrievevideo",
+			origin:  "/v1/videos/my-video-id",
+			mapping: map[string]string{
+				"openai/v1/retrievevideo": "/api/v3/contents/generations/tasks/{video_id}",
+			},
+			expected: "/api/v3/contents/generations/tasks/my-video-id",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/plugins/wasm-go/extensions/ai-proxy/util/http.go
+++ b/plugins/wasm-go/extensions/ai-proxy/util/http.go
@@ -131,9 +131,7 @@ func MapRequestPathByCapability(apiName string, originPath string, mapping map[s
 					continue
 				}
 				id := subMatch[index]
-				mappedPathOnly = r.regx.ReplaceAllStringFunc(mappedPathOnly, func(s string) string {
-					return strings.Replace(s, "{"+r.key+"}", id, 1)
-				})
+				mappedPathOnly = strings.ReplaceAll(mappedPathOnly, "{"+r.key+"}", id)
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

This PR fixes placeholder replacement in `MapRequestPathByCapability` for custom mapped paths.

Previously, ID extraction was done from the original request path, but replacement on the mapped path depended on regex matching the mapped path format. This failed for custom templates like `/api/v9/contents/generations/tasks/{video_id}`.

### Changes
- Updated `plugins/wasm-go/extensions/ai-proxy/util/http.go`:
  - Keep regex-based ID extraction from the original path.
  - Replace placeholders in mapped templates via direct substitution (`strings.ReplaceAll`), so custom path templates are supported.
- Updated `plugins/wasm-go/extensions/ai-proxy/test/util.go`:
  - Renamed the test case from `new test case` to `video placeholder maps to custom nested path`.
- Removed temporary debug logs added during troubleshooting.

### Result
Custom mapped paths containing placeholders (for example `{video_id}`) are now resolved correctly while preserving existing behavior for current mappings.

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

fixes https://github.com/higress-group/higress/issues/3811