### PR TITLE
fix(ai-proxy): strip anthropic-beta and anthropic-version headers in vertex passthrough

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
@@ -432,6 +432,14 @@ func (v *vertexProvider) onAnthropicMessagesRequestBody(ctx wrapper.HttpContext,
 		return nil, fmt.Errorf("unable to inject anthropic_version: %v", err)
 	}
 
+	// 剥除 Anthropic beta-only 的 body 字段, vertex 的 :rawPredict 不认这些字段会 400.
+	// 例如 Claude Code 交互模式会发 context_management (上下文压缩配置).
+	for _, betaField := range []string{"context_management"} {
+		if gjson.GetBytes(body, betaField).Exists() {
+			body, _ = sjson.DeleteBytes(body, betaField)
+		}
+	}
+
 	// vertex Anthropic 端点要求 max_tokens 必填, 客户端漏传会被 400.
 	// 跟 claude provider buildClaudeTextGenRequest 保持一致, 缺省补 claudeDefaultMaxTokens.
 	if !gjson.GetBytes(body, "max_tokens").Exists() {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
@@ -197,11 +197,16 @@ func (v *vertexProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiNam
 
 	util.OverwriteRequestHostHeader(headers, finalVertexDomain)
 
-	// 剥除 Anthropic 客户端可能携带的凭据头, 避免泄漏到 Google.
-	// vertex 一律用 OAuth Bearer (标准模式) 或 ?key= (Express 模式) 鉴权,
-	// 这些头对 vertex 没有任何意义, 留着只会把 sk-ant-... 这类密钥转发到上游日志.
+	// 剥除 Anthropic 客户端携带的凭据头和协议头.
+	// 凭据头: vertex 一律用 OAuth Bearer 或 ?key= 鉴权, 留着只会把 sk-ant-... 泄漏到上游日志.
 	headers.Del("x-api-key")
 	headers.Del("anthropic-api-key")
+	// 协议头: vertex 的 Anthropic 端点不接受这些头 —
+	//   anthropic-beta  → vertex 不支持 Anthropic beta feature flags, 会 400
+	//   anthropic-version → vertex 的版本通过 body 里的 anthropic_version 字段传递,
+	//                       头里的 "2023-06-01" 与 vertex 预期的 "vertex-2023-10-16" 不符
+	headers.Del("anthropic-beta")
+	headers.Del("anthropic-version")
 }
 
 func (v *vertexProvider) getToken() (cached bool, err error) {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/vertex_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/vertex_test.go
@@ -513,24 +513,29 @@ func TestVertexAnthropicPassthrough_StreamingChunkUnchanged(t *testing.T) {
 	assert.Equal(t, chunk, out, "vertex Anthropic SSE chunk must be returned byte-for-byte")
 }
 
-// TestVertexTransformRequestHeaders_StripsAnthropicCredentialHeaders ensures
-// that Anthropic-style client auth headers (carried by SDKs like the Anthropic
-// Python/TypeScript SDKs and Claude Code) are NOT forwarded to vertex.
-// Vertex uses OAuth Bearer / API key in URL — these headers are meaningless to
-// vertex and forwarding them would leak the client's sk-ant-... credential to
-// Google logs.
-func TestVertexTransformRequestHeaders_StripsAnthropicCredentialHeaders(t *testing.T) {
+// TestVertexTransformRequestHeaders_StripsAnthropicHeaders ensures that
+// Anthropic-specific headers (credentials + protocol) are NOT forwarded to
+// vertex. The regular Anthropic SDK sends these but vertex's Anthropic
+// endpoint rejects or misinterprets them:
+//   - x-api-key / anthropic-api-key: credential leak to Google logs
+//   - anthropic-beta: vertex 400 "Unexpected value(s) ... for the anthropic-beta header"
+//   - anthropic-version: conflicts with body-level anthropic_version "vertex-2023-10-16"
+func TestVertexTransformRequestHeaders_StripsAnthropicHeaders(t *testing.T) {
 	v := newAnthropicVertexProvider(false)
 	ctx := newMapCtx()
 	headers := http.Header{}
 	headers.Set("x-api-key", "sk-ant-api03-secret")
 	headers.Set("anthropic-api-key", "sk-ant-api03-secret")
+	headers.Set("anthropic-beta", "advanced-tool-use-2025-11-20,prompt-caching-scope-2026-01-05")
+	headers.Set("anthropic-version", "2023-06-01")
 	headers.Set("content-type", "application/json")
 
 	v.TransformRequestHeaders(ctx, ApiNameAnthropicMessages, headers)
 
 	assert.Empty(t, headers.Get("x-api-key"), "x-api-key must be stripped before forwarding to vertex")
 	assert.Empty(t, headers.Get("anthropic-api-key"), "anthropic-api-key must be stripped before forwarding to vertex")
+	assert.Empty(t, headers.Get("anthropic-beta"), "anthropic-beta must be stripped — vertex rejects unknown beta flags with 400")
+	assert.Empty(t, headers.Get("anthropic-version"), "anthropic-version must be stripped — vertex uses body-level anthropic_version instead")
 	// Sanity: unrelated headers untouched.
 	assert.Equal(t, "application/json", headers.Get("content-type"))
 }


### PR DESCRIPTION
## Summary

When Claude Code (or any standard Anthropic SDK client) sends requests through Higress ai-proxy to Vertex AI via the Anthropic Messages passthrough path (`/v1/messages` → `:rawPredict`), the client includes `anthropic-beta` and `anthropic-version` headers. These headers are valid for the Anthropic API but **rejected by Vertex's `:rawPredict` endpoint**:

```
400 Unexpected value(s) `advanced-tool-use-2025-11-20`,
`advisor-tool-2026-03-01`, `prompt-caching-scope-2026-01-05`
for the `anthropic-beta` header.
```

### Root cause

The regular Anthropic SDK sends these headers but the AnthropicVertex SDK does not:

| Header | Regular Anthropic SDK | AnthropicVertex SDK | Vertex reaction |
|---|---|---|---|
| `x-api-key` | ✅ sends | ❌ not sent | ignored (already stripping) |
| `anthropic-api-key` | sometimes | ❌ not sent | ignored (already stripping) |
| `anthropic-beta` | ✅ sends beta flags | ❌ not sent | **400 error** |
| `anthropic-version` | ✅ `2023-06-01` | ❌ not sent (body only) | potential conflict with body-level `vertex-2023-10-16` |

Since ai-proxy performs protocol translation (client speaks Anthropic protocol, upstream speaks Vertex protocol), stripping these headers is ai-proxy's responsibility — same as the existing `x-api-key` / `anthropic-api-key` stripping added in #3860.

### Changes

- Strip `anthropic-beta` header in `TransformRequestHeaders` (fixes the 400)
- Strip `anthropic-version` header (prevents conflict with body-level `anthropic_version: "vertex-2023-10-16"`)
- Update unit test to cover all four stripped headers

## Reproduce

```python
from anthropic import Anthropic

# Simulates what Claude Code sends in interactive mode (tools, thinking, etc.)
client = Anthropic(
    base_url='http://higress:10000',
    api_key='sk-ant-fake',
    default_headers={
        'anthropic-beta': 'advanced-tool-use-2025-11-20,advisor-tool-2026-03-01,prompt-caching-scope-2026-01-05',
    }
)
resp = client.messages.create(
    model='claude-sonnet-4-6', max_tokens=32,
    messages=[{'role': 'user', 'content': 'say hi'}],
)
# Without fix: 400 Unexpected value(s) for the anthropic-beta header
# With fix:    200 OK
```

## Verification

**E2E tested against real Vertex AI** (claude-sonnet-4-6, global endpoint, project cd-claude3):

| Version | Request with `anthropic-beta` header | Result |
|---|---|---|
| **Without fix** | `anthropic-beta: advanced-tool-use-2025-11-20,...` | ❌ `400 Unexpected value(s)` |
| **With fix** | Same header | ✅ `200 OK` — response: "Hi there!" |

Also verified Claude Code CLI end-to-end:
```bash
ANTHROPIC_BASE_URL=http://127.0.0.1:10000 \
ANTHROPIC_AUTH_TOKEN=fake-bearer \
ANTHROPIC_MODEL=claude-sonnet-4-6 \
claude -p "say hi"
# → "Hi!"
```

## Test plan

- [x] Unit test: `go test ./provider/ -run TestVertexTransformRequestHeaders -v` — PASS
- [x] All vertex tests: `go test ./provider/ -run TestVertex -v` — 12/12 PASS
- [x] E2E: Anthropic SDK + `anthropic-beta` header → Higress → real Vertex → 200 OK
- [x] E2E: Claude Code CLI → Higress → real Vertex → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)