### PR TITLE
fix(ai-proxy): use HasSuffix instead of Contains in claude.GetApiName to prevent sub-path misidentification

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -1060,16 +1060,16 @@ func (c *claudeProvider) insertHttpContextMessage(body []byte, content string, o
 }
 
 func (c *claudeProvider) GetApiName(path string) ApiName {
-	if strings.Contains(path, PathAnthropicMessages) {
+	if strings.HasSuffix(path, PathAnthropicMessages) {
 		return ApiNameChatCompletion
 	}
-	if strings.Contains(path, PathAnthropicComplete) {
+	if strings.HasSuffix(path, PathAnthropicComplete) {
 		return ApiNameCompletion
 	}
-	if strings.Contains(path, PathOpenAIModels) {
+	if strings.HasSuffix(path, PathOpenAIModels) {
 		return ApiNameModels
 	}
-	if strings.Contains(path, PathOpenAIEmbeddings) {
+	if strings.HasSuffix(path, PathOpenAIEmbeddings) {
 		return ApiNameEmbeddings
 	}
 	return ""

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
@@ -572,6 +572,12 @@ func TestClaudeProvider_GetApiName(t *testing.T) {
 	t.Run("unknown_path", func(t *testing.T) {
 		assert.Equal(t, ApiName(""), provider.GetApiName("/unknown"))
 	})
+
+	t.Run("sub_paths_should_not_match", func(t *testing.T) {
+		assert.Equal(t, ApiName(""), provider.GetApiName("/v1/messages/count_tokens"))
+		assert.Equal(t, ApiName(""), provider.GetApiName("/v1/messages/batches"))
+		assert.Equal(t, ApiName(""), provider.GetApiName("/v1/complete/something"))
+	})
 }
 
 func TestClaudeProvider_BuildClaudeTextGenRequest_ToolRoleConversion(t *testing.T) {


### PR DESCRIPTION

  The claude provider's GetApiName previously used strings.Contains for
  path matching, causing sub-paths like /v1/messages/count_tokens and
  /v1/messages/batches to be falsely identified as /v1/messages. This
  triggered unnecessary protocol conversion on endpoints that should be
  forwarded as-is to the upstream Anthropic API.

<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did
Fix incorrect API path identification in the **ai-proxy** Claude provider.

`claudeProvider.GetApiName` matched request paths with `strings.Contains`, so any path that merely **included** `/v1/messages` (or other known suffixes) was treated as a chat-completion (`ApiNameChatCompletion`) request. Sub-paths such as:

- `/v1/messages/count_tokens`
- `/v1/messages/batches`

were misclassified. In non-original-protocol mode, `main.go` then treated them as `ApiNameAnthropicMessages` and ran Claude ↔ OpenAI body/path conversion that should only apply to `/v1/messages` itself.

This change switches matching to `strings.HasSuffix` for:

- `PathAnthropicMessages` (`/v1/messages`)
- `PathAnthropicComplete` (`/v1/complete`)
- `PathOpenAIModels` (`/v1/models`)
- `PathOpenAIEmbeddings` (`/v1/embeddings`)

[Claude API Docs](https://platform.claude.com/docs/en/api/overview)

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


## Ⅲ. Why don't you add test cases (unit test/integration test)? 

`TestClaudeProvider_GetApiName` already covers the main paths (`/v1/messages`, `/v1/complete`, etc.). This PR is a one-line-per-branch behavioral fix; adding regression cases for `/v1/messages/count_tokens` and `/v1/messages/batches` (expecting empty `ApiName`) would be straightforward and is recommended in a follow-up if reviewers prefer it in the same PR.

## Ⅳ. Describe how to verify it

1. Build or deploy ai-proxy with a Claude provider configured (`protocol: original` or auto-convert mode).
2. Send requests that should **not** be converted:
   - `POST /v1/messages/count_tokens` with a valid Anthropic count-tokens body
   - `POST /v1/messages/batches` (or other `/v1/messages/*` sub-paths)
3. Confirm:
   - `:path` is **not** rewritten to `/v1/chat/completions`
   - Request/response bodies are **not** passed through Claude ↔ OpenAI conversion
   - Upstream receives the original Anthropic path and payload
4. Regression: `POST /v1/messages` still resolves to chat completion and works as before.
5. Optional: `cd plugins/wasm-go/extensions/ai-proxy && go test ./provider -run TestClaudeProvider_GetApiName -v`

## Ⅴ. Special notes for reviews






