### PR TITLE
fix(ai-proxy): re-anchor X-HI-ORIGINAL-AUTH on first hop to fix cascaded-gateway 401

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -158,10 +158,38 @@ func initContext(ctx wrapper.HttpContext) {
 	for _, originHeader := range headerToOriginalHeaderMapping {
 		_ = proxywasm.RemoveHttpRequestHeader(originHeader)
 	}
-	originalAuth, _ := proxywasm.GetHttpRequestHeader(util.HeaderOriginalAuth)
-	if originalAuth == "" {
+
+	// Distinguish "first hop into this gateway" from "internal_redirect re-entry".
+	//
+	// Signal: x-higress-fallback-from. It is set by Envoy custom_response's
+	// RedirectPolicy on every internal_redirect within this gateway, and it
+	// survives mutateRequestHeaders on the redirected stream (it is NOT in
+	// Envoy's hardcoded strip list).
+	//
+	// Absence  => first hop. Distrust any incoming X-HI-ORIGINAL-AUTH — it may
+	//             have been set by a client or by an upstream cascaded gateway
+	//             running its own ai-proxy. Re-anchor the saved value from the
+	//             request's current Authorization, which is what this gateway
+	//             should treat as the "original" credential for later
+	//             internal_redirect hops.
+	// Presence => internal_redirect re-entry within this gateway. Leave
+	//             X-HI-ORIGINAL-AUTH alone — it preserves the value this gateway's
+	//             ai-proxy wrote on the previous pass, which key-auth needs for
+	//             re-authentication after Authorization has been replaced with
+	//             the upstream apiToken.
+	//
+	// SAFETY DEPENDENCY: this signal is reliable only when external callers
+	// cannot supply x-higress-fallback-from. For cascaded deployments where an
+	// upstream gateway may itself be in an internal_redirect chain when forwarding
+	// to this gateway, list x-higress-fallback-from (and x-hi-original-auth) in
+	// the HCM internal_only_headers as defense-in-depth.
+	fallbackFrom, _ := proxywasm.GetHttpRequestHeader(util.HeaderHigressFallbackFrom)
+	if fallbackFrom == "" {
+		_ = proxywasm.RemoveHttpRequestHeader(util.HeaderOriginalAuth)
 		value, _ := proxywasm.GetHttpRequestHeader(util.HeaderAuthorization)
-		ctx.SetContext(ctxOriginalAuth, value)
+		if value != "" {
+			ctx.SetContext(ctxOriginalAuth, value)
+		}
 	}
 }
 

--- a/plugins/wasm-go/extensions/ai-proxy/util/http.go
+++ b/plugins/wasm-go/extensions/ai-proxy/util/http.go
@@ -19,6 +19,27 @@ const (
 	HeaderOriginalHost = "X-ENVOY-ORIGINAL-HOST"
 	HeaderOriginalAuth = "X-HI-ORIGINAL-AUTH"
 
+	// HeaderHigressFallbackFrom is set by Envoy custom_response's RedirectPolicy
+	// on internal_redirect (request_headers_to_add) and survives the redirect's
+	// mutateRequestHeaders pass (it is NOT in Envoy's hardcoded strip list). So
+	// its presence at the wasm boundary is a usable signal that the current
+	// filter-chain pass is an internal_redirect re-entry within this gateway.
+	//
+	// SAFETY DEPENDENCY: this header is NOT spoofing-proof unless the listener
+	// lists it in internal_only_headers. An upstream gateway that is itself in
+	// the middle of an internal_redirect chain may forward this header through
+	// to this gateway, causing this gateway's first hop to be misclassified as
+	// a re-entry. Operators relying on cascaded ai-proxy gateways should add
+	// `x-higress-fallback-from` and `x-hi-original-auth` to the listener's
+	// internal_only_headers list as defense-in-depth.
+	//
+	// Note: x-envoy-original-url (which Envoy sets on every internal_redirect
+	// in router.cc) is NOT usable here, because Envoy's recreateStream re-runs
+	// mutateRequestHeaders on the redirected stream and strips x-envoy-original-url
+	// from the hardcoded "headers to be stripped from edge AND intermediate-hop
+	// external requests" list — so wasm filters never see it on a redirect.
+	HeaderHigressFallbackFrom = "x-higress-fallback-from"
+
 	MimeTypeTextPlain       = "text/plain"
 	MimeTypeApplicationJson = "application/json"
 )


### PR DESCRIPTION
## Ⅰ. Describe what this PR does / why we need it

Fix a 401 `Invalid_API_key` returned by `key-auth` on shadow / fallback routes when this gateway is fronted by **another gateway that also runs `ai-proxy`** (cascaded-gateway architecture), or when a client happens to send the internal-protocol header `X-HI-ORIGINAL-AUTH` itself.

### Background

`ai-proxy` uses `X-HI-ORIGINAL-AUTH` as a private internal-protocol header to remember the request's original `Authorization` across an Envoy `internal_redirect`, so that `key-auth` can re-authenticate on the redirected hop after `Authorization` has been replaced with the upstream's apiToken.

The previous `initContext` logic was:

```go
originalAuth, _ := proxywasm.GetHttpRequestHeader(util.HeaderOriginalAuth)
if originalAuth == "" {
    value, _ := proxywasm.GetHttpRequestHeader(util.HeaderAuthorization)
    ctx.SetContext(ctxOriginalAuth, value)
}
```

This treats a non-empty incoming `X-HI-ORIGINAL-AUTH` as if it must have been written by **this** gateway's previous filter-chain pass — but the header is **not** listed in the listener's `internal_only_headers`, so it can also arrive set by:

1. An upstream gateway running its own `ai-proxy` (cascaded-gateway setup)
2. A client that simply puts the header on its request

### Symptom

In a cascaded setup, Gateway-1's `ai-proxy` saves the client's original token into `X-HI-ORIGINAL-AUTH` and forwards to Gateway-2 with a different `Authorization` (Gateway-1's outbound apiToken, which happens to be a valid consumer credential at Gateway-2). At Gateway-2:

- **Origin hop**: `key-auth` passes on `Authorization` (matches a consumer); `ai-proxy.initContext` sees the **non-empty** incoming `X-HI-ORIGINAL-AUTH` (Gateway-1's value), takes the `originalAuth != ""` branch, and skips re-anchoring. `Authorization` then gets replaced with the upstream apiToken; `X-HI-ORIGINAL-AUTH` keeps Gateway-1's value through to upstream.
- **Upstream returns 4xx**, `custom_response` `RedirectPolicy` triggers `internal_redirect` to `shadow-level-N`. Envoy preserves request headers across `internal_redirect`, so the new pass enters with `Authorization=<upstream-sk>` and `X-HI-ORIGINAL-AUTH=<Gateway-1's value, not a valid consumer credential here>`.
- `key-auth` on the shadow hop checks `[X-HI-ORIGINAL-AUTH, Authorization]`. Neither matches any consumer → **401 `Invalid_API_key`**.
- The access log records `consumer=<set-on-origin>` (header is preserved across redirect) **alongside** `response_code=401` + `response_code_details=internal_redirect:via_wasm::...key-auth::Request_denied_by_Key_Auth_check._Invalid_API_key`. This is the paradox observed in production.

### Reproduction

A 2-envoy local reproduction (envoy-1 emulates the front gateway via a Lua filter that sets `X-HI-ORIGINAL-AUTH = <client_token>` and rewrites `Authorization` to the downstream's consumer credential, then forwards to envoy-2 running the full production filter chain + the production `ai-proxy.wasm`) deterministically reproduces the bug:

- **Pre-fix**: `HTTP 401`, redirect chain breaks at the first shadow level, only the origin hop hits the upstream.
- **Post-fix**: `HTTP 400` (the mock upstream's response), every hop in the redirect chain reaches the upstream, `consumer=...` set on every hop.

## Ⅱ. The fix

Distinguish "first hop into this gateway" from "internal_redirect re-entry" using `x-higress-fallback-from`, which **is** listed in the listener's `internal_only_headers` (set by `custom_response`'s `RedirectPolicy.request_headers_to_add`) and therefore cannot be supplied externally.

| Signal | Branch | Action |
|---|---|---|
| `x-higress-fallback-from` absent | First hop | Distrust any incoming `X-HI-ORIGINAL-AUTH` (could be from a client or an upstream cascaded gateway). Actively `Remove` it, then re-anchor `ctxOriginalAuth` from the request's current `Authorization`. |
| `x-higress-fallback-from` present | `internal_redirect` re-entry | Leave `X-HI-ORIGINAL-AUTH` alone; per-request `ctx` is fresh, so `saveContextsToHeaders` will skip writing — the value preserved across the redirect (set by this gateway's previous pass) flows to `key-auth` for re-authentication. |

`saveContextsToHeaders` is **unchanged**.

### Code change

`util/http.go` — add the constant:
```go
HeaderHigressFallbackFrom = "x-higress-fallback-from"
```

`main.go` `initContext` — replace the `if originalAuth == ""` branch with the first-hop / re-entry distinction (see the diff in this PR for the exact rewrite, including documentation comment).

## Ⅲ. Cases covered

| # | Scenario | Pre-fix | Post-fix |
|---|---|---|---|
| 1 | Single gateway, no client `X-HI-ORIGINAL-AUTH` | OK | OK (unchanged behavior) |
| 2 | Single gateway, client sends garbage `X-HI-ORIGINAL-AUTH` | 401 after redirect | OK — first hop overwrites |
| 3 | Cascaded gateway (upstream gw set `X-HI-ORIGINAL-AUTH`) | 401 after redirect | OK — first hop overwrites |
| 4 | `internal_redirect` re-entry within same gateway | OK | OK (preserved via fallback-from check) |
| 5 | Anonymous request + spoofed `X-HI-ORIGINAL-AUTH` | propagates garbage to upstream | actively removed; `key-auth` rejects at origin (correct) |

## Ⅳ. Notes / out of scope

- **`X-HI-ORIGINAL-AUTH` should arguably also be added to the listener's `internal_only_headers`** alongside `x-higress-fallback-from`, so Envoy strips it from external requests at the listener boundary. That is the cleanest defense-in-depth and would close a related spoofing window at the **first-hop** `key-auth` check (where, before this `ai-proxy` fix runs, a client could potentially send `X-HI-ORIGINAL-AUTH` = some other valid consumer's credential to confuse identity). This is a control-plane change (helm/EnvoyFilter template) and is left as a separate work item.
- The sibling plugin `plugins/wasm-go/extensions/api-workflow/utils/http.go:38–45` uses the same `if exist == ""` idiom on `X-HI-ORIGINAL-AUTH`. If `api-workflow` is chained before `ai-proxy` on a route with a `custom_response` redirect chain, it can exhibit the same issue. Not changed here; happy to send a follow-up.

## Ⅴ. Test plan

- [x] Cascaded reproduction (2-envoy local stack) — `HTTP 401` → `HTTP 400` after fix; every hop succeeds at `key-auth`; `X-HI-ORIGINAL-AUTH` correctly anchored to the gateway's consumer credential at every hop.
- [x] Single-gateway baseline — no behavior change for normal requests.
- [x] Spoofing — client-supplied garbage `X-HI-ORIGINAL-AUTH` is removed on first hop and never reaches upstream.
- [ ] Reviewer to confirm whether unit tests exercising `initContext` would be valuable (no existing coverage). Happy to add `wasmhost.NewTestHost` + `host.CallOnHttpRequestHeaders` table tests if requested.