### PR TITLE
feat(model-mapper): sync model header on remap and disable reroute

### DIFF
--- a/plugins/wasm-go/extensions/model-mapper/main.go
+++ b/plugins/wasm-go/extensions/model-mapper/main.go
@@ -42,12 +42,18 @@ type Config struct {
 	prefixModelMapping []ModelMapping
 	defaultModel       string
 	enableOnPathSuffix []string
+	modelToHeader      string
 }
 
 func parseConfig(json gjson.Result, config *Config) error {
 	config.modelKey = json.Get("modelKey").String()
 	if config.modelKey == "" {
 		config.modelKey = "model"
+	}
+
+	config.modelToHeader = json.Get("modelToHeader").String()
+	if config.modelToHeader == "" {
+		config.modelToHeader = "x-higress-llm-model-final"
 	}
 
 	modelMapping := json.Get("modelMapping")
@@ -144,6 +150,8 @@ func onHttpRequestHeaders(ctx wrapper.HttpContext, config Config) types.Action {
 		return types.ActionContinue
 	}
 
+	// Disable re-route since the plugin may modify some headers related to the chosen route.
+	ctx.DisableReroute()
 	// Prepare for body processing
 	proxywasm.RemoveHttpRequestHeader("content-length")
 	// 100MB buffer limit
@@ -183,6 +191,12 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config Config, body []byte) type
 	}
 
 	if newModel != "" && newModel != oldModel {
+		// if x-higress-llm-model-final header is set, and it is not the same as the new model, update it
+		// this is to support fallback and token rate limit
+		model, _ := proxywasm.GetHttpRequestHeader(config.modelToHeader)
+		if model != "" && model != newModel {
+			proxywasm.ReplaceHttpRequestHeader(config.modelToHeader, newModel)
+		}
 		newBody, err := sjson.SetBytes(body, config.modelKey, newModel)
 		if err != nil {
 			log.Errorf("failed to update model: %v", err)

--- a/plugins/wasm-go/extensions/model-mapper/main.go
+++ b/plugins/wasm-go/extensions/model-mapper/main.go
@@ -190,13 +190,10 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config Config, body []byte) type
 		}
 	}
 
+	// update x-higress-llm-model-final header
+	proxywasm.ReplaceHttpRequestHeader(config.modelToHeader, newModel)
+	log.Debugf("set header %s: %s", config.modelToHeader, newModel)
 	if newModel != "" && newModel != oldModel {
-		// if x-higress-llm-model-final header is set, and it is not the same as the new model, update it
-		// this is to support fallback and token rate limit
-		model, _ := proxywasm.GetHttpRequestHeader(config.modelToHeader)
-		if model != "" && model != newModel {
-			proxywasm.ReplaceHttpRequestHeader(config.modelToHeader, newModel)
-		}
 		newBody, err := sjson.SetBytes(body, config.modelKey, newModel)
 		if err != nil {
 			log.Errorf("failed to update model: %v", err)

--- a/plugins/wasm-go/extensions/model-mapper/main_test.go
+++ b/plugins/wasm-go/extensions/model-mapper/main_test.go
@@ -11,6 +11,15 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func getHeader(headers [][2]string, key string) (string, bool) {
+	for _, h := range headers {
+		if strings.EqualFold(h[0], key) {
+			return h[1], true
+		}
+	}
+	return "", false
+}
+
 // Basic configs for wasm test host
 var (
 	basicConfig = func() json.RawMessage {
@@ -38,6 +47,20 @@ var (
 			"enableOnPathSuffix": []string{
 				"/v1/chat/completions",
 				"/v1/embeddings",
+			},
+		})
+		return data
+	}()
+
+	headerSyncConfig = func() json.RawMessage {
+		data, _ := json.Marshal(map[string]interface{}{
+			"modelKey": "model",
+			"modelMapping": map[string]string{
+				"gpt-3.5-turbo": "gpt-4",
+			},
+			"modelToHeader": "x-final-model",
+			"enableOnPathSuffix": []string{
+				"/v1/chat/completions",
 			},
 		})
 		return data
@@ -112,6 +135,61 @@ func TestParseConfig(t *testing.T) {
 			err := parseConfig(gjson.ParseBytes(jsonData), &cfg)
 			require.Error(t, err)
 		})
+
+		t.Run("modelToHeader default and custom", func(t *testing.T) {
+			var cfgDefault Config
+			require.NoError(t, parseConfig(gjson.ParseBytes([]byte(`{"modelMapping":{}}`)), &cfgDefault))
+			require.Equal(t, "x-higress-llm-model-final", cfgDefault.modelToHeader)
+
+			var cfgCustom Config
+			err := parseConfig(gjson.ParseBytes([]byte(`{
+				"modelToHeader": "x-my-model",
+				"modelMapping": {}
+			}`)), &cfgCustom)
+			require.NoError(t, err)
+			require.Equal(t, "x-my-model", cfgCustom.modelToHeader)
+		})
+
+		t.Run("empty modelMapping", func(t *testing.T) {
+			var cfg Config
+			err := parseConfig(gjson.ParseBytes([]byte(`{"modelMapping": {}}`)), &cfg)
+			require.NoError(t, err)
+			require.Empty(t, cfg.exactModelMapping)
+			require.Empty(t, cfg.prefixModelMapping)
+			require.Equal(t, "", cfg.defaultModel)
+		})
+
+		t.Run("prefix rules sorted by key for stable iteration", func(t *testing.T) {
+			var cfg Config
+			// Object key order in JSON is z then a; after sort, prefix "a" is tried before "z".
+			jsonData := []byte(`{
+				"modelMapping": {
+					"z*": "Z",
+					"a*": "A"
+				}
+			}`)
+			require.NoError(t, parseConfig(gjson.ParseBytes(jsonData), &cfg))
+			require.Len(t, cfg.prefixModelMapping, 2)
+			require.Equal(t, "a", cfg.prefixModelMapping[0].Prefix)
+			require.Equal(t, "A", cfg.prefixModelMapping[0].Target)
+			require.Equal(t, "z", cfg.prefixModelMapping[1].Prefix)
+			require.Equal(t, "Z", cfg.prefixModelMapping[1].Target)
+		})
+
+		t.Run("exact mapping wins over prefix", func(t *testing.T) {
+			var cfg Config
+			jsonData := []byte(`{
+				"modelKey": "model",
+				"modelMapping": {
+					"gpt-3.5*": "from-prefix",
+					"gpt-3.5-turbo": "from-exact"
+				}
+			}`)
+			require.NoError(t, parseConfig(gjson.ParseBytes(jsonData), &cfg))
+			require.Equal(t, "from-exact", cfg.exactModelMapping["gpt-3.5-turbo"])
+			require.Len(t, cfg.prefixModelMapping, 1)
+			require.Equal(t, "gpt-3.5", cfg.prefixModelMapping[0].Prefix)
+		})
 	})
 }
 
@@ -133,15 +211,8 @@ func TestOnHttpRequestHeaders(t *testing.T) {
 			require.Equal(t, types.ActionContinue, action)
 
 			newHeaders := host.GetRequestHeaders()
-			// content-length should still exist because path is not enabled
-			foundContentLength := false
-			for _, h := range newHeaders {
-				if strings.ToLower(h[0]) == "content-length" {
-					foundContentLength = true
-					break
-				}
-			}
-			require.True(t, foundContentLength)
+			_, foundContentLength := getHeader(newHeaders, "content-length")
+			require.True(t, foundContentLength, "content-length should be kept when path is not enabled")
 		})
 
 		t.Run("process when path and content-type match", func(t *testing.T) {
@@ -160,10 +231,25 @@ func TestOnHttpRequestHeaders(t *testing.T) {
 			require.Equal(t, types.HeaderStopIteration, action)
 
 			newHeaders := host.GetRequestHeaders()
-			// content-length should be removed
-			for _, h := range newHeaders {
-				require.NotEqual(t, strings.ToLower(h[0]), "content-length")
-			}
+			_, foundCL := getHeader(newHeaders, "content-length")
+			require.False(t, foundCL, "content-length should be removed when buffering body")
+		})
+
+		t.Run("path with query string still matches suffix", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions?trace=1"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"content-length", "99"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+			_, foundCL := getHeader(host.GetRequestHeaders(), "content-length")
+			require.False(t, foundCL)
 		})
 	})
 }
@@ -245,6 +331,119 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			processed := host.GetRequestBody()
 			require.NotNil(t, processed)
 			require.Equal(t, "gpt-4-mini", gjson.GetBytes(processed, "request.model").String())
+		})
+
+		t.Run("exact mapping beats prefix for same family", func(t *testing.T) {
+			host, status := test.NewTestHost(customConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/embeddings"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+			})
+
+			origBody := []byte(`{
+				"request": {
+					"model": "gpt-3.5-t1",
+					"input": "hello"
+				}
+			}`)
+			action := host.CallOnHttpRequestBody(origBody)
+			require.Equal(t, types.ActionContinue, action)
+
+			processed := host.GetRequestBody()
+			require.NotNil(t, processed)
+			require.Equal(t, "gpt-4-turbo-1", gjson.GetBytes(processed, "request.model").String())
+		})
+
+		t.Run("empty request body is a no-op", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+			})
+
+			action := host.CallOnHttpRequestBody(nil)
+			require.Equal(t, types.ActionContinue, action)
+			require.Nil(t, host.GetRequestBody())
+
+			action = host.CallOnHttpRequestBody([]byte{})
+			require.Equal(t, types.ActionContinue, action)
+		})
+
+		t.Run("invalid json body is skipped", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+			})
+
+			bad := []byte(`not json`)
+			action := host.CallOnHttpRequestBody(bad)
+			require.Equal(t, types.ActionContinue, action)
+			out := host.GetRequestBody()
+			if out != nil {
+				require.Equal(t, string(bad), string(out))
+			}
+		})
+
+		t.Run("no model rewrite when already mapped target", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+			})
+
+			origBody := []byte(`{"model":"gpt-4","messages":[]}`)
+			action := host.CallOnHttpRequestBody(origBody)
+			require.Equal(t, types.ActionContinue, action)
+			out := host.GetRequestBody()
+			if out != nil {
+				require.Equal(t, string(origBody), string(out))
+			}
+		})
+
+		t.Run("modelToHeader updated when it disagrees with mapped model", func(t *testing.T) {
+			host, status := test.NewTestHost(headerSyncConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"x-final-model", "gpt-3.5-turbo"},
+			})
+
+			origBody := []byte(`{"model":"gpt-3.5-turbo"}`)
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody(origBody))
+
+			processed := host.GetRequestBody()
+			require.NotNil(t, processed)
+			require.Equal(t, "gpt-4", gjson.GetBytes(processed, "model").String())
+
+			v, ok := getHeader(host.GetRequestHeaders(), "x-final-model")
+			require.True(t, ok)
+			require.Equal(t, "gpt-4", v)
 		})
 	})
 }

--- a/plugins/wasm-go/extensions/model-mapper/main_test.go
+++ b/plugins/wasm-go/extensions/model-mapper/main_test.go
@@ -278,6 +278,9 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			processed := host.GetRequestBody()
 			require.NotNil(t, processed)
 			require.Equal(t, "gpt-4", gjson.GetBytes(processed, "model").String())
+			v, ok := getHeader(host.GetRequestHeaders(), "x-higress-llm-model-final")
+			require.True(t, ok)
+			require.Equal(t, "gpt-4", v)
 		})
 
 		t.Run("default model when key missing", func(t *testing.T) {
@@ -305,6 +308,9 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			require.NotNil(t, processed)
 			// default model should be set at request.model
 			require.Equal(t, "gpt-4o", gjson.GetBytes(processed, "request.model").String())
+			v, ok := getHeader(host.GetRequestHeaders(), "x-higress-llm-model-final")
+			require.True(t, ok)
+			require.Equal(t, "gpt-4o", v)
 		})
 
 		t.Run("prefix mapping takes effect", func(t *testing.T) {
@@ -331,6 +337,9 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			processed := host.GetRequestBody()
 			require.NotNil(t, processed)
 			require.Equal(t, "gpt-4-mini", gjson.GetBytes(processed, "request.model").String())
+			v, ok := getHeader(host.GetRequestHeaders(), "x-higress-llm-model-final")
+			require.True(t, ok)
+			require.Equal(t, "gpt-4-mini", v)
 		})
 
 		t.Run("exact mapping beats prefix for same family", func(t *testing.T) {
@@ -357,6 +366,9 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			processed := host.GetRequestBody()
 			require.NotNil(t, processed)
 			require.Equal(t, "gpt-4-turbo-1", gjson.GetBytes(processed, "request.model").String())
+			v, ok := getHeader(host.GetRequestHeaders(), "x-higress-llm-model-final")
+			require.True(t, ok)
+			require.Equal(t, "gpt-4-turbo-1", v)
 		})
 
 		t.Run("empty request body is a no-op", func(t *testing.T) {
@@ -389,6 +401,7 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 				{":path", "/v1/chat/completions"},
 				{":method", "POST"},
 				{"content-type", "application/json"},
+				{"x-higress-llm-model-final", "should-not-change"},
 			})
 
 			bad := []byte(`not json`)
@@ -398,9 +411,12 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			if out != nil {
 				require.Equal(t, string(bad), string(out))
 			}
+			v, ok := getHeader(host.GetRequestHeaders(), "x-higress-llm-model-final")
+			require.True(t, ok)
+			require.Equal(t, "should-not-change", v, "invalid JSON must not refresh model header")
 		})
 
-		t.Run("no model rewrite when already mapped target", func(t *testing.T) {
+		t.Run("no body rewrite when already mapped target but header still refreshed", func(t *testing.T) {
 			host, status := test.NewTestHost(basicConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
@@ -419,9 +435,12 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			if out != nil {
 				require.Equal(t, string(origBody), string(out))
 			}
+			v, ok := getHeader(host.GetRequestHeaders(), "x-higress-llm-model-final")
+			require.True(t, ok)
+			require.Equal(t, "gpt-4", v)
 		})
 
-		t.Run("modelToHeader updated when it disagrees with mapped model", func(t *testing.T) {
+		t.Run("modelToHeader always set to resolved model", func(t *testing.T) {
 			host, status := test.NewTestHost(headerSyncConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
@@ -442,6 +461,30 @@ func TestOnHttpRequestBody_ModelMapping(t *testing.T) {
 			require.Equal(t, "gpt-4", gjson.GetBytes(processed, "model").String())
 
 			v, ok := getHeader(host.GetRequestHeaders(), "x-final-model")
+			require.True(t, ok)
+			require.Equal(t, "gpt-4", v)
+		})
+
+		t.Run("modelToHeader refreshed even when it already matches resolved model", func(t *testing.T) {
+			host, status := test.NewTestHost(basicConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/chat/completions"},
+				{":method", "POST"},
+				{"content-type", "application/json"},
+				{"x-higress-llm-model-final", "gpt-4"},
+			})
+
+			origBody := []byte(`{"model":"gpt-3.5-turbo","messages":[]}`)
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody(origBody))
+
+			processed := host.GetRequestBody()
+			require.NotNil(t, processed)
+			require.Equal(t, "gpt-4", gjson.GetBytes(processed, "model").String())
+			v, ok := getHeader(host.GetRequestHeaders(), "x-higress-llm-model-final")
 			require.True(t, ok)
 			require.Equal(t, "gpt-4", v)
 		})


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

- **可配置 `modelToHeader`**：新增配置项 `modelToHeader`，未配置时默认为 `x-higress-llm-model-final`，用于承载「解析后的最终 model」。
- **请求体阶段同步 header**：在请求体为合法 JSON 并完成 default / 精确 / 前缀匹配得到 `newModel` 后，**始终**调用 `ReplaceHttpRequestHeader(modelToHeader, newModel)`，使 fallback、按模型限流/计量等依赖该 header 的逻辑与当前解析结果一致；仅当 `newModel != ""` 且与 body 中原 model 不同时才改写 body（`sjson` + `ReplaceHttpRequestBody`）。
- **读 body 时关闭重路由**：命中需读 body 的路径时调用 `DisableReroute()`，避免插件调整与路由相关的 header 后仍触发重路由；同时去掉 `content-length`、设置 body 缓冲上限（100MB）。
- **单测**：在 `wasm-go/pkg/test` 下补充/更新 Go 与 wasm 双模式用例，覆盖配置解析、带 query 的 path 匹配、`modelToHeader` 写入、非法 JSON 不刷新 header、无 body 改写时仍更新 header 等场景。

## Ⅱ. Does this pull request fix one issue?

<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

（如无关联 issue，保持为空；若有请填写，例如：`fixes #xxx`。）

## Ⅲ. Why don't you add test cases (unit test/integration test)?

已增加并维护 **单元测试**（含 wasm 与原生 Go），通过既有 `RunTest` / `RunGoTest` 验证插件行为。未单独引入新的集成/E2E 套件；网关级验证见下一节。

## Ⅳ. Describe how to verify it

1. 在插件目录执行：`cd plugins/wasm-go/extensions/model-mapper && go test -v -count=1 ./...`（会按需编译 wasm，并跑 go / wasm 两套用例）。
2. （可选）在真实/测试集群中：对命中 `enableOnPathSuffix` 的路径发送 JSON，检查 `modelKey` 对应字段与 `modelToHeader` 是否与预期一致；映射前后 body 与 header 变化符合配置；读 body 场景下无异常重路由。

## Ⅴ. Special notes for reviews

- **`modelToHeader` 与 body 改写不同步条件**：header 在合法 JSON 解析路径上**总是**写成 `newModel`；body 仅在 `newModel` 非空且与原始 model 字符串不同时改写。空 body、非法 JSON 不会执行 header/body 的上述更新逻辑。
- **`newModel` 为空字符串**：若解析结果为空，仍会执行 `ReplaceHttpRequestHeader`；请结合下游对空 header 的语义确认是否符合预期。
- **跨组件约定**：若与 model-router、token 限流等共用 `x-higress-llm-model-final`，建议在整体链路上确认顺序与语义一致。

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Ⅰ. Describe what this PR did

- **Configurable `modelToHeader`**: New configuration item `modelToHeader`, which defaults to `x-higress-llm-model-final` when not configured, is used to carry the "parsed final model".
- **Request body phase synchronization header**: After the request body is legal JSON and completes default/exact/prefix matching to obtain `newModel`, **always** call `ReplaceHttpRequestHeader(modelToHeader, newModel)` to make fallback, current limiting/metering by model, etc. that rely on this header logic consistent with the current parsing results; only if `newModel != ""` and with the body Zhongyuan model Rewrite body (`sjson` + `ReplaceHttpRequestBody`) when different.
- **Turn off rerouting when reading the body**: Call `DisableReroute()` when hitting the path that needs to be read to avoid triggering rerouting after the plug-in adjusts the routing-related headers; at the same time, remove `content-length` and set the upper limit of the body buffer (100MB).
- **Single test**: Supplement/update Go and wasm dual-mode use cases under `wasm-go/pkg/test`, covering scenarios such as configuration parsing, path matching with query, `modelToHeader` writing, illegal JSON not refreshing the header, and header still being updated when no body is rewritten.

## Ⅱ. Does this pull request fix one issue?

<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->

(If there is no associated issue, keep it empty; if there is one, please fill it in, for example: `fixes #xxx`.)

## Ⅲ. Why don't you add test cases (unit test/integration test)?

**Unit tests** (including wasm and native Go) have been added and maintained to verify plug-in behavior through the existing `RunTest` / `RunGoTest`. The new integration/E2E suite is not introduced separately; gateway-level validation is provided in the next section.

## Ⅳ. Describe how to verify it

1. Execute in the plug-in directory: `cd plugins/wasm-go/extensions/model-mapper && go test -v -count=1 ./...` (wasm will be compiled on demand and two sets of go / wasm use cases will be run).
2. (Optional) In the real/test cluster: Send JSON to the path that hits `enableOnPathSuffix`, and check whether the corresponding fields of `modelKey` and `modelToHeader` are consistent with expectations; the changes in body and header before and after mapping conform to the configuration; there is no abnormal rerouting in the body reading scenario.

## Ⅴ. Special notes for reviews

- **`modelToHeader` and body rewrite out of sync conditions**: header is **always** written as `newModel` on the legal JSON parsing path; body is only rewritten when `newModel` is non-empty and different from the original model string. Empty body and illegal JSON will not execute the above update logic of header/body.
- **`newModel` is an empty string**: If the parsing result is empty, `ReplaceHttpRequestHeader` will still be executed; please combine the downstream semantics of empty headers to confirm whether it meets expectations.
- **Cross-component agreement**: If `x-higress-llm-model-final` is shared with model-router, token current limiting, etc., it is recommended to confirm that the order and semantics are consistent on the entire link.
