### PR TITLE
feat(jwt-auth): support remote JWKS

### DIFF
--- a/plugins/wasm-cpp/extensions/jwt_auth/README.md
+++ b/plugins/wasm-cpp/extensions/jwt_auth/README.md
@@ -33,17 +33,35 @@ description: JWT 认证插件配置参考
 | 名称                    | 数据类型          | 填写要求 | 默认值                                            | 描述                     |
 | ----------------------- | ----------------- | -------- | ------------------------------------------------- | ------------------------ |
 | `name`                  | string            | 必填     | -                                                 | 配置该consumer的名称     |
-| `jwks`                  | string            | 必填     | -                                                 | https://www.rfc-editor.org/rfc/rfc7517 指定的json格式字符串，是由验证JWT中签名的公钥（或对称密钥）组成的Json Web Key Set  |
+| `jwks`                  | string            | wasm-cpp 必填；wasm-go 未配置 `remote_jwks` 时必填 | -             | https://www.rfc-editor.org/rfc/rfc7517 指定的json格式字符串，是由验证JWT中签名的公钥（或对称密钥）组成的Json Web Key Set  |
+| `remote_jwks`           | object            | wasm-go 实现选填 | -                                      | 远程 JWKS 服务引用。引用的服务需要已由 Higress 配置或发现，例如通过 McpBridge |
+| `jwks_cache_duration`   | number            | wasm-go 实现选填 | 600                                   | 远程 JWKS 缓存时间，单位为秒，最大值为 604800 |
+| `jwks_fetch_timeout`    | number            | wasm-go 实现选填 | 1500                                  | 远程 JWKS 拉取超时时间，单位为毫秒，最大值为 10000 |
 | `issuer`                | string            | 必填     | -                                                 | JWT的签发者，需要和payload中的iss字段保持一致              |
 | `claims_to_headers`     | array of object   | 选填     | -                                                 | 抽取JWT的payload中指定字段，设置到指定的请求头中转发给后端 |
 | `from_headers`          | array of object   | 选填     | {"name":"Authorization","value_prefix":"Bearer "} | 从指定的请求头中抽取JWT |
 | `from_params`           | array of string   | 选填     | access_token                                      | 从指定的URL参数中抽取JWT                                   |
 | `from_cookies`          | array of string   | 选填     | -                                                 | 从指定的cookie中抽取JWT                                    |
 | `clock_skew_seconds`    | number            | 选填     | 60                                                | 校验JWT的exp和iat字段时允许的时钟偏移量，单位为秒          |
-| `keep_token`            | bool              | 选填     | ture                                              | 转发给后端时是否保留JWT                                    |
+| `keep_token`            | bool              | 选填     | true                                              | 转发给后端时是否保留JWT                                    |
 
 **注意：** 
 - 只有当`from_headers`,`from_params`,`from_cookies`均未配置时，才会使用默认值
+- `remote_jwks`、`jwks_cache_duration`、`jwks_fetch_timeout` 仅适用于 wasm-go 实现；wasm-cpp 实现仍需要配置 `jwks`。
+- 在 wasm-go 实现中，`jwks` 与 `remote_jwks` 只能配置其中一个。
+- 使用 `remote_jwks` 时，远程 JWKS 拉取失败、返回非法 JWKS、刷新被限流或在多 key 集合中找不到匹配 `kid` 时会拒绝请求。无 `kid` 的 token 仅在拉取到的 JWKS 恰好只有一个 key 时被接受。
+- 远程 JWKS 的失败重试按远程服务引用限流 30 秒；冷启动首次拉取未完成期间，以及拉取失败后的限流窗口内，请求会被本地拒绝。过期缓存仅在刷新请求已发起且尚未完成时继续使用。
+- 超过 64 KiB 的远程 JWKS 响应会被拒绝。
+- `jwks_cache_duration` 必须至少为 30 秒，避免缓存过期时间短于远程 JWKS 失败重试窗口。
+- 在 wasm-go 实现中，空的内联 `jwks` key 集合会在配置解析阶段被拒绝。`keep_token` 为 `false` 时，从 `from_params` 提取的 token 会从转发请求路径中移除。
+
+`remote_jwks` 的配置字段说明如下：
+| 名称           | 数据类型 | 填写要求 | 默认值 | 描述 |
+| -------------- | -------- | -------- | ------ | ---- |
+| `service_name` | string   | 必填     | -      | 用于构造出站集群的 Higress 服务名称 |
+| `service_host` | string   | 必填     | -      | JWKS 请求使用的 Host 或 `:authority` 请求头，不包含端口；端口通过 `service_port` 配置 |
+| `service_port` | number   | 选填     | 443    | JWKS 请求使用的服务端口 |
+| `path`         | string   | 必填     | -      | JWKS 请求路径，例如 `/.well-known/jwks.json` |
 
 `from_headers` 中每一项的配置字段说明如下：
 
@@ -155,6 +173,26 @@ curl  http://xxx.hello.com/test
 # consumer1不在*.example.com的allow列表里
 curl  'http://xxx.example.com/test' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEyMyJ9.eyJpc3MiOiJhYmNkIiwic3ViIjoidGVzdCIsImlhdCI6MTY2NTY2MDUyNywiZXhwIjoxODY1NjczODE5fQ.-vBSV0bKeDwQcuS6eeSZN9dLTUnSnZVk8eVCXdooCQ4'
 ```
+
+### 使用远程 JWKS（仅 wasm-go 实现）
+
+如果签名公钥由身份提供方维护，wasm-go 实现可以通过已配置的服务引用拉取和缓存远程 JWKS。该服务需要已由 Higress 配置或发现。
+
+```yaml
+global_auth: false
+consumers:
+- name: remote-consumer
+  issuer: https://issuer.example.com
+  remote_jwks:
+    service_name: issuer.example.com.dns
+    service_host: issuer.example.com
+    service_port: 443
+    path: /.well-known/jwks.json
+  jwks_cache_duration: 600
+  jwks_fetch_timeout: 1500
+```
+
+配置远程 JWKS 时需要确保网关数据面能够访问引用的服务。远程 JWKS 响应体超过 64 KiB 会被视为非法响应。
 
 #### 网关实例级别开启
 

--- a/plugins/wasm-cpp/extensions/jwt_auth/README_EN.md
+++ b/plugins/wasm-cpp/extensions/jwt_auth/README_EN.md
@@ -28,7 +28,10 @@ The configuration fields for each item in `consumers` are as follows:
 | Name                    | Data Type         | Requirements | Default Value                                      | Description                     |
 | ----------------------- | ------------------ | ------------ | -------------------------------------------------- | ------------------------------- |
 | `name`                  | string             | Required     | -                                                  | The name of the consumer        |
-| `jwks`                  | string             | Required     | -                                                  | JSON format string specified by https://www.rfc-editor.org/rfc/rfc7517, consisting of the public key (or symmetric key) used to verify the JWT signature. |
+| `jwks`                  | string             | Required for wasm-cpp; required for wasm-go unless `remote_jwks` is set | - | JSON format string specified by https://www.rfc-editor.org/rfc/rfc7517, consisting of the public key (or symmetric key) used to verify the JWT signature. |
+| `remote_jwks`           | object             | Optional in the wasm-go implementation | -                         | Remote JWKS service reference. The referenced service must already be configured or discovered by Higress, for example via McpBridge. |
+| `jwks_cache_duration`   | number             | Optional in the wasm-go implementation | 600                       | Remote JWKS cache duration, in seconds. Maximum: 604800. |
+| `jwks_fetch_timeout`    | number             | Optional in the wasm-go implementation | 1500                      | Remote JWKS fetch timeout, in milliseconds. Maximum: 10000. |
 | `issuer`                | string             | Required     | -                                                  | The issuer of the JWT, must match the `iss` field in the payload. |
 | `claims_to_headers`     | array of object    | Optional     | -                                                  | Extract the specified fields from the JWT payload and set them in the specified request headers to forward to the backend. |
 | `from_headers`          | array of object    | Optional     | {"name":"Authorization","value_prefix":"Bearer "} | Extract JWT from the specified request headers. |
@@ -39,6 +42,22 @@ The configuration fields for each item in `consumers` are as follows:
 
 **Note:**
 - The default values will only be used when `from_headers`, `from_params`, and `from_cookies` are not all configured.
+- `remote_jwks`, `jwks_cache_duration`, and `jwks_fetch_timeout` apply only to the wasm-go implementation. The wasm-cpp implementation still requires `jwks`.
+- In the wasm-go implementation, only one of `jwks` and `remote_jwks` can be configured.
+- When `remote_jwks` is used, requests fail closed if the remote JWKS fetch fails, the response is invalid, refresh is throttled, or no matching `kid` can be found in a multi-key set. Tokens without `kid` are accepted only when the fetched JWKS contains exactly one key.
+- Failed remote JWKS fetches are throttled per remote service reference for 30 seconds. Concurrent requests during the initial cold fetch, and requests during the post-failure throttle window, are denied locally. Expired cached JWKS are served only while a refresh is already in flight.
+- Remote JWKS responses larger than 64 KiB are rejected.
+- `jwks_cache_duration` must be at least 30 seconds so cache expiry does not undercut the remote JWKS failure backoff window.
+- In the wasm-go implementation, empty inline `jwks` key sets are rejected during configuration parsing. When `keep_token` is `false`, tokens extracted from `from_params` are removed from the forwarded request path.
+
+The configuration fields for `remote_jwks` are as follows:
+| Name           | Data Type | Requirements | Default Value | Description |
+| -------------- | --------- | ------------ | ------------- | ----------- |
+| `service_name` | string    | Required     | -             | The Higress service name used to build the outbound cluster. |
+| `service_host` | string    | Required     | -             | Host or `:authority` header for the JWKS request, without a port. Use `service_port` for the port. |
+| `service_port` | number    | Optional     | 443           | Service port for the JWKS request. |
+| `path`         | string    | Required     | -             | JWKS request path, for example `/.well-known/jwks.json`. |
+
 The configuration fields for each item in `from_headers` are as follows:
 | Name            | Data Type        | Requirements | Default Value | Description                                     |
 | --------------- | ---------------- | ------------ | ------------- | ----------------------------------------------- |
@@ -138,6 +157,26 @@ curl  http://xxx.hello.com/test
 # consumer1 is not in the allow list for *.example.com
 curl  'http://xxx.example.com/test' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEyMyJ9.eyJpc3MiOiJhYmNkIiwic3ViIjoidGVzdCIsImlhdCI6MTY2NTY2MDUyNywiZXhwIjoxODY1NjczODE5fQ.-vBSV0bKeDwQcuS6eeSZN9dLTUnSnZVk8eVCXdooCQ4'
 ```
+
+### Using Remote JWKS (wasm-go implementation only)
+
+If the signing keys are maintained by an identity provider, the wasm-go implementation can fetch and cache the remote JWKS from a configured service reference. The service must already be configured or discovered by Higress.
+
+```yaml
+global_auth: false
+consumers:
+- name: remote-consumer
+  issuer: https://issuer.example.com
+  remote_jwks:
+    service_name: issuer.example.com.dns
+    service_host: issuer.example.com
+    service_port: 443
+    path: /.well-known/jwks.json
+  jwks_cache_duration: 600
+  jwks_fetch_timeout: 1500
+```
+
+When remote JWKS is configured, make sure the referenced service is reachable from the gateway data plane. Remote JWKS responses larger than 64 KiB are treated as invalid responses.
 
 #### Enable at Gateway Instance Level
 The following configuration will enable JWT Auth authentication at the instance level, requiring all requests to be authenticated before accessing.

--- a/plugins/wasm-go/extensions/jwt-auth/config/config.go
+++ b/plugins/wasm-go/extensions/jwt-auth/config/config.go
@@ -14,6 +14,8 @@
 
 package config
 
+import "github.com/go-jose/go-jose/v3"
+
 var (
 	// DefaultClaimToHeaderOverride 是 claim_to_override 中 override 字段的默认值
 	DefaultClaimToHeaderOverride = true
@@ -23,6 +25,12 @@ var (
 
 	// DefaultKeepToken 是 KeepToken 的默认值
 	DefaultKeepToken = true
+
+	// DefaultJWKsCacheDuration is the default remote JWKS cache duration in seconds.
+	DefaultJWKsCacheDuration = int64(600)
+
+	// DefaultJWKsFetchTimeout is the default remote JWKS fetch timeout in milliseconds.
+	DefaultJWKsFetchTimeout = int64(1500)
 
 	// DefaultFromHeader 是 from_header 的默认值
 	DefaultFromHeader = []FromHeader{{
@@ -37,6 +45,9 @@ var (
 	DefaultFromCookies = []string{}
 )
 
+// RemoteJWKsMinRefreshIntervalSeconds is the shared lower bound for remote JWKS cache TTL and retry backoff.
+const RemoteJWKsMinRefreshIntervalSeconds = int64(30)
+
 // JWTAuthConfig defines the struct of the global config of higress wasm plugin jwt-auth.
 // https://higress.io/zh-cn/docs/plugins/jwt-auth
 type JWTAuthConfig struct {
@@ -44,6 +55,9 @@ type JWTAuthConfig struct {
 	//
 	// Consumers 配置服务的调用者，用于对请求进行认证
 	Consumers []*Consumer `json:"consumers"`
+
+	// RuleSet records whether at least one domain or route rule is configured.
+	RuleSet bool `json:"-"`
 
 	// 全局配置
 	//
@@ -67,6 +81,20 @@ type Consumer struct {
 	//
 	// https://www.rfc-editor.org/rfc/rfc7517
 	JWKs string `json:"jwks"`
+
+	// ParsedJWKs caches parsed inline JWKS after config validation.
+	ParsedJWKs *jose.JSONWebKeySet `json:"-"`
+
+	// RemoteJWKs specifies a remote JWKS endpoint referenced by service.
+	// The service must be configured or discovered by Higress, for example via McpBridge.
+	RemoteJWKs *RemoteJWKs `json:"remote_jwks,omitempty"`
+
+	// JWKsCacheDuration is the remote JWKS cache duration in seconds.
+	// Requests are denied while the first fetch is in flight or after recent fetch failures.
+	JWKsCacheDuration *int64 `json:"jwks_cache_duration,omitempty"`
+
+	// JWKsFetchTimeout is the remote JWKS fetch timeout in milliseconds.
+	JWKsFetchTimeout *int64 `json:"jwks_fetch_timeout,omitempty"`
 
 	// Issuer JWT的签发者，需要和payload中的iss字段保持一致
 	Issuer string `json:"issuer"`
@@ -100,6 +128,20 @@ type Consumer struct {
 	//
 	// 默认值为 true
 	KeepToken *bool `json:"keep_token,omitempty"`
+}
+
+type RemoteJWKs struct {
+	// ServiceName is the FQDN service name used to build the outbound cluster.
+	ServiceName string `json:"service_name"`
+
+	// ServiceHost is the HTTP Host/:authority header for the JWKS request.
+	ServiceHost string `json:"service_host,omitempty"`
+
+	// ServicePort is the service port used to build the outbound cluster. Defaults to 443.
+	ServicePort *int64 `json:"service_port,omitempty"`
+
+	// Path is the JWKS request path, for example "/.well-known/jwks.json".
+	Path string `json:"path"`
 }
 
 // ClaimsToHeader 抽取JWT的payload中指定字段，设置到指定的请求头中转发给后端

--- a/plugins/wasm-go/extensions/jwt-auth/config/parser.go
+++ b/plugins/wasm-go/extensions/jwt-auth/config/parser.go
@@ -17,19 +17,21 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/go-jose/go-jose/v3"
 	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/tidwall/gjson"
 )
 
-// RuleSet 插件是否至少在一个 domain 或 route 上生效
-var RuleSet bool
+const maxJWKsFetchTimeout = int64(10 * 1000)      // milliseconds
+const maxJWKsCacheDuration = int64(7 * 24 * 3600) // seconds
+const minJWKsCacheDuration = RemoteJWKsMinRefreshIntervalSeconds
 
 // ParseGlobalConfig 从wrapper提供的配置中解析并转换到插件运行时需要使用的配置。
 // 此处解析的是全局配置，域名和路由级配置由 ParseRuleConfig 负责。
 func ParseGlobalConfig(json gjson.Result, config *JWTAuthConfig, log log.Log) error {
-	RuleSet = false
+	config.RuleSet = len(json.Get("_rules_").Array()) > 0
 	consumers := json.Get("consumers")
 	if !consumers.IsArray() {
 		return fmt.Errorf("failed to parse configuration for consumers: consumers is not a array")
@@ -70,7 +72,7 @@ func ParseRuleConfig(json gjson.Result, global JWTAuthConfig, config *JWTAuthCon
 		config.Allow = append(config.Allow, item.String())
 	}
 
-	RuleSet = true
+	config.RuleSet = true
 	return nil
 }
 
@@ -88,11 +90,39 @@ func ParseConsumer(consumer gjson.Result, names map[string]struct{}) (c *Consume
 		return nil, fmt.Errorf("consumer already exists: %s", c.Name)
 	}
 
-	// 检查JWKs是否合法
-	jwks := &jose.JSONWebKeySet{}
-	err = json.Unmarshal([]byte(c.JWKs), jwks)
-	if err != nil {
-		return nil, fmt.Errorf("jwks is invalid, consumer:%s, status:%s, jwks:%s", c.Name, err.Error(), c.JWKs)
+	c.Issuer = strings.TrimSpace(c.Issuer)
+	c.JWKs = strings.TrimSpace(c.JWKs)
+	if c.RemoteJWKs != nil {
+		normalizeRemoteJWKs(c.RemoteJWKs)
+	}
+	if c.JWKs == "" && c.RemoteJWKs == nil {
+		return nil, fmt.Errorf("one of jwks and remote_jwks is required, consumer:%s", c.Name)
+	}
+	if c.JWKs != "" && c.RemoteJWKs != nil {
+		return nil, fmt.Errorf("only one of jwks and remote_jwks can be configured, consumer:%s", c.Name)
+	}
+	if c.JWKs != "" {
+		if c.JWKsCacheDuration != nil || c.JWKsFetchTimeout != nil {
+			return nil, fmt.Errorf("jwks_cache_duration and jwks_fetch_timeout only apply to remote_jwks, consumer:%s", c.Name)
+		}
+		// Validate inline JWKS before accepting the consumer.
+		jwks := &jose.JSONWebKeySet{}
+		err = json.Unmarshal([]byte(c.JWKs), jwks)
+		if err != nil {
+			return nil, fmt.Errorf("jwks is invalid, consumer:%s, status:%s, jwks:%s", c.Name, err.Error(), c.JWKs)
+		}
+		if len(jwks.Keys) == 0 {
+			return nil, fmt.Errorf("jwks is empty, consumer:%s", c.Name)
+		}
+		c.ParsedJWKs = jwks
+	}
+	if c.RemoteJWKs != nil {
+		if c.Issuer == "" {
+			return nil, fmt.Errorf("issuer is required when remote_jwks is set, consumer:%s", c.Name)
+		}
+		if err := validateRemoteJWKs(c.RemoteJWKs); err != nil {
+			return nil, fmt.Errorf("remote_jwks is invalid, consumer:%s, reason:%s", c.Name, err.Error())
+		}
 	}
 
 	// 检查是否需要使用默认jwt抽取来源
@@ -132,7 +162,87 @@ func ParseConsumer(consumer gjson.Result, names map[string]struct{}) (c *Consume
 		c.KeepToken = &DefaultKeepToken
 	}
 
+	if c.RemoteJWKs != nil {
+		// Fill the default remote JWKS cache duration.
+		if c.JWKsCacheDuration == nil {
+			v := DefaultJWKsCacheDuration
+			c.JWKsCacheDuration = &v
+		}
+		if *c.JWKsCacheDuration <= 0 {
+			return nil, fmt.Errorf("jwks_cache_duration must be positive, consumer:%s", c.Name)
+		}
+		if *c.JWKsCacheDuration < minJWKsCacheDuration {
+			return nil, fmt.Errorf("jwks_cache_duration must be greater than or equal to %d, consumer:%s", minJWKsCacheDuration, c.Name)
+		}
+		if *c.JWKsCacheDuration > maxJWKsCacheDuration {
+			return nil, fmt.Errorf("jwks_cache_duration must be less than or equal to %d, consumer:%s", maxJWKsCacheDuration, c.Name)
+		}
+
+		// Fill the default remote JWKS fetch timeout.
+		if c.JWKsFetchTimeout == nil {
+			v := DefaultJWKsFetchTimeout
+			c.JWKsFetchTimeout = &v
+		}
+		if *c.JWKsFetchTimeout <= 0 {
+			return nil, fmt.Errorf("jwks_fetch_timeout must be positive, consumer:%s", c.Name)
+		}
+		if *c.JWKsFetchTimeout > maxJWKsFetchTimeout {
+			return nil, fmt.Errorf("jwks_fetch_timeout must be less than or equal to %d, consumer:%s", maxJWKsFetchTimeout, c.Name)
+		}
+	}
+
 	// consumer合法，记录consumer名称
 	names[c.Name] = struct{}{}
 	return c, nil
+}
+
+func normalizeRemoteJWKs(remote *RemoteJWKs) {
+	remote.ServiceName = strings.TrimSpace(remote.ServiceName)
+	remote.ServiceHost = strings.TrimSpace(remote.ServiceHost)
+	remote.Path = strings.TrimSpace(remote.Path)
+	if remote.ServicePort == nil {
+		v := int64(443)
+		remote.ServicePort = &v
+	}
+}
+
+func validateRemoteJWKs(remote *RemoteJWKs) error {
+	if remote.ServiceName == "" {
+		return fmt.Errorf("service_name is required")
+	}
+	if hasInvalidRemoteJWKsFieldChar(remote.ServiceName) || strings.ContainsAny(remote.ServiceName, "|/?#@:") {
+		return fmt.Errorf("service_name must not contain whitespace, control characters, or URI separators")
+	}
+	if remote.ServiceHost == "" {
+		return fmt.Errorf("service_host is required")
+	}
+	if hasInvalidRemoteJWKsFieldChar(remote.ServiceHost) {
+		return fmt.Errorf("service_host must not contain whitespace or control characters")
+	}
+	if strings.ContainsAny(remote.ServiceHost, "/?#@:") || strings.Contains(remote.ServiceHost, "://") {
+		return fmt.Errorf("service_host must be a host without port")
+	}
+	if remote.Path == "" || !strings.HasPrefix(remote.Path, "/") {
+		return fmt.Errorf("path must start with /")
+	}
+	if hasInvalidRemoteJWKsFieldChar(remote.Path) {
+		return fmt.Errorf("path must not contain whitespace or control characters")
+	}
+	if *remote.ServicePort <= 0 || *remote.ServicePort > 65535 {
+		return fmt.Errorf("service_port is invalid")
+	}
+	return nil
+}
+
+func hasInvalidRemoteJWKsFieldChar(value string) bool {
+	return strings.ContainsAny(value, " \t\r\n") || hasControlChar(value)
+}
+
+func hasControlChar(value string) bool {
+	for _, r := range value {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
 }

--- a/plugins/wasm-go/extensions/jwt-auth/config/parser_test.go
+++ b/plugins/wasm-go/extensions/jwt-auth/config/parser_test.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2023 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+const testJWKs = "{\"keys\":[{\"kty\":\"EC\",\"kid\":\"p256\",\"crv\":\"P-256\",\"x\":\"GWym652nfByDbs4EzNpGXCkdjG03qFZHulNDHTo3YJU\",\"y\":\"5uVg_n-flqRJ5Zhf_aEKS0ow9SddTDgxGduSCgpoAZQ\"}]}"
+
+func TestParseGlobalConfigRecordsRulesExist(t *testing.T) {
+	cfg := &JWTAuthConfig{}
+	err := ParseGlobalConfig(gjson.Parse(`{
+		"consumers": [{
+			"name": "inline-consumer",
+			"issuer": "higress-test",
+			"jwks": `+quoteJSON(testJWKs)+`
+		}],
+		"_rules_": [{
+			"_match_domain_": ["private.example.com"],
+			"allow": ["inline-consumer"]
+		}]
+	}`), cfg, nil)
+
+	if err != nil {
+		t.Fatalf("ParseGlobalConfig returned error: %v", err)
+	}
+	if !cfg.RuleSet {
+		t.Fatalf("expected global config to record that route/domain rules exist")
+	}
+}
+
+func TestParseConsumerCachesInlineJWKs(t *testing.T) {
+	consumer, err := ParseConsumer(gjson.Parse(`{
+		"name": "inline-consumer",
+		"issuer": "higress-test",
+		"jwks": `+quoteJSON(testJWKs)+`
+	}`), map[string]struct{}{})
+
+	if err != nil {
+		t.Fatalf("ParseConsumer returned error: %v", err)
+	}
+	if consumer.ParsedJWKs == nil || len(consumer.ParsedJWKs.Keys) != 1 {
+		t.Fatalf("expected parsed inline jwks to be cached, got: %#v", consumer.ParsedJWKs)
+	}
+}
+
+func TestParseConsumerTrimsIssuer(t *testing.T) {
+	consumer, err := ParseConsumer(gjson.Parse(`{
+		"name": "inline-consumer",
+		"issuer": " higress-test ",
+		"jwks": `+quoteJSON(testJWKs)+`
+	}`), map[string]struct{}{})
+
+	if err != nil {
+		t.Fatalf("ParseConsumer returned error: %v", err)
+	}
+	if consumer.Issuer != "higress-test" {
+		t.Fatalf("expected issuer to be trimmed, got: %q", consumer.Issuer)
+	}
+}
+
+func TestParseConsumerAcceptsRemoteJWKsService(t *testing.T) {
+	consumer, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"issuer": "higress-test",
+		"remote_jwks": {
+			"service_name": "auth.example.com.dns",
+			"service_host": "auth.example.com",
+			"service_port": 443,
+			"path": "/.well-known/jwks.json"
+		}
+	}`), map[string]struct{}{})
+
+	if err != nil {
+		t.Fatalf("ParseConsumer returned error: %v", err)
+	}
+	if consumer.RemoteJWKs == nil {
+		t.Fatalf("expected remote_jwks to be parsed")
+	}
+	if consumer.RemoteJWKs.ServiceName != "auth.example.com.dns" {
+		t.Fatalf("unexpected service_name: %q", consumer.RemoteJWKs.ServiceName)
+	}
+	if consumer.RemoteJWKs.ServiceHost != "auth.example.com" {
+		t.Fatalf("unexpected service_host: %q", consumer.RemoteJWKs.ServiceHost)
+	}
+	if consumer.RemoteJWKs.ServicePort == nil || *consumer.RemoteJWKs.ServicePort != 443 {
+		t.Fatalf("unexpected service_port: %v", consumer.RemoteJWKs.ServicePort)
+	}
+	if consumer.RemoteJWKs.Path != "/.well-known/jwks.json" {
+		t.Fatalf("unexpected path: %q", consumer.RemoteJWKs.Path)
+	}
+	if got := *consumer.JWKsCacheDuration; got != 600 {
+		t.Fatalf("unexpected jwks_cache_duration: %d", got)
+	}
+	if got := *consumer.JWKsFetchTimeout; got != 1500 {
+		t.Fatalf("unexpected jwks_fetch_timeout: %d", got)
+	}
+}
+
+func TestParseConsumerTrimsRemoteJWKsServiceFields(t *testing.T) {
+	consumer, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"issuer": "higress-test",
+		"remote_jwks": {
+			"service_name": " auth.example.com.dns ",
+			"service_host": " auth.example.com ",
+			"path": " /.well-known/jwks.json "
+		}
+	}`), map[string]struct{}{})
+
+	if err != nil {
+		t.Fatalf("ParseConsumer returned error: %v", err)
+	}
+	if consumer.RemoteJWKs.ServiceName != "auth.example.com.dns" {
+		t.Fatalf("unexpected service_name: %q", consumer.RemoteJWKs.ServiceName)
+	}
+	if consumer.RemoteJWKs.ServiceHost != "auth.example.com" {
+		t.Fatalf("unexpected service_host: %q", consumer.RemoteJWKs.ServiceHost)
+	}
+	if consumer.RemoteJWKs.Path != "/.well-known/jwks.json" {
+		t.Fatalf("unexpected path: %q", consumer.RemoteJWKs.Path)
+	}
+	if consumer.RemoteJWKs.ServicePort == nil || *consumer.RemoteJWKs.ServicePort != 443 {
+		t.Fatalf("expected default service_port 443, got: %v", consumer.RemoteJWKs.ServicePort)
+	}
+}
+
+func TestParseConsumerRejectsBothInlineAndRemoteJWKs(t *testing.T) {
+	_, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"issuer": "higress-test",
+		"jwks": `+quoteJSON(testJWKs)+`,
+		"remote_jwks": {"service_name": "auth.example.com.dns", "path": "/.well-known/jwks.json"}
+	}`), map[string]struct{}{})
+
+	if err == nil || !containsError(err, "only one of jwks and remote_jwks can be configured") {
+		t.Fatalf("expected mutually exclusive jwks error, got: %v", err)
+	}
+}
+
+func TestParseConsumerRejectsMissingJWKs(t *testing.T) {
+	_, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"issuer": "higress-test"
+	}`), map[string]struct{}{})
+
+	if err == nil || !containsError(err, "one of jwks and remote_jwks is required") {
+		t.Fatalf("expected missing jwks error, got: %v", err)
+	}
+}
+
+func TestParseConsumerRejectsRemoteJWKsWithoutIssuer(t *testing.T) {
+	_, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"remote_jwks": {"service_name": "auth.example.com.dns", "path": "/.well-known/jwks.json"}
+	}`), map[string]struct{}{})
+
+	if err == nil || !containsError(err, "issuer is required when remote_jwks is set") {
+		t.Fatalf("expected missing issuer error for remote jwks, got: %v", err)
+	}
+}
+
+func TestParseConsumerRejectsInvalidRemoteJWKsService(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteJWKs string
+	}{
+		{name: "missing service_name", remoteJWKs: `"path": "/.well-known/jwks.json"`},
+		{name: "blank service_name", remoteJWKs: `"service_name": " ", "path": "/.well-known/jwks.json"`},
+		{name: "service_name whitespace", remoteJWKs: `"service_name": "auth example", "path": "/.well-known/jwks.json"`},
+		{name: "service_name cluster separator", remoteJWKs: `"service_name": "auth|example", "path": "/.well-known/jwks.json"`},
+		{name: "service_name path", remoteJWKs: `"service_name": "auth.example.com/jwks", "path": "/.well-known/jwks.json"`},
+		{name: "missing service_host", remoteJWKs: `"service_name": "auth.example.com.dns", "path": "/.well-known/jwks.json"`},
+		{name: "service_host whitespace", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "auth example", "path": "/.well-known/jwks.json"`},
+		{name: "service_host scheme", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "https://auth.example.com", "path": "/.well-known/jwks.json"`},
+		{name: "service_host port", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "auth.example.com:8443", "path": "/.well-known/jwks.json"`},
+		{name: "service_host path", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "auth.example.com/jwks", "path": "/.well-known/jwks.json"`},
+		{name: "service_host userinfo", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "user@auth.example.com", "path": "/.well-known/jwks.json"`},
+		{name: "path control char", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "auth.example.com", "path": "/jwks\n.json"`},
+		{name: "path whitespace", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "auth.example.com", "path": "/jwks file.json"`},
+		{name: "missing path", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "auth.example.com"`},
+		{name: "relative path", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "auth.example.com", "path": "jwks.json"`},
+		{name: "invalid port", remoteJWKs: `"service_name": "auth.example.com.dns", "service_host": "auth.example.com", "service_port": 99999, "path": "/.well-known/jwks.json"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseConsumer(gjson.Parse(`{
+				"name": "remote-consumer",
+				"issuer": "higress-test",
+				"remote_jwks": {`+tt.remoteJWKs+`}
+			}`), map[string]struct{}{})
+
+			if err == nil || !containsError(err, "remote_jwks is invalid") {
+				t.Fatalf("expected invalid remote_jwks error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseConsumerRejectsTooLargeRemoteJWKsFetchTimeout(t *testing.T) {
+	_, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"issuer": "higress-test",
+		"remote_jwks": {"service_name": "auth.example.com.dns", "service_host": "auth.example.com", "path": "/.well-known/jwks.json"},
+		"jwks_fetch_timeout": 10001
+	}`), map[string]struct{}{})
+
+	if err == nil || !containsError(err, "jwks_fetch_timeout must be less than or equal to") {
+		t.Fatalf("expected invalid jwks_fetch_timeout error, got: %v", err)
+	}
+}
+
+func TestParseConsumerRejectsTooLargeRemoteJWKsCacheDuration(t *testing.T) {
+	_, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"issuer": "higress-test",
+		"remote_jwks": {"service_name": "auth.example.com.dns", "service_host": "auth.example.com", "path": "/.well-known/jwks.json"},
+		"jwks_cache_duration": 604801
+	}`), map[string]struct{}{})
+
+	if err == nil || !containsError(err, "jwks_cache_duration must be less than or equal to") {
+		t.Fatalf("expected invalid jwks_cache_duration error, got: %v", err)
+	}
+}
+
+func TestParseConsumerRejectsTooSmallRemoteJWKsCacheDuration(t *testing.T) {
+	_, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"issuer": "higress-test",
+		"remote_jwks": {"service_name": "auth.example.com.dns", "service_host": "auth.example.com", "path": "/.well-known/jwks.json"},
+		"jwks_cache_duration": 29
+	}`), map[string]struct{}{})
+
+	if err == nil || !containsError(err, "jwks_cache_duration must be greater than or equal to 30") {
+		t.Fatalf("expected invalid jwks_cache_duration error, got: %v", err)
+	}
+}
+
+func TestParseConsumerRejectsRemoteJWKsOptionsForInlineJWKs(t *testing.T) {
+	_, err := ParseConsumer(gjson.Parse(`{
+		"name": "inline-consumer",
+		"issuer": "higress-test",
+		"jwks": `+quoteJSON(testJWKs)+`,
+		"jwks_cache_duration": 600
+	}`), map[string]struct{}{})
+
+	if err == nil || !containsError(err, "jwks_cache_duration and jwks_fetch_timeout only apply to remote_jwks") {
+		t.Fatalf("expected inline jwks remote option error, got: %v", err)
+	}
+}
+
+func TestParseConsumerRejectsEmptyInlineJWKs(t *testing.T) {
+	_, err := ParseConsumer(gjson.Parse(`{
+		"name": "remote-consumer",
+		"issuer": "higress-test",
+		"jwks": "{\"keys\":[]}"
+	}`), map[string]struct{}{})
+
+	if err == nil || !containsError(err, "jwks is empty") {
+		t.Fatalf("expected empty jwks error, got: %v", err)
+	}
+}
+
+func quoteJSON(value string) string {
+	return strconv.Quote(value)
+}
+
+func containsError(err error, want string) bool {
+	return err != nil && strings.Contains(err.Error(), want)
+}

--- a/plugins/wasm-go/extensions/jwt-auth/go.mod
+++ b/plugins/wasm-go/extensions/jwt-auth/go.mod
@@ -12,10 +12,15 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	github.com/tetratelabs/wazero v1.7.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/resp v0.1.1 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/plugins/wasm-go/extensions/jwt-auth/go.sum
+++ b/plugins/wasm-go/extensions/jwt-auth/go.sum
@@ -17,6 +17,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tetratelabs/wazero v1.7.2 h1:1+z5nXJNwMLPAWaTePFi49SSTL0IMx/i3Fg8Yc25GDc=
+github.com/tetratelabs/wazero v1.7.2/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -69,6 +71,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/plugins/wasm-go/extensions/jwt-auth/handler/extractor.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/extractor.go
@@ -82,14 +82,20 @@ func extractFromParams(keepToken bool, params []string, header HeaderProvider, l
 		return ""
 	}
 
-	url, _ := url.Parse(urlparams)
-	query := url.Query()
+	parsedURL, err := url.Parse(urlparams)
+	if err != nil {
+		log.Warnf("failed to parse path: invalid request path")
+		return ""
+	}
+	query := parsedURL.Query()
 
 	for i := range params {
 		token := query.Get(params[i])
 		if token != "" {
 			if !keepToken {
 				query.Del(params[i])
+				parsedURL.RawQuery = query.Encode()
+				_ = header.ReplaceHttpRequestHeader(":path", parsedURL.RequestURI())
 			}
 			return token
 		}

--- a/plugins/wasm-go/extensions/jwt-auth/handler/handler.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/handler.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	cfg "github.com/alibaba/higress/plugins/wasm-go/extensions/jwt-auth/config"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
 	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
@@ -41,113 +42,180 @@ func OnHTTPRequestHeaders(ctx wrapper.HttpContext, config cfg.JWTAuthConfig, log
 	var (
 		noAllow            = len(config.Allow) == 0 // 未配置 allow 列表，表示插件在该 domain/route 未生效
 		globalAuthNoSet    = config.GlobalAuthCheck() == cfg.GlobalAuthNoSet
-		globalAuthSetTrue  = config.GlobalAuthCheck() == cfg.GlobalAuthTrue
 		globalAuthSetFalse = config.GlobalAuthCheck() == cfg.GlobalAuthFalse
 	)
 
 	// 不需要认证而直接放行的情况：
 	// - global_auth == false 且 当前 domain/route 未配置该插件
 	// - global_auth 未设置 且 有至少一个 domain/route 配置该插件 且 当前 domain/route 未配置该插件
-	if globalAuthSetFalse || (cfg.RuleSet && globalAuthNoSet) {
+	if globalAuthSetFalse || (config.RuleSet && globalAuthNoSet) {
 		if noAllow {
 			log.Info("authorization is not required")
 			return types.ActionContinue
 		}
 	}
 
+	verifyTime := time.Now()
+	decision := verifyConsumers(config, log, verifyTime)
+	if decision.remoteConsumer != nil {
+		return fetchRemoteJWKsAndVerify(decision.remoteConsumer, config, log, verifyTime)
+	}
+	return decision.action()
+}
+
+func fetchRemoteJWKsAndVerify(consumer *cfg.Consumer, config cfg.JWTAuthConfig, log log.Log, verifyTime time.Time) types.Action {
+	err := fetchRemoteJWKs(consumer, log, func() {
+		completeAuthenticationAfterRemoteFetch(config, log, verifyTime, 1)
+	})
+	if err != nil {
+		log.Warnf("failed to dispatch remote jwks fetch, consumer:%s, reason:%s", consumer.Name, err.Error())
+		return actionAfterRemoteFetch(config, log, verifyTime, 1)
+	}
+	return types.HeaderStopAllIterationAndWatermark
+}
+
+func completeAuthenticationAfterRemoteFetch(config cfg.JWTAuthConfig, log log.Log, verifyTime time.Time, attempts int) {
+	decision := decisionAfterRemoteFetch(config, log, verifyTime, attempts)
+	if decision.waitingRemoteFetch {
+		return
+	}
+	_ = decision.action()
+	if decision.resume {
+		proxywasm.ResumeHttpRequest()
+	}
+}
+
+func actionAfterRemoteFetch(config cfg.JWTAuthConfig, log log.Log, verifyTime time.Time, attempts int) types.Action {
+	decision := decisionAfterRemoteFetch(config, log, verifyTime, attempts)
+	if decision.waitingRemoteFetch {
+		return types.HeaderStopAllIterationAndWatermark
+	}
+	return decision.action()
+}
+
+func decisionAfterRemoteFetch(config cfg.JWTAuthConfig, log log.Log, verifyTime time.Time, attempts int) authDecision {
+	for {
+		decision := verifyConsumers(config, log, verifyTime)
+		if decision.remoteConsumer == nil {
+			return decision
+		}
+		if attempts >= len(config.Consumers) {
+			log.Warnf("remote jwks fetch chain exhausted after %d attempts", attempts)
+			return authDecision{action: deniedJWTVerificationFails}
+		}
+
+		// Chained fetches only advance after each response has populated or rejected one cache entry.
+		nextAttempts := attempts + 1
+		err := fetchRemoteJWKs(decision.remoteConsumer, log, func() {
+			completeAuthenticationAfterRemoteFetch(config, log, verifyTime, nextAttempts)
+		})
+		if err == nil {
+			return authDecision{waitingRemoteFetch: true}
+		}
+
+		log.Warnf("failed to dispatch remote jwks fetch, consumer:%s, reason:%s", decision.remoteConsumer.Name, err.Error())
+		attempts = nextAttempts
+	}
+}
+
+type authDecision struct {
+	action             func() types.Action
+	resume             bool
+	remoteConsumer     *cfg.Consumer
+	waitingRemoteFetch bool
+}
+
+func verifyConsumers(config cfg.JWTAuthConfig, log log.Log, verifyTime time.Time) authDecision {
 	header := &proxywasmProvider{}
 	actionMap := map[string]func() types.Action{}
 	unAuthzConsumer := ""
+	var firstRemoteConsumer *cfg.Consumer
 
 	// 匹配consumer
 	for i := range config.Consumers {
-		err := consumerVerify(config.Consumers[i], time.Now(), header, log)
+		consumer := config.Consumers[i]
+		verified, err := consumerVerify(consumer, verifyTime, header, log)
 		if err != nil {
+			if isRemoteJWKsCacheMiss(err) {
+				if firstRemoteConsumer == nil && consumerAllowedForFetch(config, consumer.Name) {
+					firstRemoteConsumer = consumer
+				}
+				continue
+			}
 			log.Warn(err.Error())
 			if v, ok := err.(*ErrDenied); ok {
-				actionMap[config.Consumers[i].Name] = v.denied
+				actionMap[consumer.Name] = v.denied
 			}
 			continue
 		}
 
-		// 全局生效：
-		// - global_auth == true 且 当前 domain/route 未配置该插件
-		// - global_auth 未设置 且 没有任何一个 domain/route 配置该插件
-		if (globalAuthSetTrue && noAllow) || (globalAuthNoSet && !cfg.RuleSet) {
-			log.Infof("consumer %q authenticated", config.Consumers[i].Name)
-			return authenticated(config.Consumers[i].Name)
+		action, resume := actionForVerifiedConsumer(config, consumer.Name, log)
+		if resume {
+			applyConsumerSideEffects(consumer, verified, header, log)
+			return authDecision{action: action, resume: true}
 		}
-
-		// 全局生效，但当前 domain/route 配置了 allow 列表
-		if globalAuthSetTrue && !noAllow {
-			if !contains(config.Consumers[i].Name, config.Allow) {
-				log.Warnf("jwt verify failed, consumer %q not allow",
-					config.Consumers[i].Name)
-				actionMap[config.Consumers[i].Name] = deniedUnauthorizedConsumer
-				unAuthzConsumer = config.Consumers[i].Name
-				continue
-			}
-			log.Infof("consumer %q authenticated", config.Consumers[i].Name)
-			return authenticated(config.Consumers[i].Name)
+		if action != nil {
+			actionMap[consumer.Name] = action
+			unAuthzConsumer = consumer.Name
+			continue
 		}
-
-		// 非全局生效
-		if globalAuthSetFalse || (globalAuthNoSet && cfg.RuleSet) {
-			if !noAllow { // 配置了 allow 列表
-				if !contains(config.Consumers[i].Name, config.Allow) {
-					log.Warnf("jwt verify failed, consumer %q not allow",
-						config.Consumers[i].Name)
-					actionMap[config.Consumers[i].Name] = deniedUnauthorizedConsumer
-					unAuthzConsumer = config.Consumers[i].Name
-					continue
-				}
-				log.Infof("consumer %q authenticated", config.Consumers[i].Name)
-				return authenticated(config.Consumers[i].Name)
-			}
-		}
-
-		// switch config.GlobalAuthCheck() {
-
-		// case cfg.GlobalAuthNoSet:
-		// 	if !cfg.RuleSet {
-		// 		log.Infof("consumer %q authenticated", config.Consumers[i].Name)
-		// 		return authenticated(config.Consumers[i].Name)
-		// 	}
-		// case cfg.GlobalAuthTrue:
-		// 	if len(config.Allow) == 0 {
-		// 		log.Infof("consumer %q authenticated", config.Consumers[i].Name)
-		// 		return authenticated(config.Consumers[i].Name)
-		// 	}
-		// 	fallthrough // 若 allow 列表不为空，则 fallthrough 到需要检查 allow 列表的逻辑中
-
-		// // 全局生效设置为 false
-		// case cfg.GlobalAuthFalse:
-		// 	if !contains(config.Consumers[i].Name, config.Allow) {
-		// 		log.Warnf("jwt verify failed, consumer %q not allow",
-		// 			config.Consumers[i].Name)
-		// 		actionMap[config.Consumers[i].Name] = deniedUnauthorizedConsumer
-		// 		unAuthzConsumer = config.Consumers[i].Name
-		// 		continue
-		// 	}
-		// 	log.Infof("consumer %q authenticated", config.Consumers[i].Name)
-		// 	return authenticated(config.Consumers[i].Name)
-		// }
 	}
 
+	if firstRemoteConsumer != nil {
+		return authDecision{remoteConsumer: firstRemoteConsumer}
+	}
 	if len(config.Allow) == 1 {
 		if unAuthzConsumer != "" {
 			log.Warnf("consumer %q denied", unAuthzConsumer)
-			return deniedUnauthorizedConsumer()
+			return authDecision{action: deniedUnauthorizedConsumer}
 		}
 		if v, ok := actionMap[config.Allow[0]]; ok {
 			log.Warnf("consumer %q denied", config.Allow[0])
-			return v()
+			return authDecision{action: v}
 		}
 	}
 
 	// 拒绝兜底
 	log.Warnf("all consumers verify failed")
-	return deniedNotAllow()
+	return authDecision{action: deniedNotAllow}
+}
+
+func actionForVerifiedConsumer(config cfg.JWTAuthConfig, name string, log log.Log) (func() types.Action, bool) {
+	noAllow := len(config.Allow) == 0
+	globalAuthNoSet := config.GlobalAuthCheck() == cfg.GlobalAuthNoSet
+	globalAuthSetTrue := config.GlobalAuthCheck() == cfg.GlobalAuthTrue
+	globalAuthSetFalse := config.GlobalAuthCheck() == cfg.GlobalAuthFalse
+
+	if (globalAuthSetTrue && noAllow) || (globalAuthNoSet && !config.RuleSet) {
+		log.Infof("consumer %q authenticated", name)
+		return func() types.Action { return authenticated(name) }, true
+	}
+
+	if globalAuthSetTrue && !noAllow {
+		if !contains(name, config.Allow) {
+			log.Warnf("jwt verify failed, consumer %q not allow", name)
+			return deniedUnauthorizedConsumer, false
+		}
+		log.Infof("consumer %q authenticated", name)
+		return func() types.Action { return authenticated(name) }, true
+	}
+
+	if globalAuthSetFalse || (globalAuthNoSet && config.RuleSet) {
+		if !noAllow {
+			if !contains(name, config.Allow) {
+				log.Warnf("jwt verify failed, consumer %q not allow", name)
+				return deniedUnauthorizedConsumer, false
+			}
+			log.Infof("consumer %q authenticated", name)
+			return func() types.Action { return authenticated(name) }, true
+		}
+	}
+
+	return nil, false
+}
+
+func consumerAllowedForFetch(config cfg.JWTAuthConfig, name string) bool {
+	return len(config.Allow) == 0 || contains(name, config.Allow)
 }
 
 func contains(str string, arr []string) bool {

--- a/plugins/wasm-go/extensions/jwt-auth/handler/handler_test.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/handler_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2023 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/jwt-auth/config"
+)
+
+func TestActionForVerifiedConsumerUsesConfigRuleSetSnapshot(t *testing.T) {
+	action, resume := actionForVerifiedConsumer(config.JWTAuthConfig{
+		RuleSet: true,
+		Allow:   []string{"allowed-consumer"},
+	}, "other-consumer", &testLogger{T: t})
+
+	if resume {
+		t.Fatalf("expected route-level allow list to deny non-allowed consumer")
+	}
+	if action == nil {
+		t.Fatalf("expected a deny action for non-allowed consumer")
+	}
+}

--- a/plugins/wasm-go/extensions/jwt-auth/handler/jwks_cache.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/jwks_cache.go
@@ -1,0 +1,329 @@
+// Copyright (c) 2023 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	cfg "github.com/alibaba/higress/plugins/wasm-go/extensions/jwt-auth/config"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/wasm-go/pkg/log"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
+)
+
+type cachedJWKs struct {
+	keys      *jose.JSONWebKeySet
+	fetchedAt time.Time
+}
+
+type remoteJWKsFetchState struct {
+	inFlight     bool
+	startedAt    time.Time
+	deadline     time.Time
+	lastFailedAt time.Time
+}
+
+type remoteJWKsCacheKey struct {
+	serviceName string
+	serviceHost string
+	servicePort int64
+	path        string
+}
+
+// These maps are process-local caches in the single-threaded proxy-wasm VM.
+var remoteJWKsCache = map[remoteJWKsCacheKey]cachedJWKs{}
+var remoteJWKsFetchStates = map[remoteJWKsCacheKey]remoteJWKsFetchState{}
+
+var errRemoteJWKsCacheMiss = errors.New("remote jwks cache is missing or expired")
+var errRemoteJWKsRefreshThrottled = errors.New("remote jwks refresh is throttled")
+
+var dispatchRemoteJWKsHTTPCall = proxywasm.DispatchHttpCall
+
+// Failed remote JWKS fetches are backed off per remote service reference.
+// In-flight requests are not coalesced because proxy-wasm callbacks are bound
+// to one HTTP stream context.
+const remoteJWKsMinRefreshInterval = time.Duration(cfg.RemoteJWKsMinRefreshIntervalSeconds) * time.Second
+const maxRemoteJWKsResponseSize = 64 * 1024
+
+func remoteJWKsCacheKeyForConsumer(consumer *cfg.Consumer) remoteJWKsCacheKey {
+	remote := consumer.RemoteJWKs
+	if remote == nil {
+		return remoteJWKsCacheKey{}
+	}
+	return remoteJWKsCacheKey{
+		serviceName: remote.ServiceName,
+		serviceHost: remote.ServiceHost,
+		servicePort: remoteJWKsServicePort(remote),
+		path:        remote.Path,
+	}
+}
+
+func PruneRemoteJWKsCache(consumers []*cfg.Consumer) {
+	active := make(map[remoteJWKsCacheKey]struct{}, len(consumers))
+	for _, consumer := range consumers {
+		if consumer != nil && consumer.RemoteJWKs != nil {
+			active[remoteJWKsCacheKeyForConsumer(consumer)] = struct{}{}
+		}
+	}
+	for key := range remoteJWKsCache {
+		if _, ok := active[key]; !ok {
+			delete(remoteJWKsCache, key)
+		}
+	}
+	for key := range remoteJWKsFetchStates {
+		if _, ok := active[key]; !ok {
+			delete(remoteJWKsFetchStates, key)
+		}
+	}
+}
+
+func consumerJWKs(consumer *cfg.Consumer, now time.Time) (*jose.JSONWebKeySet, error) {
+	raw := consumer.JWKs
+	if raw == "" {
+		cached, ok := remoteJWKsCache[remoteJWKsCacheKeyForConsumer(consumer)]
+		cacheDuration := remoteJWKsCacheDuration(consumer)
+		if ok && now.Before(cached.fetchedAt.Add(time.Duration(cacheDuration)*time.Second)) {
+			return cached.keys, nil
+		}
+		if ok && remoteJWKsFetchInFlight(consumer, now) {
+			return cached.keys, nil
+		}
+		if !remoteJWKsFetchAllowed(consumer, now) {
+			return nil, errRemoteJWKsRefreshThrottled
+		}
+		return nil, errRemoteJWKsCacheMiss
+	}
+
+	if consumer.ParsedJWKs != nil {
+		return consumer.ParsedJWKs, nil
+	}
+	return parseJWKs(raw)
+}
+
+// remoteJWKsFetchedAfter tells the verifier whether this same request has
+// already retried with a freshly fetched JWKS.
+func remoteJWKsFetchedAfter(consumer *cfg.Consumer, t time.Time) bool {
+	cached, ok := remoteJWKsCache[remoteJWKsCacheKeyForConsumer(consumer)]
+	return ok && cached.fetchedAt.After(t)
+}
+
+func isRemoteJWKsCacheMiss(err error) bool {
+	return errors.Is(err, errRemoteJWKsCacheMiss)
+}
+
+func isRemoteJWKsRefreshThrottled(err error) bool {
+	return errors.Is(err, errRemoteJWKsRefreshThrottled)
+}
+
+func fetchRemoteJWKs(consumer *cfg.Consumer, log log.Log, callback func()) error {
+	cluster, path, err := remoteJWKsFetchCluster(consumer)
+	if err != nil {
+		return err
+	}
+
+	timeout := uint32(remoteJWKsFetchTimeout(consumer))
+	startedAt := time.Now()
+	if !recordRemoteJWKsFetchStart(consumer, startedAt) {
+		return errRemoteJWKsRefreshThrottled
+	}
+	headers := [][2]string{{"Accept", "application/json"}, {":method", http.MethodGet}, {":path", path}, {":authority", remoteJWKsAuthority(consumer)}}
+	_, err = dispatchRemoteJWKsHTTPCall(cluster.ClusterName(), headers, nil, nil, timeout, func(numHeaders, bodySize, numTrailers int) {
+		statusCode, err := remoteJWKsResponseStatus()
+		if err != nil {
+			recordRemoteJWKsFetchFailure(consumer, startedAt, time.Now())
+			log.Warnf("failed to read remote jwks response status, consumer:%s, reason:%s", consumer.Name, err.Error())
+			callback()
+			return
+		}
+		if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+			recordRemoteJWKsFetchFailure(consumer, startedAt, time.Now())
+			log.Warnf("failed to fetch remote jwks, consumer:%s, status:%d", consumer.Name, statusCode)
+			callback()
+			return
+		}
+		if bodySize > maxRemoteJWKsResponseSize {
+			recordRemoteJWKsFetchFailure(consumer, startedAt, time.Now())
+			log.Warnf("remote jwks is invalid, consumer:%s, status:%d, reason:jwks response exceeds %d bytes", consumer.Name, statusCode, maxRemoteJWKsResponseSize)
+			callback()
+			return
+		}
+		body, err := proxywasm.GetHttpCallResponseBody(0, bodySize)
+		if err != nil {
+			recordRemoteJWKsFetchFailure(consumer, startedAt, time.Now())
+			log.Warnf("failed to read remote jwks response body, consumer:%s, status:%d, reason:%s", consumer.Name, statusCode, err.Error())
+			callback()
+			return
+		}
+		keys, err := parseRemoteJWKsResponse(string(body))
+		if err != nil {
+			recordRemoteJWKsFetchFailure(consumer, startedAt, time.Now())
+			log.Warnf("remote jwks is invalid, consumer:%s, status:%d, reason:%s", consumer.Name, statusCode, err.Error())
+			callback()
+			return
+		}
+		cacheRemoteJWKs(consumer, keys, startedAt, time.Now())
+		callback()
+	})
+	if err != nil {
+		recordRemoteJWKsFetchFailure(consumer, startedAt, time.Now())
+		return err
+	}
+	return nil
+}
+
+func remoteJWKsResponseStatus() (int, error) {
+	headers, err := proxywasm.GetHttpCallResponseHeaders()
+	if err != nil {
+		return 0, err
+	}
+	for _, header := range headers {
+		if header[0] == ":status" {
+			return strconv.Atoi(header[1])
+		}
+	}
+	return 0, fmt.Errorf("missing :status")
+}
+
+func remoteJWKsFetchCluster(consumer *cfg.Consumer) (wrapper.FQDNCluster, string, error) {
+	remote := consumer.RemoteJWKs
+	if remote == nil || remote.ServiceName == "" || remote.Path == "" {
+		return wrapper.FQDNCluster{}, "", fmt.Errorf("remote_jwks is not configured")
+	}
+	return wrapper.FQDNCluster{
+		FQDN: remote.ServiceName,
+		Host: remote.ServiceHost,
+		Port: remoteJWKsServicePort(remote),
+	}, remote.Path, nil
+}
+
+func remoteJWKsServicePort(remote *cfg.RemoteJWKs) int64 {
+	if remote.ServicePort == nil {
+		return 443
+	}
+	return *remote.ServicePort
+}
+
+func remoteJWKsAuthority(consumer *cfg.Consumer) string {
+	remote := consumer.RemoteJWKs
+	if remote == nil {
+		return ""
+	}
+	port := remoteJWKsServicePort(remote)
+	if port == 80 || port == 443 {
+		return remote.ServiceHost
+	}
+	return remote.ServiceHost + ":" + strconv.FormatInt(port, 10)
+}
+
+func remoteJWKsCacheDuration(consumer *cfg.Consumer) int64 {
+	if consumer.JWKsCacheDuration == nil {
+		return cfg.DefaultJWKsCacheDuration
+	}
+	return *consumer.JWKsCacheDuration
+}
+
+func remoteJWKsFetchTimeout(consumer *cfg.Consumer) int64 {
+	if consumer.JWKsFetchTimeout == nil {
+		return cfg.DefaultJWKsFetchTimeout
+	}
+	return *consumer.JWKsFetchTimeout
+}
+
+func parseRemoteJWKsResponse(raw string) (*jose.JSONWebKeySet, error) {
+	if len(raw) > maxRemoteJWKsResponseSize {
+		return nil, fmt.Errorf("jwks response exceeds %d bytes", maxRemoteJWKsResponseSize)
+	}
+	return parseJWKs(raw)
+}
+
+func parseJWKs(raw string) (*jose.JSONWebKeySet, error) {
+	jwks := &jose.JSONWebKeySet{}
+	if err := json.Unmarshal([]byte(raw), jwks); err != nil {
+		return nil, err
+	}
+	if len(jwks.Keys) == 0 {
+		return nil, fmt.Errorf("jwks has no keys")
+	}
+	return jwks, nil
+}
+
+// Initial cold/expired fetches are only backed off after failures. A successful
+// completed fetch must not block the next TTL-driven refresh.
+func remoteJWKsFetchAllowed(consumer *cfg.Consumer, now time.Time) bool {
+	state, ok := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]
+	if !ok {
+		return true
+	}
+	if remoteJWKsInFlight(state, now) {
+		return false
+	}
+	return state.lastFailedAt.IsZero() || now.Sub(state.lastFailedAt) >= remoteJWKsMinRefreshInterval
+}
+
+func remoteJWKsFetchInFlight(consumer *cfg.Consumer, now time.Time) bool {
+	state, ok := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]
+	return ok && remoteJWKsInFlight(state, now)
+}
+
+func remoteJWKsInFlight(state remoteJWKsFetchState, now time.Time) bool {
+	return state.inFlight && now.Before(state.deadline)
+}
+
+func recordRemoteJWKsFetchStart(consumer *cfg.Consumer, now time.Time) bool {
+	if !remoteJWKsFetchAllowed(consumer, now) {
+		return false
+	}
+	state := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]
+	state.inFlight = true
+	state.startedAt = now
+	state.deadline = now.Add(time.Duration(remoteJWKsFetchTimeout(consumer)) * time.Millisecond)
+	remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)] = state
+	return true
+}
+
+func recordRemoteJWKsFetchFailure(consumer *cfg.Consumer, startedAt time.Time, now time.Time) {
+	state := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]
+	if !state.startedAt.Equal(startedAt) {
+		return
+	}
+	state.inFlight = false
+	state.startedAt = time.Time{}
+	state.deadline = time.Time{}
+	state.lastFailedAt = now
+	remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)] = state
+}
+
+func cacheRemoteJWKs(consumer *cfg.Consumer, keys *jose.JSONWebKeySet, startedAt time.Time, now time.Time) {
+	cacheKey := remoteJWKsCacheKeyForConsumer(consumer)
+	state := remoteJWKsFetchStates[cacheKey]
+	if !state.startedAt.Equal(startedAt) {
+		return
+	}
+	remoteJWKsCache[cacheKey] = cachedJWKs{
+		keys:      keys,
+		fetchedAt: now,
+	}
+	state.inFlight = false
+	state.startedAt = time.Time{}
+	state.deadline = time.Time{}
+	state.lastFailedAt = time.Time{}
+	remoteJWKsFetchStates[cacheKey] = state
+}

--- a/plugins/wasm-go/extensions/jwt-auth/handler/jwks_cache_test.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/jwks_cache_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/jwt-auth/config"
+)
+
+func cacheRemoteJWKsForTest(name, uri, raw string, expiresAt time.Time) {
+	consumer := remoteJWKsTestConsumer(name, uri)
+	fetchedAt := expiresAt.Add(-time.Duration(*consumer.JWKsCacheDuration) * time.Second)
+	cacheRemoteJWKsFetchedAtForTest(name, uri, raw, fetchedAt)
+}
+
+func cacheRemoteJWKsFetchedAtForTest(name, uri, raw string, fetchedAt time.Time) {
+	consumer := remoteJWKsTestConsumer(name, uri)
+	keys, err := parseJWKs(raw)
+	if err != nil {
+		panic(err)
+	}
+	remoteJWKsCache[remoteJWKsCacheKeyForConsumer(consumer)] = cachedJWKs{keys: keys, fetchedAt: fetchedAt}
+}
+
+func markRemoteJWKsFetchFailedForTest(name, uri string, at time.Time) {
+	consumer := remoteJWKsTestConsumer(name, uri)
+	remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)] = remoteJWKsFetchState{lastFailedAt: at}
+}
+
+func markRemoteJWKsFetchInFlightForTest(name, uri string) {
+	consumer := remoteJWKsTestConsumer(name, uri)
+	deadline := time.Now().Add(time.Duration(*consumer.JWKsFetchTimeout) * time.Millisecond)
+	remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)] = remoteJWKsFetchState{inFlight: true, deadline: deadline}
+}
+
+func markRemoteJWKsStaleFetchInFlightForTest(name, uri string) {
+	consumer := remoteJWKsTestConsumer(name, uri)
+	deadline := time.Now().Add(-time.Millisecond)
+	remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)] = remoteJWKsFetchState{inFlight: true, deadline: deadline}
+}
+
+func clearRemoteJWKsCacheForTest() {
+	remoteJWKsCache = map[remoteJWKsCacheKey]cachedJWKs{}
+	remoteJWKsFetchStates = map[remoteJWKsCacheKey]remoteJWKsFetchState{}
+}
+
+func remoteJWKsTestConsumer(name, uri string) *config.Consumer {
+	remote := &config.RemoteJWKs{
+		ServiceName: "auth.example.com.dns",
+		ServiceHost: "auth.example.com",
+		ServicePort: int64Ptr(443),
+		Path:        "/.well-known/jwks.json",
+	}
+	if parsed, err := url.Parse(uri); err == nil && parsed.Hostname() != "" {
+		remote.ServiceName = parsed.Hostname() + ".dns"
+		remote.ServiceHost = parsed.Hostname()
+		remote.Path = parsed.RequestURI()
+		if parsed.Port() != "" {
+			port, err := strconv.ParseInt(parsed.Port(), 10, 64)
+			if err == nil {
+				remote.ServicePort = &port
+			}
+		} else if parsed.Scheme == "http" {
+			remote.ServicePort = int64Ptr(80)
+		}
+	}
+	return &config.Consumer{
+		Name:              name,
+		RemoteJWKs:        remote,
+		JWKsCacheDuration: &config.DefaultJWKsCacheDuration,
+		JWKsFetchTimeout:  &config.DefaultJWKsFetchTimeout,
+	}
+}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}

--- a/plugins/wasm-go/extensions/jwt-auth/handler/remote_jwks_test.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/remote_jwks_test.go
@@ -1,0 +1,457 @@
+// Copyright (c) 2023 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/jwt-auth/config"
+)
+
+func TestParseRemoteJWKsRejectsInvalidKeySets(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "invalid json", raw: `{"keys":[`},
+		{name: "empty key set", raw: `{"keys":[]}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseJWKs(tt.raw); err == nil {
+				t.Fatalf("expected %s to be rejected", tt.name)
+			}
+		})
+	}
+}
+
+func TestParseRemoteJWKsRejectsOversizedResponses(t *testing.T) {
+	raw := strings.Repeat(" ", maxRemoteJWKsResponseSize+1) + JWKs
+	if _, err := parseRemoteJWKsResponse(raw); err == nil {
+		t.Fatalf("expected oversized remote jwks response to be rejected")
+	}
+}
+
+func TestRemoteJWKsFetchClusterUsesConfiguredServiceReference(t *testing.T) {
+	port := int64(8443)
+	cluster, path, err := remoteJWKsFetchCluster(&config.Consumer{
+		Name: "consumer-remote",
+		RemoteJWKs: &config.RemoteJWKs{
+			ServiceName: "issuer-jwks.dns",
+			ServiceHost: "auth.example.com",
+			ServicePort: &port,
+			Path:        "/.well-known/jwks.json",
+		},
+	})
+	if err != nil {
+		t.Fatalf("remoteJWKsFetchCluster returned error: %v", err)
+	}
+	if cluster.FQDN != "issuer-jwks.dns" {
+		t.Fatalf("unexpected cluster FQDN: %q", cluster.FQDN)
+	}
+	if cluster.Host != "auth.example.com" {
+		t.Fatalf("expected bare host for authority, got: %q", cluster.Host)
+	}
+	if cluster.Port != 8443 {
+		t.Fatalf("unexpected cluster port: %d", cluster.Port)
+	}
+	if path != "/.well-known/jwks.json" {
+		t.Fatalf("unexpected request path: %q", path)
+	}
+}
+
+func TestFetchRemoteJWKsDispatchesConfiguredRequest(t *testing.T) {
+	oldDispatch := dispatchRemoteJWKsHTTPCall
+	var gotCluster string
+	var gotHeaders [][2]string
+	var gotTimeout uint32
+	dispatchRemoteJWKsHTTPCall = func(cluster string, headers [][2]string, body []byte, trailers [][2]string, timeout uint32, callback func(int, int, int)) (uint32, error) {
+		gotCluster = cluster
+		gotHeaders = headers
+		gotTimeout = timeout
+		return 1, nil
+	}
+	defer func() {
+		dispatchRemoteJWKsHTTPCall = oldDispatch
+		clearRemoteJWKsCacheForTest()
+	}()
+
+	timeout := int64(2500)
+	port := int64(8443)
+	consumer := &config.Consumer{
+		Name:             "consumer-remote",
+		JWKsFetchTimeout: &timeout,
+		RemoteJWKs: &config.RemoteJWKs{
+			ServiceName: "issuer-jwks.dns",
+			ServiceHost: "auth.example.com",
+			ServicePort: &port,
+			Path:        "/.well-known/jwks.json",
+		},
+	}
+	if err := fetchRemoteJWKs(consumer, &testLogger{T: t}, func() {
+		t.Fatalf("callback should not run without an HTTP response")
+	}); err != nil {
+		t.Fatalf("fetchRemoteJWKs returned error: %v", err)
+	}
+
+	if gotCluster != "outbound|8443||issuer-jwks.dns" {
+		t.Fatalf("unexpected cluster: %q", gotCluster)
+	}
+	if gotTimeout != uint32(timeout) {
+		t.Fatalf("unexpected timeout: %d", gotTimeout)
+	}
+	wantHeaders := map[string]string{
+		"Accept":     "application/json",
+		":method":    "GET",
+		":path":      "/.well-known/jwks.json",
+		":authority": "auth.example.com:8443",
+	}
+	for _, header := range gotHeaders {
+		if want, ok := wantHeaders[header[0]]; ok {
+			if header[1] != want {
+				t.Fatalf("unexpected %s header: %q", header[0], header[1])
+			}
+			delete(wantHeaders, header[0])
+		}
+	}
+	if len(wantHeaders) != 0 {
+		t.Fatalf("missing dispatch headers: %v", wantHeaders)
+	}
+}
+
+func TestRemoteJWKsFetchClusterRejectsMissingPath(t *testing.T) {
+	_, _, err := remoteJWKsFetchCluster(&config.Consumer{Name: "consumer-remote", RemoteJWKs: &config.RemoteJWKs{ServiceName: "issuer-jwks.dns"}})
+	if err == nil {
+		t.Fatalf("expected remoteJWKsFetchCluster to reject remote_jwks without path")
+	}
+}
+
+func TestRemoteJWKsDefaultServicePortIsHTTPS(t *testing.T) {
+	if got := remoteJWKsServicePort(&config.RemoteJWKs{}); got != 443 {
+		t.Fatalf("expected default remote jwks service port 443, got: %d", got)
+	}
+}
+
+func TestPruneRemoteJWKsCacheRemovesInactiveEntries(t *testing.T) {
+	active := remoteJWKsTestConsumer("active", "https://active.example.com/.well-known/jwks.json")
+	inactive := remoteJWKsTestConsumer("inactive", "https://inactive.example.com/.well-known/jwks.json")
+	now := time.Now()
+	cacheRemoteJWKsFetchedAtForTest(active.Name, "https://active.example.com/.well-known/jwks.json", JWKs, now)
+	cacheRemoteJWKsFetchedAtForTest(inactive.Name, "https://inactive.example.com/.well-known/jwks.json", JWKs, now)
+	markRemoteJWKsFetchFailedForTest(inactive.Name, "https://inactive.example.com/.well-known/jwks.json", now)
+	defer clearRemoteJWKsCacheForTest()
+
+	PruneRemoteJWKsCache([]*config.Consumer{active})
+
+	if _, ok := remoteJWKsCache[remoteJWKsCacheKeyForConsumer(active)]; !ok {
+		t.Fatalf("expected active remote jwks cache entry to remain")
+	}
+	if _, ok := remoteJWKsCache[remoteJWKsCacheKeyForConsumer(inactive)]; ok {
+		t.Fatalf("expected inactive remote jwks cache entry to be pruned")
+	}
+	if _, ok := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(inactive)]; ok {
+		t.Fatalf("expected inactive remote jwks fetch state to be pruned")
+	}
+}
+
+func TestRemoteJWKsCacheExpiryReturnsCacheMiss(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	cacheRemoteJWKsForTest("consumer-remote", uri, JWKs, time.Now().Add(-time.Minute))
+	defer clearRemoteJWKsCacheForTest()
+
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	if _, err := consumerJWKs(consumer, time.Now()); !isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("expected expired remote jwks to return cache miss, got: %v", err)
+	}
+}
+
+func TestRemoteJWKsCacheExpiryAfterSuccessDoesNotThrottleRefresh(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	now := time.Now()
+	cacheRemoteJWKsForTest("consumer-remote", uri, JWKs, now.Add(-time.Second))
+	defer clearRemoteJWKsCacheForTest()
+
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	if _, err := consumerJWKs(consumer, now); !isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("expected expired remote jwks to request refresh, got: %v", err)
+	}
+}
+
+func TestRemoteJWKsSuccessClearsRecentFailureThrottle(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	now := time.Now()
+	markRemoteJWKsFetchFailedForTest("consumer-remote", uri, now.Add(-3*time.Second))
+	keys, err := parseJWKs(JWKs)
+	if err != nil {
+		t.Fatalf("parseJWKs returned error: %v", err)
+	}
+	cacheRemoteJWKs(remoteJWKsTestConsumer("consumer-remote", uri), keys, time.Time{}, now.Add(-2*time.Second))
+	defer clearRemoteJWKsCacheForTest()
+
+	cacheDuration := int64(1)
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	consumer.JWKsCacheDuration = &cacheDuration
+	if _, err := consumerJWKs(consumer, now); !isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("expected expired remote jwks to request refresh after a later success, got: %v", err)
+	}
+}
+
+func TestRemoteJWKsExpiredCacheServedWhileRefreshInFlight(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	now := time.Now()
+	cacheRemoteJWKsFetchedAtForTest("consumer-remote", uri, JWKs, now.Add(-time.Minute))
+	markRemoteJWKsFetchInFlightForTest("consumer-remote", uri)
+	defer clearRemoteJWKsCacheForTest()
+
+	cacheDuration := int64(1)
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	consumer.JWKsCacheDuration = &cacheDuration
+	keys, err := consumerJWKs(consumer, now)
+	if err != nil {
+		t.Fatalf("expected expired remote jwks to be served while refresh is in flight, got: %v", err)
+	}
+	if len(keys.Keys) == 0 {
+		t.Fatalf("expected cached keys")
+	}
+}
+
+func TestRemoteJWKsRecentFailureThrottlesCacheMiss(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	now := time.Now()
+	markRemoteJWKsFetchFailedForTest("consumer-remote", uri, now)
+	defer clearRemoteJWKsCacheForTest()
+
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	if _, err := consumerJWKs(consumer, now.Add(time.Second)); !isRemoteJWKsRefreshThrottled(err) {
+		t.Fatalf("expected recent remote jwks fetch to be throttled, got: %v", err)
+	}
+}
+
+func TestRemoteJWKsInFlightFetchThrottlesCacheMiss(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	markRemoteJWKsFetchInFlightForTest("consumer-remote", uri)
+	defer clearRemoteJWKsCacheForTest()
+
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	if _, err := consumerJWKs(consumer, time.Now()); !isRemoteJWKsRefreshThrottled(err) {
+		t.Fatalf("expected in-flight remote jwks fetch to be throttled, got: %v", err)
+	}
+}
+
+func TestRemoteJWKsPreDispatchErrorDoesNotThrottleURI(t *testing.T) {
+	consumer := &config.Consumer{Name: "consumer-remote"}
+	err := fetchRemoteJWKs(consumer, &testLogger{T: t}, func() {
+		t.Fatalf("callback should not run on pre-dispatch validation failure")
+	})
+	defer clearRemoteJWKsCacheForTest()
+
+	if err == nil {
+		t.Fatalf("expected missing remote_jwks to fail before dispatch")
+	}
+	state := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]
+	if !state.lastFailedAt.IsZero() {
+		t.Fatalf("pre-dispatch error should not update remote jwks failure throttle")
+	}
+}
+
+func TestRemoteJWKsDispatchErrorFailsClosedAndThrottles(t *testing.T) {
+	consumer := remoteJWKsTestConsumer("consumer-remote", "https://auth.example.com/.well-known/jwks.json")
+	oldDispatch := dispatchRemoteJWKsHTTPCall
+	dispatchRemoteJWKsHTTPCall = func(string, [][2]string, []byte, [][2]string, uint32, func(int, int, int)) (uint32, error) {
+		return 0, errors.New("cluster not found")
+	}
+	defer func() {
+		dispatchRemoteJWKsHTTPCall = oldDispatch
+		clearRemoteJWKsCacheForTest()
+	}()
+
+	err := fetchRemoteJWKs(consumer, &testLogger{T: t}, func() {
+		t.Fatalf("callback should not run when dispatch fails inline")
+	})
+	if err == nil {
+		t.Fatalf("expected inline dispatch error")
+	}
+	if _, err := consumerJWKs(consumer, time.Now()); !isRemoteJWKsRefreshThrottled(err) {
+		t.Fatalf("expected inline dispatch failure to throttle later fetches, got: %v", err)
+	}
+	if state := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]; state.inFlight {
+		t.Fatalf("inline dispatch failure should not leave an in-flight fetch")
+	}
+}
+
+func TestRemoteJWKsStaleInFlightFetchAllowsCacheMiss(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	markRemoteJWKsStaleFetchInFlightForTest("consumer-remote", uri)
+	defer clearRemoteJWKsCacheForTest()
+
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	if _, err := consumerJWKs(consumer, time.Now()); !isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("expected stale in-flight remote jwks fetch to allow retry, got: %v", err)
+	}
+}
+
+func TestRemoteJWKsFailureThrottleIsSharedByURI(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	now := time.Now()
+	markRemoteJWKsFetchFailedForTest("consumer-short", uri, now)
+	defer clearRemoteJWKsCacheForTest()
+
+	cacheDuration := int64(120)
+	consumer := remoteJWKsTestConsumer("consumer-long", uri)
+	consumer.JWKsCacheDuration = &cacheDuration
+	if _, err := consumerJWKs(consumer, now.Add(time.Second)); !isRemoteJWKsRefreshThrottled(err) {
+		t.Fatalf("expected recent remote jwks failure to throttle all consumers for same URI, got: %v", err)
+	}
+}
+
+func TestRemoteJWKsCacheIsSharedByURIWithConsumerSpecificExpiry(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	now := time.Now()
+	cacheRemoteJWKsFetchedAtForTest("consumer-short", uri, JWKs, now.Add(-time.Minute))
+	defer clearRemoteJWKsCacheForTest()
+
+	cacheDuration := int64(120)
+	consumer := remoteJWKsTestConsumer("consumer-long", uri)
+	consumer.JWKsCacheDuration = &cacheDuration
+	if _, err := consumerJWKs(consumer, now); err != nil {
+		t.Fatalf("expected consumer with longer cache duration to reuse shared remote jwks, got: %v", err)
+	}
+
+	cacheDuration = int64(30)
+	consumer.JWKsCacheDuration = &cacheDuration
+	if _, err := consumerJWKs(consumer, now); !isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("expected consumer with shorter cache duration to expire shared remote jwks, got: %v", err)
+	}
+
+	cacheDuration = int64(120)
+	consumer.JWKsCacheDuration = &cacheDuration
+	if _, err := consumerJWKs(consumer, now); err != nil {
+		t.Fatalf("expected shorter cache duration miss not to evict shared remote jwks for longer duration, got: %v", err)
+	}
+}
+
+func TestStaleRemoteJWKsFetchFailureDoesNotClearNewInFlightFetch(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	now := time.Now()
+	firstStartedAt := now.Add(-2 * time.Second)
+	secondStartedAt := now
+
+	recordRemoteJWKsFetchStart(consumer, firstStartedAt)
+	recordRemoteJWKsFetchStart(consumer, secondStartedAt)
+	recordRemoteJWKsFetchFailure(consumer, firstStartedAt, now.Add(time.Millisecond))
+	defer clearRemoteJWKsCacheForTest()
+
+	if !remoteJWKsFetchInFlight(consumer, now.Add(2*time.Millisecond)) {
+		t.Fatalf("expected stale callback not to clear newer in-flight fetch")
+	}
+}
+
+func TestRemoteJWKsFetchStartDoesNotOverwriteActiveInFlightFetch(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	now := time.Now()
+	defer clearRemoteJWKsCacheForTest()
+
+	if !recordRemoteJWKsFetchStart(consumer, now) {
+		t.Fatalf("expected first remote jwks fetch start to be recorded")
+	}
+	if recordRemoteJWKsFetchStart(consumer, now.Add(time.Millisecond)) {
+		t.Fatalf("expected active in-flight fetch to reject a second start")
+	}
+
+	state := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]
+	if !state.startedAt.Equal(now) {
+		t.Fatalf("expected original fetch start time to be preserved")
+	}
+}
+
+func TestStaleRemoteJWKsFailureDoesNotClearNewInFlightFetch(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	now := time.Now()
+	firstStartedAt := now.Add(-2 * time.Second)
+	secondStartedAt := now
+	defer clearRemoteJWKsCacheForTest()
+
+	recordRemoteJWKsFetchStart(consumer, firstStartedAt)
+	recordRemoteJWKsFetchStart(consumer, secondStartedAt)
+	recordRemoteJWKsFetchFailure(consumer, firstStartedAt, now.Add(time.Millisecond))
+
+	state := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]
+	if !state.inFlight || !state.startedAt.Equal(secondStartedAt) {
+		t.Fatalf("expected stale failure not to clear newer in-flight fetch")
+	}
+	if !state.lastFailedAt.IsZero() {
+		t.Fatalf("expected stale failure not to reintroduce failure throttle")
+	}
+}
+
+func TestStaleRemoteJWKsFetchSuccessDoesNotOverwriteNewerCache(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	now := time.Now()
+	firstStartedAt := now.Add(-2 * time.Second)
+	secondStartedAt := now
+	staleKeys, err := parseJWKs(JWKs)
+	if err != nil {
+		t.Fatalf("parseJWKs returned error: %v", err)
+	}
+	freshKeys, err := parseJWKs(`{"keys":[{"kty":"RSA","kid":"fresh","n":"pFKAKJ0V3vFwGTvBSHbPwrNdvPyr-zMTh7Y9IELFIMNUQfG9_d2D1wZcrX5CPvtEISHin3GdPyfqEX6NjPyqvCLFTuNh80-r5Mvld-A5CHwITZXz5krBdqY5Z0wu64smMbzst3HNxHbzLQvHUY-KS6hceOB84d9B4rhkIJEEAWxxIA7yPJYjYyIC_STpPddtJkkweVvoa0m0-_FQkDFsbRS0yGgMNG4-uc7qLIU4kSwMQWcw1Rwy39LUDP4zNzuZABbWsDDBsMlVUaszRdKIlk5AQ-Fkah3E247dYGUQjSQ0N3dFLlMDv_e62BT3IBXGLg7wvGosWFNT_LpIenIW6Q","e":"AQAB"}]}`)
+	if err != nil {
+		t.Fatalf("parseJWKs returned error: %v", err)
+	}
+
+	recordRemoteJWKsFetchStart(consumer, firstStartedAt)
+	recordRemoteJWKsFetchStart(consumer, secondStartedAt)
+	cacheRemoteJWKs(consumer, freshKeys, secondStartedAt, now.Add(time.Millisecond))
+	cacheRemoteJWKs(consumer, staleKeys, firstStartedAt, now.Add(2*time.Millisecond))
+	defer clearRemoteJWKsCacheForTest()
+
+	cached := remoteJWKsCache[remoteJWKsCacheKeyForConsumer(consumer)]
+	if got := cached.keys.Keys[0].KeyID; got != "fresh" {
+		t.Fatalf("expected stale success not to overwrite newer cache, got key id: %q", got)
+	}
+}
+
+func TestStaleRemoteJWKsFetchFailureDoesNotThrottleAfterNewerSuccess(t *testing.T) {
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	now := time.Now()
+	firstStartedAt := now.Add(-2 * time.Second)
+	secondStartedAt := now
+	keys, err := parseJWKs(JWKs)
+	if err != nil {
+		t.Fatalf("parseJWKs returned error: %v", err)
+	}
+
+	recordRemoteJWKsFetchStart(consumer, firstStartedAt)
+	recordRemoteJWKsFetchStart(consumer, secondStartedAt)
+	cacheRemoteJWKs(consumer, keys, secondStartedAt, now.Add(time.Millisecond))
+	recordRemoteJWKsFetchFailure(consumer, firstStartedAt, now.Add(2*time.Millisecond))
+	defer clearRemoteJWKsCacheForTest()
+
+	state := remoteJWKsFetchStates[remoteJWKsCacheKeyForConsumer(consumer)]
+	if !state.lastFailedAt.IsZero() {
+		t.Fatalf("expected stale failure not to reintroduce throttle after newer success")
+	}
+	if _, ok := remoteJWKsCache[remoteJWKsCacheKeyForConsumer(consumer)]; !ok {
+		t.Fatalf("expected newer success cache entry to be preserved")
+	}
+}

--- a/plugins/wasm-go/extensions/jwt-auth/handler/verify.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/verify.go
@@ -15,7 +15,8 @@
 package handler
 
 import (
-	"encoding/json"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -31,6 +32,12 @@ var protectionSpace = "MSE Gateway" // 认证失败时，返回响应头 WWW-Aut
 type ErrDenied struct {
 	msg    string
 	denied func() types.Action
+}
+
+type logSafeJWT string
+
+type verifiedConsumer struct {
+	claims map[string]any
 }
 
 type Logger interface {
@@ -61,36 +68,72 @@ func (e *ErrDenied) Error() string {
 	return e.msg
 }
 
-func consumerVerify(consumer *cfg.Consumer, verifyTime time.Time, header HeaderProvider, log Logger) error {
-	tokenStr := extractToken(*consumer.KeepToken, consumer, header, log)
+func consumerVerify(consumer *cfg.Consumer, verifyTime time.Time, header HeaderProvider, log Logger) (*verifiedConsumer, error) {
+	tokenStr := extractToken(true, consumer, header, log)
 	if tokenStr == "" {
-		return &ErrDenied{
+		return nil, &ErrDenied{
 			msg:    fmt.Sprintf("jwt is missing, consumer: %s", consumer.Name),
 			denied: deniedJWTMissing,
 		}
 	}
+	tokenLogValue := jwtLogValue(tokenStr)
 
 	// 当前版本的higress暂不支持jwe，此处用ParseSigned
 	token, err := jwt.ParseSigned(tokenStr)
 	if err != nil {
-		return &ErrDenied{
+		return nil, &ErrDenied{
 			msg: fmt.Sprintf("jwt parse failed, consumer: %s, token: %s, reason: %s",
 				consumer.Name,
-				tokenStr,
+				tokenLogValue,
 				err.Error(),
 			),
 			denied: deniedJWTVerificationFails,
 		}
 	}
 
-	// 此处可以直接使用 JSON 反序列 jwks
-	jwks := jose.JSONWebKeySet{}
-	err = json.Unmarshal([]byte(consumer.JWKs), &jwks)
+	if consumer.RemoteJWKs != nil {
+		// Avoid remote JWKS fetches for tokens that cannot belong to this issuer.
+		// Signature and time claims are still verified after keys are loaded.
+		unsafeClaims := jwt.Claims{}
+		if err := token.UnsafeClaimsWithoutVerification(&unsafeClaims); err != nil {
+			return nil, &ErrDenied{
+				msg: fmt.Sprintf("jwt verify failed, consumer: %s, token: %s, reason: failed to parse unsafe claims: %s",
+					consumer.Name,
+					tokenLogValue,
+					err.Error(),
+				),
+				denied: deniedJWTVerificationFails,
+			}
+		}
+		if unsafeClaims.Issuer != consumer.Issuer {
+			return nil, &ErrDenied{
+				msg: fmt.Sprintf("jwt verify failed, consumer: %s, token: %s, reason: issuer does not equal",
+					consumer.Name,
+					tokenLogValue,
+				),
+				denied: deniedJWTVerificationFails,
+			}
+		}
+	}
+
+	jwks, err := consumerJWKs(consumer, verifyTime)
 	if err != nil {
-		return &ErrDenied{
+		if isRemoteJWKsCacheMiss(err) {
+			return nil, err
+		}
+		if isRemoteJWKsRefreshThrottled(err) {
+			return nil, &ErrDenied{
+				msg: fmt.Sprintf("jwt verify failed, consumer: %s, token: %s, reason: remote jwks refresh is throttled",
+					consumer.Name,
+					tokenLogValue,
+				),
+				denied: deniedJWTVerificationFails,
+			}
+		}
+		return nil, &ErrDenied{
 			msg: fmt.Sprintf("jwt parse failed, consumer: %s, token: %s, reason: %s",
 				consumer.Name,
-				tokenStr,
+				tokenLogValue,
 				err.Error(),
 			),
 			denied: deniedJWTVerificationFails,
@@ -98,9 +141,9 @@ func consumerVerify(consumer *cfg.Consumer, verifyTime time.Time, header HeaderP
 	}
 
 	out := jwt.Claims{}
-	rawClaims := map[string]any{}
 
-	// 提前确认 kid 状态
+	// Check the token key ID before signature verification so remote JWKS can
+	// refresh on unknown keys without trying an arbitrary cached key.
 	var kid string
 	var key jose.JSONWebKey
 	for _, header := range token.Headers {
@@ -109,13 +152,38 @@ func consumerVerify(consumer *cfg.Consumer, verifyTime time.Time, header HeaderP
 			break
 		}
 	}
-	// 没有 kid 时选择第一个 key
 	if kid == "" {
-		key = jwks.Keys[0]
-	}
-
-	keys := jwks.Key(kid)
-	if len(keys) == 0 { // kid 不存在时选择第一个 key
+		if consumer.RemoteJWKs == nil {
+			if keys := jwks.Key(""); len(keys) > 0 {
+				key = keys[0]
+			} else {
+				key = jwks.Keys[0]
+			}
+		} else if len(jwks.Keys) == 1 {
+			key = jwks.Keys[0]
+		} else {
+			return nil, &ErrDenied{
+				msg: fmt.Sprintf("jwt verify failed, consumer: %s, token: %s, reason: kid is required for multi-key remote jwks",
+					consumer.Name,
+					tokenLogValue,
+				),
+				denied: deniedJWTVerificationFails,
+			}
+		}
+	} else if keys := jwks.Key(kid); len(keys) == 0 {
+		if consumer.RemoteJWKs != nil {
+			if remoteJWKsFetchedAfter(consumer, verifyTime) {
+				return nil, &ErrDenied{
+					msg: fmt.Sprintf("jwt verify failed, consumer: %s, token: %s, reason: kid does not match remote jwks",
+						consumer.Name,
+						tokenLogValue,
+					),
+					denied: deniedJWTVerificationFails,
+				}
+			} else {
+				return nil, errRemoteJWKsCacheMiss
+			}
+		}
 		key = jwks.Keys[0]
 	} else {
 		key = keys[0]
@@ -123,24 +191,24 @@ func consumerVerify(consumer *cfg.Consumer, verifyTime time.Time, header HeaderP
 
 	// Claims 支持直接传入 jose 的 jwk
 	// 无需额外调用verify，claims内部已进行验证
-	err = token.Claims(key, &out)
+	rawClaims := map[string]any{}
+	err = token.Claims(key, &out, &rawClaims)
 	if err != nil {
-		return &ErrDenied{
+		return nil, &ErrDenied{
 			msg: fmt.Sprintf("jwt verify failed, consumer: %s, token: %s, reason: %s",
 				consumer.Name,
-				tokenStr,
+				tokenLogValue,
 				err.Error(),
 			),
 			denied: deniedJWTVerificationFails,
 		}
 	}
-	token.UnsafeClaimsWithoutVerification(&rawClaims)
 
 	if out.Issuer != consumer.Issuer {
-		return &ErrDenied{
+		return nil, &ErrDenied{
 			msg: fmt.Sprintf("jwt verify failed, consumer: %s, token: %s, reason: issuer does not equal",
 				consumer.Name,
-				tokenStr,
+				tokenLogValue,
 			),
 			denied: deniedJWTVerificationFails,
 		}
@@ -155,20 +223,35 @@ func consumerVerify(consumer *cfg.Consumer, verifyTime time.Time, header HeaderP
 		time.Duration(*consumer.ClockSkewSeconds)*time.Second,
 	)
 	if err != nil {
-		return &ErrDenied{
+		return nil, &ErrDenied{
 			msg: fmt.Sprintf("jwt verify failed, consumer: %s, token: %s, reason: %s",
 				consumer.Name,
-				tokenStr,
+				tokenLogValue,
 				err.Error(),
 			),
 			denied: deniedJWTExpired,
 		}
 	}
 
-	if consumer.ClaimsToHeaders != nil {
-		claimsToHeader(rawClaims, *consumer.ClaimsToHeaders)
+	return &verifiedConsumer{claims: rawClaims}, nil
+}
+
+func jwtLogValue(token string) logSafeJWT {
+	return logSafeJWT(token)
+}
+
+func (t logSafeJWT) String() string {
+	sum := sha256.Sum256([]byte(t))
+	return "sha256:" + hex.EncodeToString(sum[:8])
+}
+
+func applyConsumerSideEffects(consumer *cfg.Consumer, verified *verifiedConsumer, header HeaderProvider, log Logger) {
+	if !*consumer.KeepToken {
+		_ = extractToken(false, consumer, header, log)
 	}
-	return nil
+	if consumer.ClaimsToHeaders != nil {
+		claimsToHeader(verified.claims, *consumer.ClaimsToHeaders)
+	}
 }
 
 func deniedJWTMissing() types.Action {

--- a/plugins/wasm-go/extensions/jwt-auth/handler/verify_test.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/verify_test.go
@@ -1,11 +1,20 @@
 package handler
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/jwt-auth/config"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/tidwall/gjson"
 )
 
@@ -13,8 +22,62 @@ type testLogger struct {
 	T *testing.T
 }
 
+func (l *testLogger) Trace(msg string) {
+	l.T.Log(msg)
+}
+
+func (l *testLogger) Tracef(format string, args ...interface{}) {
+	l.T.Logf(format, args...)
+}
+
+func (l *testLogger) Debug(msg string) {
+	l.T.Log(msg)
+}
+
+func (l *testLogger) Debugf(format string, args ...interface{}) {
+	l.T.Logf(format, args...)
+}
+
+func (l *testLogger) Info(msg string) {
+	l.T.Log(msg)
+}
+
+func (l *testLogger) Infof(format string, args ...interface{}) {
+	l.T.Logf(format, args...)
+}
+
+func (l *testLogger) Warn(msg string) {
+	l.T.Log(msg)
+}
+
 func (l *testLogger) Warnf(format string, args ...interface{}) {
 	l.T.Logf(format, args...)
+}
+
+func (l *testLogger) Error(msg string) {
+	l.T.Log(msg)
+}
+
+func (l *testLogger) Errorf(format string, args ...interface{}) {
+	l.T.Logf(format, args...)
+}
+
+func (l *testLogger) Critical(msg string) {
+	l.T.Log(msg)
+}
+
+func (l *testLogger) Criticalf(format string, args ...interface{}) {
+	l.T.Logf(format, args...)
+}
+
+func (l *testLogger) ResetID(pluginID string) {}
+
+type recordingLogger struct {
+	entries []string
+}
+
+func (l *recordingLogger) Warnf(format string, args ...interface{}) {
+	l.entries = append(l.entries, fmt.Sprintf(format, args...))
 }
 
 type testProvider struct {
@@ -111,7 +174,7 @@ func TestConsumerVerify(t *testing.T) {
 	}
 
 	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + ES256Allow}}
-	err := consumerVerify(&config.Consumer{
+	_, err := consumerVerify(&config.Consumer{
 		Name:             "consumer1",
 		JWKs:             JWKs,
 		Issuer:           "higress-test",
@@ -126,4 +189,382 @@ func TestConsumerVerify(t *testing.T) {
 			t.Error(v.msg)
 		}
 	}
+}
+
+func TestConsumerVerifyWithCachedRemoteJWKs(t *testing.T) {
+	log := &testLogger{T: t}
+	cacheRemoteJWKsForTest("consumer-remote", "https://auth.example.com/.well-known/jwks.json", JWKs, time.Now().Add(time.Minute))
+	defer clearRemoteJWKsCacheForTest()
+
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + ES256Allow}}
+	consumer := remoteJWKsVerifyConsumer("https://auth.example.com/.well-known/jwks.json")
+	_, err := consumerVerify(consumer, time.Now(), header, log)
+
+	if err != nil {
+		if v, ok := err.(*ErrDenied); ok {
+			t.Error(v.msg)
+		} else {
+			t.Error(err)
+		}
+	}
+}
+
+func TestConsumerVerifyWithRemoteSingleKeyJWKsAllowsMissingKid(t *testing.T) {
+	log := &testLogger{T: t}
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	token, singleKeyJWKs := signedES256TokenWithoutKid(t)
+	cacheRemoteJWKsForTest("consumer-remote", uri, singleKeyJWKs, time.Now().Add(time.Minute))
+	defer clearRemoteJWKsCacheForTest()
+
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + token}}
+	consumer := remoteJWKsVerifyConsumer(uri)
+	_, err := consumerVerify(consumer, time.Now(), header, log)
+	if err != nil {
+		t.Fatalf("expected remote single-key jwks token without kid to verify, got: %v", err)
+	}
+}
+
+func TestConsumerVerifyWithRemoteMultiKeyJWKsRejectsMissingKidWhenEmptyKidKeyExists(t *testing.T) {
+	log := &testLogger{T: t}
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	token, multiKeyJWKs := signedES256TokenWithoutKidAndMultiKeyJWKsWithEmptyKid(t)
+	cacheRemoteJWKsForTest("consumer-remote", uri, multiKeyJWKs, time.Now().Add(time.Minute))
+	defer clearRemoteJWKsCacheForTest()
+
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + token}}
+	consumer := remoteJWKsVerifyConsumer(uri)
+	_, err := consumerVerify(consumer, time.Now(), header, log)
+	if err == nil {
+		t.Fatalf("expected remote multi-key jwks token without kid to fail")
+	}
+	if !strings.Contains(err.Error(), "kid is required for multi-key remote jwks") {
+		t.Fatalf("expected multi-key remote jwks missing kid denial, got: %v", err)
+	}
+	if isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("missing kid should be denied without remote jwks refresh")
+	}
+}
+
+func TestConsumerVerifyInlineMissingKidMatchesEmptyKeyID(t *testing.T) {
+	log := &testLogger{T: t}
+	token, multiKeyJWKs := signedES256TokenWithoutKidAndLaterEmptyKidJWKs(t)
+
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + token}}
+	_, err := consumerVerify(&config.Consumer{
+		Name:             "consumer-inline",
+		JWKs:             multiKeyJWKs,
+		Issuer:           "higress-test",
+		FromHeaders:      &[]config.FromHeader{{Name: "jwt", ValuePrefix: "Bearer "}},
+		ClockSkewSeconds: &config.DefaultClockSkewSeconds,
+		KeepToken:        &config.DefaultKeepToken,
+	}, time.Now(), header, log)
+	if err != nil {
+		t.Fatalf("expected inline token without kid to match empty KeyID key, got: %v", err)
+	}
+}
+
+func TestConsumerVerifyErrorUsesLogSafeToken(t *testing.T) {
+	rawToken := "not-a-jwt-secret-token"
+	_, err := consumerVerify(&config.Consumer{
+		Name:             "consumer1",
+		JWKs:             JWKs,
+		Issuer:           "higress-test",
+		FromHeaders:      &[]config.FromHeader{{Name: "jwt", ValuePrefix: "Bearer "}},
+		ClockSkewSeconds: &config.DefaultClockSkewSeconds,
+		KeepToken:        &config.DefaultKeepToken,
+	}, time.Now(), &testProvider{headerMap: map[string]string{"jwt": "Bearer " + rawToken}}, &testLogger{T: t})
+
+	if err == nil {
+		t.Fatalf("expected malformed token to fail")
+	}
+	if got, want := err.Error(), "token: "+fmt.Sprint(jwtLogValue(rawToken)); !strings.Contains(got, want) {
+		t.Fatalf("error should use log-safe jwt value: got %q, want substring %q", got, want)
+	}
+}
+
+func TestJWTLogValueUsesStableHashFormat(t *testing.T) {
+	rawToken := "not-a-jwt-secret-token"
+	if got, want := fmt.Sprint(jwtLogValue(rawToken)), "sha256:1258efc316106960"; got != want {
+		t.Fatalf("unexpected jwt log value: got %q, want %q", got, want)
+	}
+}
+
+func TestConsumerVerifyWithRemoteJWKsReturnsCacheMissOnUnknownKid(t *testing.T) {
+	log := &testLogger{T: t}
+	staleJWKs := "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"rsa\",\"n\":\"pFKAKJ0V3vFwGTvBSHbPwrNdvPyr-zMTh7Y9IELFIMNUQfG9_d2D1wZcrX5CPvtEISHin3GdPyfqEX6NjPyqvCLFTuNh80-r5Mvld-A5CHwITZXz5krBdqY5Z0wu64smMbzst3HNxHbzLQvHUY-KS6hceOB84d9B4rhkIJEEAWxxIA7yPJYjYyIC_STpPddtJkkweVvoa0m0-_FQkDFsbRS0yGgMNG4-uc7qLIU4kSwMQWcw1Rwy39LUDP4zNzuZABbWsDDBsMlVUaszRdKIlk5AQ-Fkah3E247dYGUQjSQ0N3dFLlMDv_e62BT3IBXGLg7wvGosWFNT_LpIenIW6Q\",\"e\":\"AQAB\"}]}"
+	cacheRemoteJWKsForTest("consumer-remote", "https://auth.example.com/.well-known/jwks.json", staleJWKs, time.Now().Add(time.Minute))
+	defer clearRemoteJWKsCacheForTest()
+
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + ES256Allow}}
+	consumer := remoteJWKsVerifyConsumer("https://auth.example.com/.well-known/jwks.json")
+	_, err := consumerVerify(consumer, time.Now(), header, log)
+
+	if !isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("expected remote jwks cache miss for unknown kid, got: %v", err)
+	}
+}
+
+func TestConsumerVerifyWithRemoteJWKsRejectsMissingKid(t *testing.T) {
+	log := &testLogger{T: t}
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	cacheRemoteJWKsForTest("consumer-remote", uri, JWKs, time.Now().Add(time.Minute))
+	defer clearRemoteJWKsCacheForTest()
+
+	tokenWithoutKid := jwtWithHeader(ES256Allow, `{"alg":"ES256","typ":"JWT"}`)
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + tokenWithoutKid}}
+	consumer := remoteJWKsVerifyConsumer(uri)
+	_, err := consumerVerify(consumer, time.Now(), header, log)
+
+	if err == nil {
+		t.Fatalf("expected remote jwks token without kid to fail")
+	}
+	if !strings.Contains(err.Error(), "kid is required for multi-key remote jwks") {
+		t.Fatalf("expected multi-key remote jwks missing kid denial, got: %v", err)
+	}
+	if isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("missing kid should be denied without remote jwks refresh")
+	}
+}
+
+func TestConsumerVerifyWithRemoteJWKsAllowsUnknownKidRefreshAfterRecentFetch(t *testing.T) {
+	log := &testLogger{T: t}
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	staleJWKs := "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"rsa\",\"n\":\"pFKAKJ0V3vFwGTvBSHbPwrNdvPyr-zMTh7Y9IELFIMNUQfG9_d2D1wZcrX5CPvtEISHin3GdPyfqEX6NjPyqvCLFTuNh80-r5Mvld-A5CHwITZXz5krBdqY5Z0wu64smMbzst3HNxHbzLQvHUY-KS6hceOB84d9B4rhkIJEEAWxxIA7yPJYjYyIC_STpPddtJkkweVvoa0m0-_FQkDFsbRS0yGgMNG4-uc7qLIU4kSwMQWcw1Rwy39LUDP4zNzuZABbWsDDBsMlVUaszRdKIlk5AQ-Fkah3E247dYGUQjSQ0N3dFLlMDv_e62BT3IBXGLg7wvGosWFNT_LpIenIW6Q\",\"e\":\"AQAB\"}]}"
+	now := time.Now()
+	cacheRemoteJWKsFetchedAtForTest("consumer-remote", uri, staleJWKs, now.Add(-time.Second))
+	defer clearRemoteJWKsCacheForTest()
+
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + ES256Allow}}
+	consumer := remoteJWKsVerifyConsumer(uri)
+	_, err := consumerVerify(consumer, now, header, log)
+
+	if !isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("expected cache fetched before this request not to throttle unknown kid refresh, got: %v", err)
+	}
+}
+
+func TestConsumerVerifyWithRemoteJWKsRejectsUnknownKidAfterRequestRefresh(t *testing.T) {
+	log := &testLogger{T: t}
+	uri := "https://auth.example.com/.well-known/jwks.json"
+	staleJWKs := "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"rsa\",\"n\":\"pFKAKJ0V3vFwGTvBSHbPwrNdvPyr-zMTh7Y9IELFIMNUQfG9_d2D1wZcrX5CPvtEISHin3GdPyfqEX6NjPyqvCLFTuNh80-r5Mvld-A5CHwITZXz5krBdqY5Z0wu64smMbzst3HNxHbzLQvHUY-KS6hceOB84d9B4rhkIJEEAWxxIA7yPJYjYyIC_STpPddtJkkweVvoa0m0-_FQkDFsbRS0yGgMNG4-uc7qLIU4kSwMQWcw1Rwy39LUDP4zNzuZABbWsDDBsMlVUaszRdKIlk5AQ-Fkah3E247dYGUQjSQ0N3dFLlMDv_e62BT3IBXGLg7wvGosWFNT_LpIenIW6Q\",\"e\":\"AQAB\"}]}"
+	now := time.Now()
+	cacheRemoteJWKsFetchedAtForTest("consumer-remote", uri, staleJWKs, now.Add(-time.Second))
+	defer clearRemoteJWKsCacheForTest()
+
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + ES256Allow}}
+	consumer := remoteJWKsVerifyConsumer(uri)
+	if _, err := consumerVerify(consumer, now, header, log); !isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("expected first unknown kid to request remote jwks refresh, got: %v", err)
+	}
+
+	cacheRemoteJWKsFetchedAtForTest("consumer-remote", uri, staleJWKs, now.Add(time.Millisecond))
+	_, err := consumerVerify(consumer, now, header, log)
+	if isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("unknown kid should be denied after this request already refreshed remote jwks")
+	}
+	if err == nil {
+		t.Fatalf("expected unknown kid to fail")
+	}
+}
+
+func TestConsumerVerifyWithRemoteJWKsSkipsIssuerMismatchBeforeFetch(t *testing.T) {
+	log := &testLogger{T: t}
+	defer clearRemoteJWKsCacheForTest()
+
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + ES256Allow}}
+	consumer := remoteJWKsVerifyConsumer("https://auth.example.com/.well-known/jwks.json")
+	consumer.Issuer = "other-issuer"
+	_, err := consumerVerify(consumer, time.Now(), header, log)
+
+	if isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("issuer mismatch should not trigger remote jwks fetch")
+	}
+	if err == nil {
+		t.Fatalf("expected issuer mismatch to fail")
+	}
+}
+
+func TestConsumerVerifyWithRemoteJWKsReportsUnsafeClaimsParseError(t *testing.T) {
+	log := &testLogger{T: t}
+	defer clearRemoteJWKsCacheForTest()
+
+	tokenWithMalformedPayload := jwtWithPayload(ES256Allow, "not-json")
+	header := &testProvider{headerMap: map[string]string{"jwt": "Bearer " + tokenWithMalformedPayload}}
+	consumer := remoteJWKsVerifyConsumer("https://auth.example.com/.well-known/jwks.json")
+	_, err := consumerVerify(consumer, time.Now(), header, log)
+
+	if isRemoteJWKsCacheMiss(err) {
+		t.Fatalf("malformed unsafe claims should not trigger remote jwks fetch")
+	}
+	if err == nil || !strings.Contains(err.Error(), "failed to parse unsafe claims") {
+		t.Fatalf("expected unsafe claims parse error, got: %v", err)
+	}
+}
+
+func remoteJWKsVerifyConsumer(uri string) *config.Consumer {
+	consumer := remoteJWKsTestConsumer("consumer-remote", uri)
+	consumer.Issuer = "higress-test"
+	consumer.ClaimsToHeaders = &[]config.ClaimsToHeader{}
+	consumer.FromHeaders = &[]config.FromHeader{{Name: "jwt", ValuePrefix: "Bearer "}}
+	consumer.ClockSkewSeconds = &config.DefaultClockSkewSeconds
+	consumer.KeepToken = &config.DefaultKeepToken
+	return consumer
+}
+
+func TestExtractTokenRemovesQueryParamWhenKeepTokenFalse(t *testing.T) {
+	header := &testProvider{headerMap: map[string]string{":path": "/resource?access_token=token-value&keep=1"}}
+	token := extractToken(false, &config.Consumer{
+		FromParams: &[]string{"access_token"},
+	}, header, &testLogger{T: t})
+
+	if token != "token-value" {
+		t.Fatalf("unexpected token: %q", token)
+	}
+	if got := header.headerMap[":path"]; got != "/resource?keep=1" {
+		t.Fatalf("expected token query param to be removed, got: %q", got)
+	}
+}
+
+func TestExtractFromParamsParseErrorUsesStaticLogMessage(t *testing.T) {
+	header := &testProvider{headerMap: map[string]string{":path": "%zz?access_token=secret-token"}}
+	log := &recordingLogger{}
+	token := extractFromParams(true, []string{"access_token"}, header, log)
+
+	if token != "" {
+		t.Fatalf("expected malformed path to return no token, got: %q", token)
+	}
+	if got, want := strings.Join(log.entries, "\n"), "failed to parse path: invalid request path"; got != want {
+		t.Fatalf("unexpected path parse error log: got %q, want %q", got, want)
+	}
+}
+
+func jwtWithHeader(token, headerJSON string) string {
+	parts := strings.Split(token, ".")
+	parts[0] = base64.RawURLEncoding.EncodeToString([]byte(headerJSON))
+	return strings.Join(parts, ".")
+}
+
+func jwtWithPayload(token, payload string) string {
+	parts := strings.Split(token, ".")
+	parts[1] = base64.RawURLEncoding.EncodeToString([]byte(payload))
+	return strings.Join(parts, ".")
+}
+
+func signedES256TokenWithoutKid(t *testing.T) (string, string) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.ES256,
+		Key:       privateKey,
+	}, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+
+	claims := jwt.Claims{
+		Issuer:    "higress-test",
+		Subject:   "higress-test",
+		Audience:  []string{"foo", "bar"},
+		Expiry:    jwt.NewNumericDate(time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC)),
+		NotBefore: jwt.NewNumericDate(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	token, err := jwt.Signed(signer).Claims(claims).CompactSerialize()
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	jwks, err := json.Marshal(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:   &privateKey.PublicKey,
+		KeyID: "p256",
+	}}})
+	if err != nil {
+		t.Fatalf("failed to marshal jwks: %v", err)
+	}
+	return token, string(jwks)
+}
+
+func signedES256TokenWithoutKidAndMultiKeyJWKsWithEmptyKid(t *testing.T) (string, string) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	otherKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate second key: %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.ES256,
+		Key:       privateKey,
+	}, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+
+	claims := jwt.Claims{
+		Issuer:    "higress-test",
+		Subject:   "higress-test",
+		Audience:  []string{"foo", "bar"},
+		Expiry:    jwt.NewNumericDate(time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC)),
+		NotBefore: jwt.NewNumericDate(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	token, err := jwt.Signed(signer).Claims(claims).CompactSerialize()
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	jwks, err := json.Marshal(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{
+		{Key: &privateKey.PublicKey},
+		{Key: &otherKey.PublicKey, KeyID: "other"},
+	}})
+	if err != nil {
+		t.Fatalf("failed to marshal jwks: %v", err)
+	}
+	return token, string(jwks)
+}
+
+func signedES256TokenWithoutKidAndLaterEmptyKidJWKs(t *testing.T) (string, string) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	otherKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate second key: %v", err)
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: jose.ES256,
+		Key:       privateKey,
+	}, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+
+	claims := jwt.Claims{
+		Issuer:    "higress-test",
+		Subject:   "higress-test",
+		Audience:  []string{"foo", "bar"},
+		Expiry:    jwt.NewNumericDate(time.Date(2034, 1, 1, 0, 0, 0, 0, time.UTC)),
+		NotBefore: jwt.NewNumericDate(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	token, err := jwt.Signed(signer).Claims(claims).CompactSerialize()
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	jwks, err := json.Marshal(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{
+		{Key: &otherKey.PublicKey, KeyID: "other"},
+		{Key: &privateKey.PublicKey},
+	}})
+	if err != nil {
+		t.Fatalf("failed to marshal jwks: %v", err)
+	}
+	return token, string(jwks)
 }

--- a/plugins/wasm-go/extensions/jwt-auth/main.go
+++ b/plugins/wasm-go/extensions/jwt-auth/main.go
@@ -17,7 +17,9 @@ package main
 import (
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/jwt-auth/config"
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/jwt-auth/handler"
+	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
+	"github.com/tidwall/gjson"
 )
 
 // @Name jwt-proxy
@@ -33,7 +35,29 @@ import (
 // @Contact.email ink33@smlk.org
 //
 // @Example
-// {}
+//
+//	{
+//	  "consumers": [
+//	    {
+//	      "name": "example-consumer",
+//	      "issuer": "https://issuer.example.com",
+//	      "remote_jwks": {
+//	        "service_name": "issuer.example.com.dns",
+//	        "service_host": "issuer.example.com",
+//	        "service_port": 443,
+//	        "path": "/.well-known/jwks.json"
+//	      },
+//	      "jwks_cache_duration": 600,
+//	      "jwks_fetch_timeout": 1500
+//	    },
+//	    {
+//	      "name": "inline-consumer",
+//	      "issuer": "https://issuer.example.com",
+//	      "jwks": "{\"keys\":[...]}"
+//	    }
+//	  ]
+//	}
+//
 // @End
 func main() {}
 
@@ -42,9 +66,17 @@ func init() {
 		// 插件名称
 		"jwt-auth",
 		// 为解析插件配置，设置自定义函数
-		wrapper.ParseConfigBy(config.ParseGlobalConfig),
-		wrapper.ParseOverrideConfigBy(config.ParseGlobalConfig, config.ParseRuleConfig),
+		wrapper.ParseConfigBy(parseGlobalConfig),
+		wrapper.ParseOverrideConfigBy(parseGlobalConfig, config.ParseRuleConfig),
 		// 为处理请求头，设置自定义函数
 		wrapper.ProcessRequestHeadersBy(handler.OnHTTPRequestHeaders),
 	)
+}
+
+func parseGlobalConfig(json gjson.Result, cfg *config.JWTAuthConfig, logger log.Log) error {
+	if err := config.ParseGlobalConfig(json, cfg, logger); err != nil {
+		return err
+	}
+	handler.PruneRemoteJWKsCache(cfg.Consumers)
+	return nil
 }

--- a/plugins/wasm-go/extensions/jwt-auth/main_test.go
+++ b/plugins/wasm-go/extensions/jwt-auth/main_test.go
@@ -1,0 +1,597 @@
+// Copyright (c) 2023 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/test"
+)
+
+const (
+	remoteES256Allow = "eyJhbGciOiJFUzI1NiIsImtpZCI6InAyNTYiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOlsiZm9vIiwiYmFyIl0sImV4cCI6MjAxOTY4NjQwMCwiaXNzIjoiaGlncmVzcy10ZXN0IiwibmJmIjoxNzA0MDY3MjAwLCJzdWIiOiJoaWdyZXNzLXRlc3QifQ.hm71YWfjALshUAgyOu-r9W2WBG_zfqIZZacAbc7oIH1r7dbB0sGQn3wKMWMmOzmxX0UyaVZ0KMk-HFTA1hDnBQ"
+	remoteJWKs       = "{\"keys\":[{\"kty\":\"EC\",\"kid\":\"p256\",\"crv\":\"P-256\",\"x\":\"GWym652nfByDbs4EzNpGXCkdjG03qFZHulNDHTo3YJU\",\"y\":\"5uVg_n-flqRJ5Zhf_aEKS0ow9SddTDgxGduSCgpoAZQ\"}]}"
+)
+
+func TestRemoteJWKsFetchAuthenticatesRequest(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(remoteJWKsConfig("https://auth.example.com/.well-known/jwks.json"))
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected header stop for remote JWKS fetch, got: %v", action)
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "200"}, {"content-type", "application/json"}}, []byte(remoteJWKs))
+		if got := host.GetHttpStreamAction(); got != types.ActionContinue {
+			t.Fatalf("expected request to resume, got: %v", got)
+		}
+
+		foundConsumer := false
+		for _, header := range host.GetRequestHeaders() {
+			if strings.EqualFold(header[0], "X-Mse-Consumer") && header[1] == "remote-consumer" {
+				foundConsumer = true
+			}
+		}
+		if !foundConsumer {
+			t.Fatalf("expected X-Mse-Consumer header after remote JWKS authentication")
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestRemoteJWKsFetchAuthenticatesRequestWithKeepTokenFalse(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(remoteJWKsConfigWithKeepToken("https://auth.example.com/.well-known/keep-token-false.json", false))
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected header stop for remote JWKS fetch, got: %v", action)
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "200"}, {"content-type", "application/json"}}, []byte(remoteJWKs))
+		if got := host.GetHttpStreamAction(); got != types.ActionContinue {
+			t.Fatalf("expected request to resume, got: %v", got)
+		}
+		for _, header := range host.GetRequestHeaders() {
+			if strings.EqualFold(header[0], "authorization") {
+				t.Fatalf("expected authorization header to be removed after authentication")
+			}
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestKeepTokenFalseDoesNotRemoveClaimHeaderWithSameName(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(remoteJWKsConfigWithAuthorizationClaimHeader("https://auth.example.com/.well-known/claim-header.json"))
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected header stop for remote JWKS fetch, got: %v", action)
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "200"}, {"content-type", "application/json"}}, []byte(remoteJWKs))
+		if got := host.GetHttpStreamAction(); got != types.ActionContinue {
+			t.Fatalf("expected request to resume, got: %v", got)
+		}
+		foundClaimHeader := false
+		for _, header := range host.GetRequestHeaders() {
+			if strings.EqualFold(header[0], "authorization") && header[1] == "higress-test" {
+				foundClaimHeader = true
+			}
+		}
+		if !foundClaimHeader {
+			t.Fatalf("expected claims_to_headers to replace authorization after token removal")
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestRemoteJWKsMissDoesNotBlockLaterInlineConsumer(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(remoteMissThenInlineConfig())
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.ActionContinue {
+			t.Fatalf("expected later inline consumer to continue request, got: %v", action)
+		}
+
+		foundConsumer := false
+		for _, header := range host.GetRequestHeaders() {
+			if strings.EqualFold(header[0], "X-Mse-Consumer") && header[1] == "inline-consumer" {
+				foundConsumer = true
+			}
+		}
+		if !foundConsumer {
+			t.Fatalf("expected X-Mse-Consumer header for inline consumer")
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestUnmatchedRouteBypassesWhenRulesExistAndGlobalAuthUnset(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(routeScopedInlineConfig())
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "public.example.com"},
+			{":path", "/health"},
+			{":method", "GET"},
+		})
+		if action != types.ActionContinue {
+			t.Fatalf("expected unmatched route to bypass auth when global_auth is unset, got: %v", action)
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestRemoteJWKsFetchFailureThrottlesNextRequest(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(remoteJWKsConfig("https://auth.example.com/.well-known/failing-jwks.json"))
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected header stop for remote JWKS fetch, got: %v", action)
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "500"}}, nil)
+		host.CompleteHttp()
+
+		action = host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action == types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected recent remote JWKS failure to throttle instead of fetching again")
+		}
+		if response := host.GetLocalResponse(); response == nil {
+			t.Fatalf("expected throttled request to fail closed")
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestRemoteJWKsOnlyFetchesAllowedConsumers(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(disallowedRemoteThenAllowedRemoteConfig())
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected header stop for allowed remote JWKS fetch, got: %v", action)
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "200"}, {"content-type", "application/json"}}, []byte(remoteJWKs))
+		if got := host.GetHttpStreamAction(); got != types.ActionContinue {
+			t.Fatalf("expected request to resume, got: %v", got)
+		}
+
+		foundConsumer := false
+		for _, header := range host.GetRequestHeaders() {
+			if strings.EqualFold(header[0], "X-Mse-Consumer") && header[1] == "allowed-remote-consumer" {
+				foundConsumer = true
+			}
+		}
+		if !foundConsumer {
+			t.Fatalf("expected X-Mse-Consumer header for allowed remote consumer")
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestRemoteJWKsFetchFailureTriesNextAllowedRemoteConsumer(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(twoAllowedRemoteConsumersConfig())
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected header stop for first remote JWKS fetch, got: %v", action)
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "500"}}, nil)
+		if response := host.GetLocalResponse(); response != nil {
+			t.Fatalf("expected first remote JWKS fetch failure to try another allowed consumer")
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "200"}, {"content-type", "application/json"}}, []byte(remoteJWKs))
+		if got := host.GetHttpStreamAction(); got != types.ActionContinue {
+			t.Fatalf("expected request to resume after second remote JWKS authentication, got: %v", got)
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestRemoteJWKsFetchChainExhaustsEligibleConsumers(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(manyAllowedRemoteConsumersConfig(4))
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected header stop for first remote JWKS fetch, got: %v", action)
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "500"}}, nil)
+		if response := host.GetLocalResponse(); response != nil {
+			t.Fatalf("expected first failed fetch to try the next remote consumer")
+		}
+		host.CallOnHttpCall([][2]string{{":status", "500"}}, nil)
+		if response := host.GetLocalResponse(); response != nil {
+			t.Fatalf("expected second failed fetch to try the next remote consumer")
+		}
+		host.CallOnHttpCall([][2]string{{":status", "500"}}, nil)
+		if response := host.GetLocalResponse(); response != nil {
+			t.Fatalf("expected third failed fetch to try the next remote consumer")
+		}
+		host.CallOnHttpCall([][2]string{{":status", "500"}}, nil)
+		if response := host.GetLocalResponse(); response == nil {
+			t.Fatalf("expected chained remote JWKS fetches to stop after eligible consumers are exhausted")
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestAllowedRemoteMissTakesPriorityOverUnauthorizedInlineConsumer(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(allowedRemoteThenUnauthorizedInlineConfig())
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected allowed remote consumer to fetch before unauthorized denial, got: %v", action)
+		}
+		host.CompleteHttp()
+	})
+}
+
+func TestUnauthorizedConsumerDoesNotMutateRequestBeforeAllowedRemoteFetch(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(allowedRemoteThenMutatingUnauthorizedInlineConfig())
+		defer host.Reset()
+		if status != types.OnPluginStartStatusOK {
+			t.Fatalf("unexpected plugin start status: %v", status)
+		}
+
+		action := host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/"},
+			{":method", "GET"},
+			{"authorization", "Bearer " + remoteES256Allow},
+		})
+		if action != types.HeaderStopAllIterationAndWatermark {
+			t.Fatalf("expected allowed remote consumer to fetch before unauthorized denial, got: %v", action)
+		}
+
+		host.CallOnHttpCall([][2]string{{":status", "200"}, {"content-type", "application/json"}}, []byte(remoteJWKs))
+		if got := host.GetHttpStreamAction(); got != types.ActionContinue {
+			t.Fatalf("expected request to resume, got: %v", got)
+		}
+		for _, header := range host.GetRequestHeaders() {
+			if strings.EqualFold(header[0], "x-unauthorized-subject") {
+				t.Fatalf("unexpected header mutation from unauthorized consumer")
+			}
+			if strings.EqualFold(header[0], "authorization") {
+				t.Fatalf("expected authorization header to be removed only after allowed remote authentication")
+			}
+		}
+		host.CompleteHttp()
+	})
+}
+
+func remoteJWKsConfig(endpoint string) json.RawMessage {
+	return remoteJWKsConfigWithKeepToken(endpoint, true)
+}
+
+func remoteJWKsConfigWithKeepToken(endpoint string, keepToken bool) json.RawMessage {
+	data, _ := json.Marshal(map[string]any{
+		"global_auth": true,
+		"consumers": []map[string]any{{
+			"name":               "remote-consumer",
+			"issuer":             "higress-test",
+			"remote_jwks":        remoteJWKsService(endpoint),
+			"clock_skew_seconds": 2000000000,
+			"keep_token":         keepToken,
+		}},
+	})
+	return data
+}
+
+func remoteJWKsConfigWithAuthorizationClaimHeader(endpoint string) json.RawMessage {
+	data, _ := json.Marshal(map[string]any{
+		"global_auth": true,
+		"consumers": []map[string]any{{
+			"name":               "remote-consumer",
+			"issuer":             "higress-test",
+			"remote_jwks":        remoteJWKsService(endpoint),
+			"clock_skew_seconds": 2000000000,
+			"keep_token":         false,
+			"claims_to_headers": []map[string]any{{
+				"claim":  "iss",
+				"header": "authorization",
+			}},
+		}},
+	})
+	return data
+}
+
+func disallowedRemoteThenAllowedRemoteConfig() json.RawMessage {
+	data, _ := json.Marshal(map[string]any{
+		"global_auth": true,
+		"consumers": []map[string]any{
+			{
+				"name":               "disallowed-remote-consumer",
+				"issuer":             "higress-test",
+				"remote_jwks":        remoteJWKsService("https://auth.example.com/.well-known/disallowed.json"),
+				"clock_skew_seconds": 2000000000,
+			},
+			{
+				"name":               "allowed-remote-consumer",
+				"issuer":             "higress-test",
+				"remote_jwks":        remoteJWKsService("https://auth.example.com/.well-known/allowed.json"),
+				"clock_skew_seconds": 2000000000,
+			},
+		},
+		"_rules_": []map[string]any{{
+			"_match_route_": []string{"test-route-default"},
+			"allow":         []string{"allowed-remote-consumer"},
+		}},
+	})
+	return data
+}
+
+func twoAllowedRemoteConsumersConfig() json.RawMessage {
+	data, _ := json.Marshal(map[string]any{
+		"global_auth": true,
+		"consumers": []map[string]any{
+			{
+				"name":               "first-remote-consumer",
+				"issuer":             "higress-test",
+				"remote_jwks":        remoteJWKsService("https://auth.example.com/.well-known/first.json"),
+				"clock_skew_seconds": 2000000000,
+			},
+			{
+				"name":               "second-remote-consumer",
+				"issuer":             "higress-test",
+				"remote_jwks":        remoteJWKsService("https://auth.example.com/.well-known/second.json"),
+				"clock_skew_seconds": 2000000000,
+			},
+		},
+		"_rules_": []map[string]any{{
+			"_match_route_": []string{"test-route-default"},
+			"allow":         []string{"first-remote-consumer", "second-remote-consumer"},
+		}},
+	})
+	return data
+}
+
+func manyAllowedRemoteConsumersConfig(count int) json.RawMessage {
+	consumers := make([]map[string]any, 0, count)
+	allow := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		name := "remote-consumer-" + string(rune('a'+i))
+		consumers = append(consumers, map[string]any{
+			"name":               name,
+			"issuer":             "higress-test",
+			"remote_jwks":        remoteJWKsService("https://auth.example.com/.well-known/" + name + ".json"),
+			"clock_skew_seconds": 2000000000,
+		})
+		allow = append(allow, name)
+	}
+	data, _ := json.Marshal(map[string]any{
+		"global_auth": true,
+		"consumers":   consumers,
+		"_rules_": []map[string]any{{
+			"_match_route_": []string{"test-route-default"},
+			"allow":         allow,
+		}},
+	})
+	return data
+}
+
+func allowedRemoteThenUnauthorizedInlineConfig() json.RawMessage {
+	data, _ := json.Marshal(map[string]any{
+		"global_auth": true,
+		"consumers": []map[string]any{
+			{
+				"name":               "allowed-remote-consumer",
+				"issuer":             "higress-test",
+				"remote_jwks":        remoteJWKsService("https://auth.example.com/.well-known/allowed-priority.json"),
+				"clock_skew_seconds": 2000000000,
+			},
+			{
+				"name":               "unauthorized-inline-consumer",
+				"issuer":             "higress-test",
+				"jwks":               remoteJWKs,
+				"clock_skew_seconds": 2000000000,
+			},
+		},
+		"_rules_": []map[string]any{{
+			"_match_route_": []string{"test-route-default"},
+			"allow":         []string{"allowed-remote-consumer"},
+		}},
+	})
+	return data
+}
+
+func allowedRemoteThenMutatingUnauthorizedInlineConfig() json.RawMessage {
+	data, _ := json.Marshal(map[string]any{
+		"global_auth": true,
+		"consumers": []map[string]any{
+			{
+				"name":               "allowed-remote-consumer",
+				"issuer":             "higress-test",
+				"remote_jwks":        remoteJWKsService("https://auth.example.com/.well-known/allowed-mutation.json"),
+				"clock_skew_seconds": 2000000000,
+				"keep_token":         false,
+			},
+			{
+				"name":               "unauthorized-inline-consumer",
+				"issuer":             "higress-test",
+				"jwks":               remoteJWKs,
+				"clock_skew_seconds": 2000000000,
+				"keep_token":         false,
+				"claims_to_headers": []map[string]any{{
+					"claim":  "sub",
+					"header": "x-unauthorized-subject",
+				}},
+			},
+		},
+		"_rules_": []map[string]any{{
+			"_match_route_": []string{"test-route-default"},
+			"allow":         []string{"allowed-remote-consumer"},
+		}},
+	})
+	return data
+}
+
+func remoteMissThenInlineConfig() json.RawMessage {
+	data, _ := json.Marshal(map[string]any{
+		"global_auth": true,
+		"consumers": []map[string]any{
+			{
+				"name":               "remote-consumer",
+				"issuer":             "higress-test",
+				"remote_jwks":        remoteJWKsService("https://auth.example.com/.well-known/miss-before-inline.json"),
+				"clock_skew_seconds": 2000000000,
+			},
+			{
+				"name":               "inline-consumer",
+				"issuer":             "higress-test",
+				"jwks":               remoteJWKs,
+				"clock_skew_seconds": 2000000000,
+			},
+		},
+	})
+	return data
+}
+
+func routeScopedInlineConfig() json.RawMessage {
+	data, _ := json.Marshal(map[string]any{
+		"consumers": []map[string]any{{
+			"name":               "inline-consumer",
+			"issuer":             "higress-test",
+			"jwks":               remoteJWKs,
+			"clock_skew_seconds": 2000000000,
+		}},
+		"_rules_": []map[string]any{{
+			"_match_domain_": []string{"private.example.com"},
+			"allow":          []string{"inline-consumer"},
+		}},
+	})
+	return data
+}
+
+func remoteJWKsService(endpoint string) map[string]any {
+	parsed, _ := url.Parse(endpoint)
+	port := 443
+	if parsed.Scheme == "http" {
+		port = 80
+	}
+	return map[string]any{
+		"service_name": parsed.Hostname() + ".dns",
+		"service_host": parsed.Hostname(),
+		"service_port": port,
+		"path":         parsed.RequestURI(),
+	}
+}


### PR DESCRIPTION
## Summary
- Add `remote_jwks` support to wasm-go `jwt-auth` consumers as an alternative to inline `jwks`.
- Fetch, validate, cache, and refresh remote JWKS through a Higress service reference (`service_name`, `service_host`, `service_port`, `path`).
- Validate remote JWKS service configuration, including bare `service_host` plus separate `service_port`.
- Cache parsed JWKS and apply each consumer's `jwks_cache_duration` at read time.
- Serve the existing cached JWKS while a TTL refresh for the same remote service reference is in flight.
- Bound remote JWKS fetch timeout, cache duration, and response size.
- Guard stale fetch callbacks so an old response cannot clear newer fetch/cache state.
- Fail closed on fetch failures, invalid JWKS, throttled cold-cache refreshes, and unresolved key IDs. Tokens without `kid` are accepted only when the fetched JWKS contains exactly one key.
- Respect route/domain `allow` lists before triggering remote JWKS fetches.
- Apply `keep_token: false` and `claims_to_headers` side effects only after the selected authorized consumer verifies successfully.
- Document remote JWKS fields in the existing JWT plugin docs, explicitly marking them as wasm-go-only.

## Notes
- Remote JWKS responses larger than 64 KiB are rejected before calling `GetHttpCallResponseBody`.
- Cold-cache in-flight fetches and recent failures are denied locally to avoid request stampedes.
- `keep_token: false` removal is deferred until authentication succeeds; failed candidates no longer remove tokens before later consumers are checked.
- Concurrent requests during a cold remote JWKS fetch are fail-closed instead of coalesced because proxy-wasm HTTP call callbacks are bound to one stream context.

## Tests
- `go test ./...` in `plugins/wasm-go/extensions/jwt-auth`
- `git diff --check`