### PR TITLE
feat: support bedrock messages invoke

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
@@ -12,6 +12,7 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -40,21 +41,33 @@ const (
 	// converseStream路径 /model/{modelId}/converse-stream
 	bedrockStreamChatCompletionPath = "/model/%s/converse-stream"
 	// invoke_model 路径 /model/{modelId}/invoke
-	bedrockInvokeModelPath    = "/model/%s/invoke"
-	bedrockMantleMessagesPath = "/anthropic/v1/messages"
-	bedrockSignedHeaders      = "host;x-amz-date"
-	requestIdHeader           = "X-Amzn-Requestid"
-	bedrockCacheTypeDefault   = "default"
-	bedrockCacheTTL5m         = "5m"
-	bedrockCacheTTL1h         = "1h"
-	bedrockPromptCacheNova    = "amazon.nova"
-	bedrockPromptCacheClaude  = "anthropic.claude"
+	bedrockInvokeModelPath         = "/model/%s/invoke"
+	bedrockStreamInvokeModelPath   = "/model/%s/invoke-with-response-stream"
+	bedrockMantleMessagesPath      = "/anthropic/v1/messages"
+	bedrockSignedHeaders           = "host;x-amz-date"
+	requestIdHeader                = "X-Amzn-Requestid"
+	bedrockCacheTypeDefault        = "default"
+	bedrockCacheTTL5m              = "5m"
+	bedrockCacheTTL1h              = "1h"
+	bedrockPromptCacheNova         = "amazon.nova"
+	bedrockPromptCacheClaude       = "anthropic.claude"
+	bedrockAnthropicInvokeVersion  = "bedrock-2023-05-31"
+	bedrockComputerUseBeta20241022 = "computer-use-2024-10-22"
+	bedrockComputerUseBeta20250124 = "computer-use-2025-01-24"
+	bedrockFilesAPIBeta            = "files-api-2025-04-14"
+	bedrockCodeExecutionBeta       = "code-execution-2025-05-22"
+	bedrockMCPClientBeta           = "mcp-client-2025-04-04"
+	// Bedrock uses this beta tag even when clients send date-versioned tool_search_tool_*_20251119 tool types.
+	bedrockToolSearchBeta20251019 = "tool-search-tool-2025-10-19"
 
 	bedrockCachePointPositionSystemPrompt    = "systemPrompt"
 	bedrockCachePointPositionLastUserMessage = "lastUserMessage"
 	bedrockCachePointPositionLastMessage     = "lastMessage"
 
-	ctxKeyBedrockToolCallState = "bedrock_tool_call_state"
+	ctxKeyBedrockToolCallState             = "bedrock_tool_call_state"
+	ctxKeyBedrockAnthropicMessagesEndpoint = "bedrock_anthropic_messages_endpoint"
+	bedrockAnthropicMessagesEndpointInvoke = "invoke"
+	bedrockAnthropicMessagesEndpointMantle = "mantle"
 )
 
 var (
@@ -73,6 +86,9 @@ func (b *bedrockProviderInitializer) ValidateConfig(config *ProviderConfig) erro
 	}
 	if len(config.awsRegion) == 0 {
 		return errors.New("missing bedrock region parameters")
+	}
+	if endpoint := strings.TrimSpace(config.bedrockAnthropicMessagesEndpoint); endpoint != "" && normalizeBedrockAnthropicMessagesEndpoint(endpoint) == "" {
+		return errors.New("invalid bedrockAnthropicMessagesEndpoint: expected mantle or runtime")
 	}
 	return nil
 }
@@ -100,7 +116,10 @@ type bedrockProvider struct {
 
 func (b *bedrockProvider) OnStreamingResponseBody(ctx wrapper.HttpContext, name ApiName, chunk []byte, isLastChunk bool) ([]byte, error) {
 	if name == ApiNameAnthropicMessages {
-		return chunk, nil
+		if b.anthropicMessagesEndpoint() == bedrockAnthropicMessagesEndpointMantle {
+			return chunk, nil
+		}
+		return b.convertAnthropicMessagesInvokeStreamToSSE(ctx, chunk, isLastChunk)
 	}
 
 	events := extractAmazonEventStreamEvents(ctx, chunk)
@@ -702,7 +721,7 @@ func validateCRC(r io.Reader, expect uint32) error {
 
 func (b *bedrockProvider) TransformResponseHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
 	ctx.SetContext(requestIdHeader, headers.Get(requestIdHeader))
-	if headers.Get("Content-Type") == "application/vnd.amazon.eventstream" {
+	if strings.HasPrefix(strings.ToLower(headers.Get("Content-Type")), "application/vnd.amazon.eventstream") {
 		headers.Set("Content-Type", "text/event-stream; charset=utf-8")
 	}
 	headers.Del("Content-Length")
@@ -730,13 +749,26 @@ func (b *bedrockProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiN
 
 func (b *bedrockProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
 	if apiName == ApiNameAnthropicMessages {
-		util.OverwriteRequestHostHeader(headers, fmt.Sprintf(bedrockMantleDomain, strings.TrimSpace(b.config.awsRegion)))
-		util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), b.config.capabilities)
-		headers.Set("anthropic-version", b.anthropicVersion())
+		endpoint := b.anthropicMessagesEndpoint()
+		ctx.SetContext(ctxKeyBedrockAnthropicMessagesEndpoint, endpoint)
 
+		if endpoint == bedrockAnthropicMessagesEndpointMantle {
+			util.OverwriteRequestHostHeader(headers, fmt.Sprintf(bedrockMantleDomain, strings.TrimSpace(b.config.awsRegion)))
+			b.overwriteMantleMessagesPath(headers)
+			headers.Set("anthropic-version", b.anthropicVersion())
+
+			if len(b.config.apiTokens) > 0 {
+				headers.Set("x-api-key", b.config.GetApiTokenInUse(ctx))
+				headers.Del(util.HeaderAuthorization)
+			}
+			return
+		}
+
+		util.OverwriteRequestHostHeader(headers, fmt.Sprintf(bedrockDefaultDomain, strings.TrimSpace(b.config.awsRegion)))
+		headers.Del("anthropic-version")
+		headers.Del("x-api-key")
 		if len(b.config.apiTokens) > 0 {
-			headers.Set("x-api-key", b.config.GetApiTokenInUse(ctx))
-			headers.Del(util.HeaderAuthorization)
+			util.OverwriteRequestAuthorizationHeader(headers, "Bearer "+b.config.GetApiTokenInUse(ctx))
 		}
 		return
 	}
@@ -787,6 +819,9 @@ func (b *bedrockProvider) TransformRequestBodyHeaders(ctx wrapper.HttpContext, a
 
 	// Always apply auth after request body/path are finalized.
 	// For Bearer token mode this is a no-op; for AK/SK mode this generates SigV4 headers.
+	if b.config.providerBasePath != "" {
+		headers.Set(":path", b.config.applyProviderBasePath(headers.Get(":path")))
+	}
 	b.setAuthHeaders(apiName, transformedBody, headers)
 	return transformedBody, nil
 }
@@ -825,10 +860,27 @@ func (b *bedrockProvider) onImageGenerationRequestBody(ctx wrapper.HttpContext, 
 }
 
 func (b *bedrockProvider) onAnthropicMessagesRequestBody(ctx wrapper.HttpContext, body []byte, headers http.Header) ([]byte, error) {
-	if gjson.GetBytes(body, "stream").Bool() {
-		headers.Set("Accept", "text/event-stream")
+	if b.anthropicMessagesEndpoint() == bedrockAnthropicMessagesEndpointMantle {
+		if gjson.GetBytes(body, "stream").Bool() {
+			headers.Set("Accept", "text/event-stream")
+			ctx.SetContext(ctxKeyIsStreaming, true)
+		} else {
+			ctx.SetContext(ctxKeyIsStreaming, false)
+		}
+
+		model := gjson.GetBytes(body, "model").String()
+		if err := b.config.mapModel(ctx, &model); err != nil {
+			return nil, err
+		}
+		return sjson.SetBytes(body, "model", model)
+	}
+
+	stream := gjson.GetBytes(body, "stream").Bool()
+	if stream {
+		headers.Set("Accept", "application/vnd.amazon.eventstream")
 		ctx.SetContext(ctxKeyIsStreaming, true)
 	} else {
+		headers.Set("Accept", "application/json")
 		ctx.SetContext(ctxKeyIsStreaming, false)
 	}
 
@@ -836,7 +888,56 @@ func (b *bedrockProvider) onAnthropicMessagesRequestBody(ctx wrapper.HttpContext
 	if err := b.config.mapModel(ctx, &model); err != nil {
 		return nil, err
 	}
-	return sjson.SetBytes(body, "model", model)
+	b.overwriteAnthropicMessagesInvokePath(headers, model, stream)
+
+	var err error
+	if gjson.GetBytes(body, "model").Exists() {
+		body, err = sjson.DeleteBytes(body, "model")
+		if err != nil {
+			return nil, fmt.Errorf("unable to strip model from anthropic messages body: %v", err)
+		}
+	}
+	if gjson.GetBytes(body, "stream").Exists() {
+		body, err = sjson.DeleteBytes(body, "stream")
+		if err != nil {
+			return nil, fmt.Errorf("unable to strip stream from anthropic messages body: %v", err)
+		}
+	}
+	if !gjson.GetBytes(body, "anthropic_version").Exists() {
+		body, err = sjson.SetBytes(body, "anthropic_version", b.bedrockAnthropicVersion())
+		if err != nil {
+			return nil, fmt.Errorf("unable to inject anthropic_version: %v", err)
+		}
+	}
+	if betaHeader := headers.Get("anthropic-beta"); betaHeader != "" {
+		body, err = mergeAnthropicBetaHeaderIntoBody(body, betaHeader)
+		if err != nil {
+			return nil, err
+		}
+		headers.Del("anthropic-beta")
+	}
+	body, err = mergeAnthropicBetaValuesIntoBody(body, bedrockAnthropicMessagesAutoBetas(body, model))
+	if err != nil {
+		return nil, err
+	}
+	body, err = removeAnthropicCacheControlTTL(body)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range b.config.bedrockAdditionalFields {
+		body, err = sjson.SetBytes(body, key, value)
+		if err != nil {
+			return nil, fmt.Errorf("unable to set bedrock additional field %s: %v", key, err)
+		}
+	}
+	return body, nil
+}
+
+func (b *bedrockProvider) bedrockAnthropicVersion() string {
+	if b.config.apiVersion != "" {
+		return b.config.apiVersion
+	}
+	return bedrockAnthropicInvokeVersion
 }
 
 func (b *bedrockProvider) anthropicVersion() string {
@@ -844,6 +945,353 @@ func (b *bedrockProvider) anthropicVersion() string {
 		return b.config.apiVersion
 	}
 	return claudeDefaultVersion
+}
+
+func (b *bedrockProvider) anthropicMessagesEndpoint() string {
+	if endpoint := normalizeBedrockAnthropicMessagesEndpoint(b.config.bedrockAnthropicMessagesEndpoint); endpoint != "" {
+		return endpoint
+	}
+
+	domain := normalizeBedrockProviderDomain(b.config.providerDomain)
+	if strings.HasPrefix(domain, "bedrock-mantle.") {
+		return bedrockAnthropicMessagesEndpointMantle
+	}
+	if strings.HasPrefix(domain, "bedrock-runtime.") {
+		return bedrockAnthropicMessagesEndpointInvoke
+	}
+
+	path := strings.ToLower(strings.TrimSpace(b.config.capabilities[string(ApiNameAnthropicMessages)]))
+	if path == "" || strings.Contains(path, "/anthropic/v1/messages") {
+		return bedrockAnthropicMessagesEndpointMantle
+	}
+	return bedrockAnthropicMessagesEndpointInvoke
+}
+
+func normalizeBedrockAnthropicMessagesEndpoint(endpoint string) string {
+	switch strings.ToLower(strings.TrimSpace(endpoint)) {
+	case bedrockAnthropicMessagesEndpointMantle:
+		return bedrockAnthropicMessagesEndpointMantle
+	case "runtime", bedrockAnthropicMessagesEndpointInvoke:
+		return bedrockAnthropicMessagesEndpointInvoke
+	default:
+		return ""
+	}
+}
+
+func normalizeBedrockProviderDomain(domain string) string {
+	domain = normalizeProviderDomainHost(domain)
+	if domain == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(domain); err == nil {
+		domain = host
+	}
+	return domain
+}
+
+func (b *bedrockProvider) overwriteMantleMessagesPath(headers http.Header) {
+	path := strings.TrimSpace(b.config.capabilities[string(ApiNameAnthropicMessages)])
+	if path == "" || strings.Contains(path, "%s") || strings.Contains(path, "/invoke") {
+		path = bedrockMantleMessagesPath
+	}
+	util.OverwriteRequestPathHeader(headers, path)
+}
+
+func (b *bedrockProvider) overwriteAnthropicMessagesInvokePath(headers http.Header, model string, stream bool) {
+	pathFormat := b.anthropicMessagesInvokePathFormat(stream)
+	if strings.Contains(pathFormat, "%s") {
+		b.overwriteRequestPathHeader(headers, pathFormat, model)
+		return
+	}
+	util.OverwriteRequestPathHeader(headers, pathFormat)
+}
+
+func (b *bedrockProvider) anthropicMessagesInvokePathFormat(stream bool) string {
+	pathFormat := strings.TrimSpace(b.config.capabilities[string(ApiNameAnthropicMessages)])
+	if pathFormat == "" || strings.Contains(pathFormat, "/anthropic/v1/messages") {
+		pathFormat = bedrockInvokeModelPath
+	}
+	if stream {
+		if strings.HasSuffix(pathFormat, "/invoke") {
+			return strings.TrimSuffix(pathFormat, "/invoke") + strings.TrimPrefix(bedrockStreamInvokeModelPath, "/model/%s")
+		}
+		return pathFormat
+	}
+	if strings.HasSuffix(pathFormat, "/invoke-with-response-stream") {
+		return strings.TrimSuffix(pathFormat, "/invoke-with-response-stream") + "/invoke"
+	}
+	return pathFormat
+}
+
+func mergeAnthropicBetaHeaderIntoBody(body []byte, betaHeader string) ([]byte, error) {
+	return mergeAnthropicBetaValuesIntoBody(body, strings.Split(betaHeader, ","))
+}
+
+func mergeAnthropicBetaValuesIntoBody(body []byte, rawBetas []string) ([]byte, error) {
+	betas := make([]string, 0)
+	seen := make(map[string]bool)
+	existing := gjson.GetBytes(body, "anthropic_beta")
+	if existing.IsArray() {
+		existing.ForEach(func(_, value gjson.Result) bool {
+			beta := strings.TrimSpace(value.String())
+			if beta != "" && !seen[beta] {
+				betas = append(betas, beta)
+				seen[beta] = true
+			}
+			return true
+		})
+	}
+	for _, rawBeta := range rawBetas {
+		beta := strings.TrimSpace(rawBeta)
+		if beta != "" && !seen[beta] {
+			betas = append(betas, beta)
+			seen[beta] = true
+		}
+	}
+	if len(betas) == 0 {
+		return body, nil
+	}
+	updated, err := sjson.SetBytes(body, "anthropic_beta", betas)
+	if err != nil {
+		return nil, fmt.Errorf("unable to merge anthropic-beta into request body: %v", err)
+	}
+	return updated, nil
+}
+
+func bedrockAnthropicMessagesAutoBetas(body []byte, model string) []string {
+	modelLower := strings.ToLower(model)
+	if !strings.Contains(modelLower, "claude") {
+		return nil
+	}
+
+	betas := make([]string, 0)
+	toolSearchUsed := false
+	tools := gjson.GetBytes(body, "tools")
+	if tools.IsArray() {
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			switch toolType := tool.Get("type").String(); toolType {
+			case "computer_20250124":
+				betas = append(betas, bedrockComputerUseBeta20250124)
+			case "computer_20241022":
+				betas = append(betas, bedrockComputerUseBeta20241022)
+			case "tool_search_tool_regex", "tool_search_tool_regex_20251119", "tool_search_tool_bm25_20251119":
+				toolSearchUsed = true
+			default:
+				if strings.HasPrefix(toolType, "computer_") {
+					betas = append(betas, bedrockComputerUseBeta20241022)
+				}
+			}
+			return true
+		})
+	}
+	if toolSearchUsed {
+		betas = append(betas, bedrockToolSearchBeta20251019)
+	}
+
+	if bedrockAnthropicMessagesFileIDUsed(body) {
+		betas = append(betas, bedrockFilesAPIBeta, bedrockCodeExecutionBeta)
+	}
+	if mcpServers := gjson.GetBytes(body, "mcp_servers"); mcpServers.IsArray() && len(mcpServers.Array()) > 0 {
+		betas = append(betas, bedrockMCPClientBeta)
+	}
+	return betas
+}
+
+func bedrockAnthropicMessagesFileIDUsed(body []byte) bool {
+	found := false
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.IsArray() {
+		return false
+	}
+	messages.ForEach(func(_, message gjson.Result) bool {
+		content := message.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		content.ForEach(func(_, item gjson.Result) bool {
+			source := item.Get("source")
+			if source.Get("type").String() == "file" && source.Get("file_id").String() != "" {
+				found = true
+				return false
+			}
+			return true
+		})
+		return !found
+	})
+	return found
+}
+
+func removeAnthropicCacheControlTTL(body []byte) ([]byte, error) {
+	result := body
+	paths := make([]string, 0)
+
+	collectAnthropicBlockCacheControlTTLPaths(gjson.GetBytes(body, "system"), "system", &paths)
+
+	messages := gjson.GetBytes(body, "messages")
+	if messages.IsArray() {
+		messages.ForEach(func(messageIndex, message gjson.Result) bool {
+			content := message.Get("content")
+			if content.IsArray() {
+				collectAnthropicBlockCacheControlTTLPaths(content, fmt.Sprintf("messages.%d.content", messageIndex.Int()), &paths)
+			}
+			return true
+		})
+	}
+
+	tools := gjson.GetBytes(body, "tools")
+	if tools.IsArray() {
+		tools.ForEach(func(toolIndex, tool gjson.Result) bool {
+			if tool.Get("cache_control.ttl").Exists() {
+				paths = append(paths, fmt.Sprintf("tools.%d.cache_control.ttl", toolIndex.Int()))
+			}
+			return true
+		})
+	}
+
+	var err error
+	for _, path := range paths {
+		result, err = sjson.DeleteBytes(result, path)
+		if err != nil {
+			break
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to remove cache_control.ttl from anthropic messages body: %v", err)
+	}
+	return result, nil
+}
+
+func collectAnthropicBlockCacheControlTTLPaths(value gjson.Result, path string, paths *[]string) {
+	if value.IsArray() {
+		value.ForEach(func(index, block gjson.Result) bool {
+			collectAnthropicBlockCacheControlTTLPaths(block, fmt.Sprintf("%s.%d", path, index.Int()), paths)
+			return true
+		})
+		return
+	}
+	if !value.IsObject() {
+		return
+	}
+	if value.Get("cache_control.ttl").Exists() {
+		*paths = append(*paths, path+".cache_control.ttl")
+	}
+	if content := value.Get("content"); content.IsArray() {
+		collectAnthropicBlockCacheControlTTLPaths(content, path+".content", paths)
+	}
+}
+
+func (b *bedrockProvider) convertAnthropicMessagesInvokeStreamToSSE(ctx wrapper.HttpContext, chunk []byte, isLastChunk bool) ([]byte, error) {
+	payloads := extractAmazonEventStreamPayloads(ctx, chunk)
+	if isLastChunk {
+		logAndClearIncompleteAnthropicMessagesInvokeStreamFrame(ctx)
+	}
+	if len(payloads) == 0 {
+		return []byte(""), nil
+	}
+
+	var responseBuilder strings.Builder
+	for _, payload := range payloads {
+		payload, eventName := normalizeAnthropicMessagesInvokeStreamPayload(payload)
+		if eventName != "" {
+			responseBuilder.WriteString("event: ")
+			responseBuilder.WriteString(eventName)
+			responseBuilder.WriteString("\n")
+		}
+		responseBuilder.WriteString("data: ")
+		responseBuilder.Write(payload)
+		responseBuilder.WriteString("\n\n")
+	}
+	return []byte(responseBuilder.String()), nil
+}
+
+func normalizeAnthropicMessagesInvokeStreamPayload(payload []byte) ([]byte, string) {
+	var compactPayload bytes.Buffer
+	if err := json.Compact(&compactPayload, payload); err != nil {
+		log.Warnf("failed to parse Bedrock Invoke eventstream payload as JSON; emitting Anthropic error event: %v", err)
+		return anthropicMessagesInvokeStreamErrorPayload(), "error"
+	}
+	payload = compactPayload.Bytes()
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(payload, &data); err != nil {
+		log.Warnf("failed to parse Bedrock Invoke eventstream payload as JSON object; emitting Anthropic error event: %v", err)
+		return anthropicMessagesInvokeStreamErrorPayload(), "error"
+	}
+
+	if metrics, ok := data["amazon-bedrock-invocationMetrics"].(map[string]interface{}); ok {
+		delete(data, "amazon-bedrock-invocationMetrics")
+		usage := make(map[string]interface{})
+		if inputTokenCount, ok := metrics["inputTokenCount"]; ok {
+			usage["input_tokens"] = inputTokenCount
+		}
+		if outputTokenCount, ok := metrics["outputTokenCount"]; ok {
+			usage["output_tokens"] = outputTokenCount
+		}
+		if len(usage) > 0 {
+			data["usage"] = usage
+		}
+		payload, _ = json.Marshal(data)
+	}
+
+	eventName, _ := data["type"].(string)
+	return payload, eventName
+}
+
+func anthropicMessagesInvokeStreamErrorPayload() []byte {
+	payload, err := json.Marshal(map[string]interface{}{
+		"type": "error",
+		"error": map[string]interface{}{
+			"type":    "api_error",
+			"message": "invalid Bedrock Invoke eventstream payload",
+		},
+	})
+	if err != nil {
+		return []byte(`{"type":"error","error":{"type":"api_error","message":"invalid Bedrock Invoke eventstream payload"}}`)
+	}
+	return payload
+}
+
+func logAndClearIncompleteAnthropicMessagesInvokeStreamFrame(ctx wrapper.HttpContext) {
+	bufferedStreamingBody, has := ctx.GetContext(ctxKeyStreamingBody).([]byte)
+	if !has || len(bufferedStreamingBody) == 0 {
+		return
+	}
+	log.Warnf("discarding incomplete Bedrock Invoke eventstream frame at end of Anthropic Messages stream: %d bytes", len(bufferedStreamingBody))
+	ctx.SetContext(ctxKeyStreamingBody, nil)
+}
+
+func extractAmazonEventStreamPayloads(ctx wrapper.HttpContext, chunk []byte) [][]byte {
+	body := chunk
+	if bufferedStreamingBody, has := ctx.GetContext(ctxKeyStreamingBody).([]byte); has {
+		body = append(bufferedStreamingBody, chunk...)
+	}
+
+	r := bytes.NewReader(body)
+	var payloads [][]byte
+	var lastRead int64 = 0
+	messageBuffer := make([]byte, 1024)
+
+	for {
+		msg, err := decodeMessage(r, messageBuffer)
+		if err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+				log.Errorf("failed to decode invoke response stream message: %v", err)
+			}
+			break
+		}
+		if len(msg.Payload) > 0 {
+			payload := make([]byte, len(msg.Payload))
+			copy(payload, msg.Payload)
+			payloads = append(payloads, payload)
+		}
+		lastRead = r.Size() - int64(r.Len())
+	}
+	if lastRead < int64(len(body)) {
+		ctx.SetContext(ctxKeyStreamingBody, body[lastRead:])
+	} else {
+		ctx.SetContext(ctxKeyStreamingBody, nil)
+	}
+	return payloads
 }
 
 func (b *bedrockProvider) buildBedrockImageGenerationRequest(origRequest *imageGenerationRequest, headers http.Header) ([]byte, error) {
@@ -1650,8 +2098,8 @@ func (b *bedrockProvider) setAuthHeaders(apiName ApiName, body []byte, headers h
 	amzDate := t.Format("20060102T150405Z")
 	dateStamp := t.Format("20060102")
 	path := headers.Get(":path")
-	service := bedrockAWSService(apiName)
-	signature := b.generateSignatureWithService(path, amzDate, dateStamp, body, service)
+	service := b.bedrockAWSService(apiName)
+	signature := b.generateSignatureWithServiceAndHost(path, amzDate, dateStamp, body, service, b.bedrockSigningHost(headers, service))
 	headers.Set("X-Amz-Date", amzDate)
 	util.OverwriteRequestAuthorizationHeader(headers, fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s/%s/%s/aws4_request, SignedHeaders=%s, Signature=%s", accessKey, dateStamp, region, service, bedrockSignedHeaders, signature))
 }
@@ -1661,13 +2109,16 @@ func (b *bedrockProvider) generateSignature(path, amzDate, dateStamp string, bod
 }
 
 func (b *bedrockProvider) generateSignatureWithService(path, amzDate, dateStamp string, body []byte, service string) string {
+	return b.generateSignatureWithServiceAndHost(path, amzDate, dateStamp, body, service, bedrockAWSEndpoint(service, strings.TrimSpace(b.config.awsRegion)))
+}
+
+func (b *bedrockProvider) generateSignatureWithServiceAndHost(path, amzDate, dateStamp string, body []byte, service string, host string) string {
 	canonicalURI := encodeSigV4Path(path)
 	hashedPayload := sha256Hex(body)
 	region := strings.TrimSpace(b.config.awsRegion)
 	secretKey := strings.TrimSpace(b.config.awsSecretKey)
 
-	endpoint := bedrockAWSEndpoint(service, region)
-	canonicalHeaders := fmt.Sprintf("host:%s\nx-amz-date:%s\n", endpoint, amzDate)
+	canonicalHeaders := fmt.Sprintf("host:%s\nx-amz-date:%s\n", host, amzDate)
 	canonicalRequest := fmt.Sprintf("%s\n%s\n\n%s\n%s\n%s",
 		httpPostMethod, canonicalURI, canonicalHeaders, bedrockSignedHeaders, hashedPayload)
 
@@ -1681,8 +2132,15 @@ func (b *bedrockProvider) generateSignatureWithService(path, amzDate, dateStamp 
 	return signature
 }
 
-func bedrockAWSService(apiName ApiName) string {
-	if apiName == ApiNameAnthropicMessages {
+func (b *bedrockProvider) bedrockSigningHost(headers http.Header, service string) string {
+	if host := strings.TrimSpace(headers.Get(":authority")); host != "" {
+		return host
+	}
+	return bedrockAWSEndpoint(service, strings.TrimSpace(b.config.awsRegion))
+}
+
+func (b *bedrockProvider) bedrockAWSService(apiName ApiName) string {
+	if apiName == ApiNameAnthropicMessages && b.anthropicMessagesEndpoint() == bedrockAnthropicMessagesEndpointMantle {
 		return awsServiceBedrockMantle
 	}
 	return awsServiceBedrock

--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock_sigv4_path_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock_sigv4_path_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/sjson"
 )
 
 func TestEncodeSigV4Path(t *testing.T) {
@@ -186,6 +188,297 @@ func TestIsPromptCacheSupportedModel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, isPromptCacheSupportedModel(tt.model))
+		})
+	}
+}
+
+func TestBedrockAnthropicMessagesEndpointDetection(t *testing.T) {
+	tests := []struct {
+		name           string
+		endpoint       string
+		providerDomain string
+		capabilities   map[string]string
+		want           string
+	}{
+		{
+			name:     "explicit runtime endpoint selects invoke",
+			endpoint: "runtime",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockMantleMessagesPath,
+			},
+			want: bedrockAnthropicMessagesEndpointInvoke,
+		},
+		{
+			name:     "explicit invoke endpoint alias selects invoke",
+			endpoint: "invoke",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockMantleMessagesPath,
+			},
+			want: bedrockAnthropicMessagesEndpointInvoke,
+		},
+		{
+			name:     "explicit mantle endpoint selects mantle",
+			endpoint: "mantle",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockInvokeModelPath,
+			},
+			want: bedrockAnthropicMessagesEndpointMantle,
+		},
+		{
+			name:           "provider domain mantle wins over default invoke capability",
+			providerDomain: "bedrock-mantle.us-east-1.api.aws",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockInvokeModelPath,
+			},
+			want: bedrockAnthropicMessagesEndpointMantle,
+		},
+		{
+			name:           "provider domain runtime selects invoke",
+			providerDomain: "bedrock-runtime.us-east-1.amazonaws.com",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockMantleMessagesPath,
+			},
+			want: bedrockAnthropicMessagesEndpointInvoke,
+		},
+		{
+			name:           "provider domain runtime with scheme port and path selects invoke",
+			providerDomain: "https://bedrock-runtime.us-east-1.amazonaws.com:443/proxy",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockMantleMessagesPath,
+			},
+			want: bedrockAnthropicMessagesEndpointInvoke,
+		},
+		{
+			name:           "proxy domain containing runtime falls back to capability",
+			providerDomain: "bedrock-runtime-proxy.internal.example.com",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockMantleMessagesPath,
+			},
+			want: bedrockAnthropicMessagesEndpointMantle,
+		},
+		{
+			name:           "proxy domain containing mantle falls back to invoke capability",
+			providerDomain: "bedrock-mantle-proxy.internal.example.com",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockInvokeModelPath,
+			},
+			want: bedrockAnthropicMessagesEndpointInvoke,
+		},
+		{
+			name: "mantle capability selects mantle",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockMantleMessagesPath,
+			},
+			want: bedrockAnthropicMessagesEndpointMantle,
+		},
+		{
+			name: "default mantle capability selects mantle",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockMantleMessagesPath,
+			},
+			want: bedrockAnthropicMessagesEndpointMantle,
+		},
+		{
+			name:         "empty capability selects mantle",
+			capabilities: map[string]string{},
+			want:         bedrockAnthropicMessagesEndpointMantle,
+		},
+		{
+			name: "invoke capability selects invoke",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockInvokeModelPath,
+			},
+			want: bedrockAnthropicMessagesEndpointInvoke,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &bedrockProvider{
+				config: ProviderConfig{
+					bedrockAnthropicMessagesEndpoint: tt.endpoint,
+					providerDomain:                   tt.providerDomain,
+					capabilities:                     tt.capabilities,
+				},
+			}
+			assert.Equal(t, tt.want, p.anthropicMessagesEndpoint())
+		})
+	}
+}
+
+func TestBedrockAnthropicMessagesInvokeProviderBasePathIsSigned(t *testing.T) {
+	p := &bedrockProvider{
+		config: ProviderConfig{
+			awsAccessKey:     "test-ak-for-unit-test",
+			awsSecretKey:     "test-sk-for-unit-test",
+			awsRegion:        "us-east-1",
+			providerBasePath: "/bedrock-proxy",
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockInvokeModelPath,
+			},
+			modelMapping: map[string]string{
+				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
+			},
+		},
+	}
+	ctx := newMockMultipartHttpContext()
+	headers := http.Header{}
+	headers.Set(":path", "/v1/messages")
+	headers.Set(":authority", "example.com")
+
+	p.TransformRequestHeaders(ctx, ApiNameAnthropicMessages, headers)
+	transformedBody, err := p.TransformRequestBodyHeaders(ctx, ApiNameAnthropicMessages, []byte(`{
+		"model": "claude-request-model",
+		"max_tokens": 100,
+		"messages": [{"role": "user", "content": "hello"}]
+	}`), headers)
+	require.NoError(t, err)
+
+	path := headers.Get(":path")
+	assert.Equal(t, "/bedrock-proxy/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/invoke", path)
+	amzDate := headers.Get("X-Amz-Date")
+	require.Len(t, amzDate, len("20060102T150405Z"))
+	expectedSignature := p.generateSignatureWithService(path, amzDate, amzDate[:8], transformedBody, awsServiceBedrock)
+	assert.Contains(t, headers.Get("Authorization"), "Signature="+expectedSignature)
+}
+
+func TestBedrockAnthropicMessagesInvalidExplicitEndpoint(t *testing.T) {
+	err := (&bedrockProviderInitializer{}).ValidateConfig(&ProviderConfig{
+		apiTokens:                        []string{"test-token-for-unit-test"},
+		awsRegion:                        "us-east-1",
+		bedrockAnthropicMessagesEndpoint: "bad-endpoint",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid bedrockAnthropicMessagesEndpoint")
+}
+
+func TestBedrockAnthropicMessagesInvokeProviderDomainHostIsSigned(t *testing.T) {
+	providerDomain := normalizeProviderDomainHost("https://bedrock-runtime.us-west-2.amazonaws.com:443/proxy")
+	p := &bedrockProvider{
+		config: ProviderConfig{
+			awsAccessKey:   "test-ak-for-unit-test",
+			awsSecretKey:   "test-sk-for-unit-test",
+			awsRegion:      "us-west-2",
+			providerDomain: providerDomain,
+			capabilities: map[string]string{
+				string(ApiNameAnthropicMessages): bedrockInvokeModelPath,
+			},
+			modelMapping: map[string]string{
+				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
+			},
+		},
+	}
+	ctx := newMockMultipartHttpContext()
+	headers := http.Header{}
+	headers.Set(":path", "/v1/messages")
+	headers.Set(":authority", "example.com")
+
+	p.TransformRequestHeaders(ctx, ApiNameAnthropicMessages, headers)
+	headers.Set(":authority", providerDomain)
+	transformedBody, err := p.TransformRequestBodyHeaders(ctx, ApiNameAnthropicMessages, []byte(`{
+		"model": "claude-request-model",
+		"max_tokens": 100,
+		"messages": [{"role": "user", "content": "hello"}]
+	}`), headers)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bedrock-runtime.us-west-2.amazonaws.com:443", headers.Get(":authority"))
+	amzDate := headers.Get("X-Amz-Date")
+	require.Len(t, amzDate, len("20060102T150405Z"))
+	expectedSignature := p.generateSignatureWithServiceAndHost(headers.Get(":path"), amzDate, amzDate[:8], transformedBody, awsServiceBedrock, providerDomain)
+	assert.Contains(t, headers.Get("Authorization"), "Signature="+expectedSignature)
+}
+
+func TestBedrockAnthropicMessagesAutoBetas(t *testing.T) {
+	body := []byte(`{
+		"messages": [{
+			"role": "user",
+			"content": [{
+				"type": "document",
+				"source": {"type": "file", "file_id": "file_123"}
+			}]
+		}],
+		"tools": [
+			{"type": "computer_20241022"},
+			{"type": "tool_search_tool_regex_20251119"}
+		],
+		"mcp_servers": [{"type": "url", "url": "https://mcp.example.com", "name": "mcp"}]
+	}`)
+
+	betas := bedrockAnthropicMessagesAutoBetas(body, "anthropic.claude-opus-4-20250514-v1:0")
+	assert.ElementsMatch(t, []string{
+		bedrockComputerUseBeta20241022,
+		bedrockToolSearchBeta20251019,
+		bedrockFilesAPIBeta,
+		bedrockCodeExecutionBeta,
+		bedrockMCPClientBeta,
+	}, betas)
+	assert.Contains(t, betas, "tool-search-tool-2025-10-19")
+
+	assert.Empty(t, bedrockAnthropicMessagesAutoBetas(body, "amazon.nova-pro-v1:0"))
+}
+
+func TestBedrockAnthropicMessagesAutoBetasToolSearchClaudeModels(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		toolType string
+		wantBeta bool
+	}{
+		{
+			name:     "bedrock opus 4 model",
+			model:    "anthropic.claude-opus-4-20250514-v1:0",
+			toolType: "tool_search_tool_regex",
+			wantBeta: true,
+		},
+		{
+			name:     "bedrock sonnet model",
+			model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+			toolType: "tool_search_tool_regex_20251119",
+			wantBeta: true,
+		},
+		{
+			name:     "bedrock haiku inference profile",
+			model:    "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+			toolType: "tool_search_tool_bm25_20251119",
+			wantBeta: true,
+		},
+		{
+			name:     "future claude opus 40 model",
+			model:    "anthropic.claude-opus-40-20270101-v1:0",
+			toolType: "tool_search_tool_regex",
+			wantBeta: true,
+		},
+		{
+			name:     "future claude opus 4o model",
+			model:    "anthropic.claude-opus-4o-20270101-v1:0",
+			toolType: "tool_search_tool_regex",
+			wantBeta: true,
+		},
+		{
+			name:     "non claude model",
+			model:    "amazon.nova-pro-v1:0",
+			toolType: "tool_search_tool_regex",
+			wantBeta: false,
+		},
+		{
+			name:     "claude model without tool search tool",
+			model:    "anthropic.claude-sonnet-4-5-20250929-v1:0",
+			toolType: "custom_tool",
+			wantBeta: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := sjson.SetBytes([]byte(`{"tools":[{}]}`), "tools.0.type", tt.toolType)
+			require.NoError(t, err)
+			betas := bedrockAnthropicMessagesAutoBetas(body, tt.model)
+			if tt.wantBeta {
+				assert.Contains(t, betas, bedrockToolSearchBeta20251019)
+				return
+			}
+			assert.NotContains(t, betas, bedrockToolSearchBeta20251019)
 		})
 	}
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"hash/fnv"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"path"
 	"regexp"
 	"strconv"
@@ -379,6 +380,9 @@ type ProviderConfig struct {
 	// @Title zh-CN Amazon Bedrock Prompt Cache 保留策略（默认值）
 	// @Description zh-CN 仅适用于Amazon Bedrock服务。作为请求中 prompt_cache_retention 缺省时的默认值，支持 in_memory 和 24h。
 	promptCacheRetention string `required:"false" yaml:"promptCacheRetention" json:"promptCacheRetention"`
+	// @Title zh-CN Amazon Bedrock Anthropic Messages Endpoint
+	// @Description zh-CN 仅适用于Amazon Bedrock服务。用于指定 /v1/messages 使用 mantle 端点还是 runtime invoke 端点，可选值：mantle、runtime。
+	bedrockAnthropicMessagesEndpoint string `required:"false" yaml:"bedrockAnthropicMessagesEndpoint" json:"bedrockAnthropicMessagesEndpoint"`
 	// @Title zh-CN minimax API type
 	// @Description zh-CN 仅适用于 minimax 服务。minimax API 类型，v2 和 pro 中选填一项，默认值为 v2
 	minimaxApiType string `required:"false" yaml:"minimaxApiType" json:"minimaxApiType"`
@@ -617,6 +621,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 			c.bedrockAdditionalFields[k] = v.Value()
 		}
 		c.promptCacheRetention = json.Get("promptCacheRetention").String()
+		c.bedrockAnthropicMessagesEndpoint = strings.ToLower(strings.TrimSpace(json.Get("bedrockAnthropicMessagesEndpoint").String()))
 		if rawPositions := json.Get("bedrockPromptCachePointPositions"); rawPositions.Exists() {
 			c.bedrockPromptCachePointPositions = make(map[string]bool)
 			for k, v := range rawPositions.Map() {
@@ -727,6 +732,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 			string(ApiNameAudioTranslation),
 			string(ApiNameRealtime),
 			string(ApiNameResponses),
+			string(ApiNameAnthropicMessages),
 			string(ApiNameCohereV1Rerank),
 			string(ApiNameVideos),
 			string(ApiNameRetrieveVideo),
@@ -756,7 +762,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 		}
 	}
 	c.mergeConsecutiveMessages = json.Get("mergeConsecutiveMessages").Bool()
-	c.providerDomain = json.Get("providerDomain").String()
+	c.providerDomain = normalizeProviderDomainHost(json.Get("providerDomain").String())
 	c.promoteThinkingOnEmpty = json.Get("promoteThinkingOnEmpty").Bool()
 	c.logUpstreamErrorResponseBody = json.Get("logUpstreamErrorResponseBody").Bool()
 	c.hiclawMode = json.Get("hiclawMode").Bool()
@@ -765,6 +771,18 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 		c.promoteThinkingOnEmpty = true
 	}
 	c.providerBasePath = json.Get("providerBasePath").String()
+}
+
+func normalizeProviderDomainHost(domain string) string {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if domain == "" {
+		return ""
+	}
+	if parsed, err := url.Parse(domain); err == nil && parsed.Host != "" {
+		domain = parsed.Host
+	}
+	domain = strings.Split(domain, "/")[0]
+	return strings.TrimSuffix(domain, ".")
 }
 
 func (c *ProviderConfig) Validate() error {
@@ -1383,8 +1401,8 @@ func (c *ProviderConfig) handleRequestHeaders(provider Provider, ctx wrapper.Htt
 	}
 
 	// Apply providerDomain if configured (overrides any domain set by the provider)
-	if c.providerDomain != "" {
-		util.OverwriteRequestHostHeader(headers, c.providerDomain)
+	if providerDomain := normalizeProviderDomainHost(c.providerDomain); providerDomain != "" {
+		util.OverwriteRequestHostHeader(headers, providerDomain)
 	}
 
 	util.ReplaceRequestHeaders(headers)

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
@@ -289,6 +289,29 @@ func TestProviderDomain_Config(t *testing.T) {
 		config.FromJson(gjson.Parse(jsonStr))
 		assert.Equal(t, "universal-proxy.example.com", config.providerDomain)
 	})
+
+	t.Run("providerDomain_full_url_is_normalized_to_authority", func(t *testing.T) {
+		config := ProviderConfig{}
+		jsonStr := `{"providerDomain": "https://Bedrock-Runtime.us-west-2.amazonaws.com:443/proxy"}`
+		config.FromJson(gjson.Parse(jsonStr))
+		assert.Equal(t, "bedrock-runtime.us-west-2.amazonaws.com:443", config.providerDomain)
+	})
+}
+
+func TestBedrockAnthropicMessagesEndpointConfig(t *testing.T) {
+	t.Run("bedrockAnthropicMessagesEndpoint_parsed_from_json", func(t *testing.T) {
+		config := ProviderConfig{}
+		jsonStr := `{"type": "bedrock", "bedrockAnthropicMessagesEndpoint": "runtime"}`
+		config.FromJson(gjson.Parse(jsonStr))
+		assert.Equal(t, "runtime", config.bedrockAnthropicMessagesEndpoint)
+	})
+
+	t.Run("bedrockAnthropicMessagesEndpoint_ignored_for_other_providers", func(t *testing.T) {
+		config := ProviderConfig{}
+		jsonStr := `{"type": "openai", "bedrockAnthropicMessagesEndpoint": "runtime"}`
+		config.FromJson(gjson.Parse(jsonStr))
+		assert.Equal(t, "", config.bedrockAnthropicMessagesEndpoint)
+	})
 }
 
 func TestProviderBasePath_Config(t *testing.T) {

--- a/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
@@ -30,6 +30,24 @@ var basicBedrockConfig = func() json.RawMessage {
 	return data
 }()
 
+var bedrockInvokeAkSkConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":         "bedrock",
+			"awsAccessKey": "test-ak-for-unit-test",
+			"awsSecretKey": "test-sk-for-unit-test",
+			"awsRegion":    "us-east-1",
+			"capabilities": map[string]string{
+				"anthropic/v1/messages": "/model/%s/invoke",
+			},
+			"modelMapping": map[string]string{
+				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
+			},
+		},
+	})
+	return data
+}()
+
 // Test config: Bedrock original protocol config with AWS Access Key/Secret Key
 var bedrockOriginalAkSkConfig = func() json.RawMessage {
 	data, _ := json.Marshal(map[string]interface{}{
@@ -117,6 +135,42 @@ var bedrockApiTokenConfig = func() json.RawMessage {
 	return data
 }()
 
+var bedrockInvokeApiTokenConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type": "bedrock",
+			"apiTokens": []string{
+				"test-token-for-unit-test",
+			},
+			"awsRegion": "us-east-1",
+			"capabilities": map[string]string{
+				"anthropic/v1/messages": "/model/%s/invoke",
+			},
+			"modelMapping": map[string]string{
+				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
+			},
+		},
+	})
+	return data
+}()
+
+var bedrockExplicitRuntimeEndpointApiTokenConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type": "bedrock",
+			"apiTokens": []string{
+				"test-token-for-unit-test",
+			},
+			"awsRegion":                        "us-east-1",
+			"bedrockAnthropicMessagesEndpoint": "runtime",
+			"modelMapping": map[string]string{
+				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
+			},
+		},
+	})
+	return data
+}()
+
 var bedrockMantleApiTokenConfig = func() json.RawMessage {
 	data, _ := json.Marshal(map[string]interface{}{
 		"provider": map[string]interface{}{
@@ -125,6 +179,25 @@ var bedrockMantleApiTokenConfig = func() json.RawMessage {
 				"test-token-for-unit-test",
 			},
 			"awsRegion": "us-east-1",
+			"modelMapping": map[string]string{
+				"*": "anthropic.claude-opus-4-7",
+			},
+		},
+	})
+	return data
+}()
+
+var bedrockExplicitMantleCapabilityApiTokenConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type": "bedrock",
+			"apiTokens": []string{
+				"test-token-for-unit-test",
+			},
+			"awsRegion": "us-east-1",
+			"capabilities": map[string]string{
+				"anthropic/v1/messages": "/anthropic/v1/messages",
+			},
 			"modelMapping": map[string]string{
 				"*": "anthropic.claude-opus-4-7",
 			},
@@ -230,6 +303,62 @@ var bedrockWithAdditionalFieldsConfig = func() json.RawMessage {
 			"bedrockAdditionalFields": map[string]interface{}{
 				"top_k": 200,
 			},
+			"modelMapping": map[string]string{
+				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
+			},
+		},
+	})
+	return data
+}()
+
+var bedrockMessagesInvokeWithVersionAndAdditionalFieldsConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type": "bedrock",
+			"apiTokens": []string{
+				"test-token-for-unit-test",
+			},
+			"awsRegion":  "us-east-1",
+			"apiVersion": "bedrock-test-version",
+			"capabilities": map[string]string{
+				"anthropic/v1/messages": "/model/%s/invoke",
+			},
+			"bedrockAdditionalFields": map[string]interface{}{
+				"top_k": 200,
+			},
+			"modelMapping": map[string]string{
+				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
+			},
+		},
+	})
+	return data
+}()
+
+var bedrockMessagesInvokeWithRuntimeProviderDomainConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type": "bedrock",
+			"apiTokens": []string{
+				"test-token-for-unit-test",
+			},
+			"awsRegion":      "us-east-1",
+			"providerDomain": "https://bedrock-runtime.us-west-2.amazonaws.com:443/proxy",
+			"modelMapping": map[string]string{
+				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
+			},
+		},
+	})
+	return data
+}()
+
+var bedrockMessagesInvokeWithRuntimeProviderDomainAkSkConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"provider": map[string]interface{}{
+			"type":           "bedrock",
+			"awsAccessKey":   "test-ak-for-unit-test",
+			"awsSecretKey":   "test-sk-for-unit-test",
+			"awsRegion":      "us-west-2",
+			"providerDomain": "https://bedrock-runtime.us-west-2.amazonaws.com:443/proxy",
 			"modelMapping": map[string]string{
 				"*": "anthropic.claude-3-5-haiku-20241022-v1:0",
 			},
@@ -457,7 +586,361 @@ func RunBedrockOnHttpRequestBodyTests(t *testing.T) {
 			require.Contains(t, pathValue, "/converse", "Path should contain converse endpoint")
 		})
 
-		t.Run("bedrock anthropic messages request should use mantle endpoint and preserve native body", func(t *testing.T) {
+		t.Run("bedrock anthropic messages request should use runtime invoke when configured", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockInvokeApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+				{"anthropic-beta", "computer-use-2024-10-22, fine-grained-tool-streaming-2025-05-14"},
+				{"anthropic-version", "2023-06-01"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost, "Host header should exist")
+			require.Equal(t, "bedrock-runtime.us-east-1.amazonaws.com", hostValue)
+
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist")
+			require.Contains(t, authValue, "Bearer ")
+			require.Contains(t, authValue, "test-token-for-unit-test")
+
+			_, hasAPIKey := test.GetHeaderValue(requestHeaders, "x-api-key")
+			require.False(t, hasAPIKey, "x-api-key should not be sent to bedrock-runtime")
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"stream": false,
+					"messages": [{
+						"role": "user",
+						"content": [{
+							"type": "text",
+							"text": "Hello",
+							"cache_control": {"type": "ephemeral", "ttl": "1h"}
+						}]
+					}],
+					"tools": [{"type": "web_search_20250305"}]
+				}`
+
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.False(t, gjson.GetBytes(processedBody, "model").Exists(), "model should be moved to invoke path")
+			require.False(t, gjson.GetBytes(processedBody, "stream").Exists(), "stream should not be forwarded to Bedrock Invoke")
+			require.Equal(t, "bedrock-2023-05-31", gjson.GetBytes(processedBody, "anthropic_version").String())
+			require.Equal(t, "web_search_20250305", gjson.GetBytes(processedBody, "tools.0.type").String())
+			require.Equal(t, "ephemeral", gjson.GetBytes(processedBody, "messages.0.content.0.cache_control.type").String())
+			require.False(t, gjson.GetBytes(processedBody, "messages.0.content.0.cache_control.ttl").Exists(), "Bedrock Invoke does not support cache_control.ttl")
+			require.Equal(t, "computer-use-2024-10-22", gjson.GetBytes(processedBody, "anthropic_beta.0").String())
+			require.Equal(t, "fine-grained-tool-streaming-2025-05-14", gjson.GetBytes(processedBody, "anthropic_beta.1").String())
+
+			requestHeaders = host.GetRequestHeaders()
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath, "Path header should exist")
+			require.Equal(t, "/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/invoke", pathValue)
+			acceptValue, hasAccept := test.GetHeaderValue(requestHeaders, "Accept")
+			require.True(t, hasAccept, "Accept header should exist")
+			require.Equal(t, "application/json", acceptValue)
+			_, hasAnthropicBeta := test.GetHeaderValue(requestHeaders, "anthropic-beta")
+			require.False(t, hasAnthropicBeta, "anthropic-beta should be moved into request body for Bedrock Invoke")
+		})
+
+		t.Run("bedrock anthropic messages request should use explicit runtime endpoint field", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockExplicitRuntimeEndpointApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}]
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost, "Host header should exist")
+			require.Equal(t, "bedrock-runtime.us-east-1.amazonaws.com", hostValue)
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath, "Path header should exist")
+			require.Equal(t, "/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/invoke", pathValue)
+		})
+
+		t.Run("bedrock anthropic messages request should apply version additional fields and remove nested cache ttl", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockMessagesInvokeWithVersionAndAdditionalFieldsConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"system": [
+						{"type": "text", "text": "System prompt", "cache_control": {"type": "ephemeral", "ttl": "5m"}}
+					],
+					"messages": [
+						{
+							"role": "user",
+							"content": [
+								{"type": "text", "text": "Hello", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+								{"type": "tool_result", "tool_use_id": "toolu_1", "content": [
+									{"type": "text", "text": "Nested result", "cache_control": {"type": "ephemeral", "ttl": "5m"}}
+								]},
+								{"type": "text", "text": "World", "cache_control": {"type": "ephemeral"}}
+							]
+						},
+						{
+							"role": "assistant",
+							"content": [
+								{"type": "text", "text": "Ack", "cache_control": {"type": "ephemeral", "ttl": "5m"}}
+							]
+						},
+						{
+							"role": "user",
+							"content": "String content should stay untouched"
+						}
+					],
+					"tools": [
+						{
+							"name": "inspect_cache",
+							"description": "inspect cache settings",
+							"input_schema": {
+								"type": "object",
+								"properties": {
+									"cache_control": {
+										"type": "object",
+										"properties": {
+											"ttl": {"type": "string"}
+										}
+									}
+								}
+							},
+							"cache_control": {"type": "ephemeral", "ttl": "1h"}
+						}
+					]
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			require.Equal(t, "bedrock-test-version", gjson.GetBytes(processedBody, "anthropic_version").String())
+			require.Equal(t, int64(200), gjson.GetBytes(processedBody, "top_k").Int())
+			require.False(t, gjson.GetBytes(processedBody, "system.0.cache_control.ttl").Exists())
+			require.Equal(t, "ephemeral", gjson.GetBytes(processedBody, "system.0.cache_control.type").String())
+			require.False(t, gjson.GetBytes(processedBody, "messages.0.content.0.cache_control.ttl").Exists())
+			require.False(t, gjson.GetBytes(processedBody, "messages.0.content.1.content.0.cache_control.ttl").Exists())
+			require.False(t, gjson.GetBytes(processedBody, "messages.1.content.0.cache_control.ttl").Exists())
+			require.Equal(t, "ephemeral", gjson.GetBytes(processedBody, "messages.0.content.2.cache_control.type").String())
+			require.Equal(t, "String content should stay untouched", gjson.GetBytes(processedBody, "messages.2.content").String())
+			require.False(t, gjson.GetBytes(processedBody, "tools.0.cache_control.ttl").Exists())
+			require.Equal(t, "ephemeral", gjson.GetBytes(processedBody, "tools.0.cache_control.type").String())
+			require.Equal(t, "string", gjson.GetBytes(processedBody, "tools.0.input_schema.properties.cache_control.properties.ttl.type").String())
+		})
+
+		t.Run("bedrock anthropic messages request should merge explicit and auto beta values", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockInvokeApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+				{"anthropic-beta", " computer-use-2024-10-22 , output-128k-2025-02-19 "},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"anthropic_beta": ["context-1m-2025-08-07", "computer-use-2024-10-22"],
+					"messages": [{
+						"role": "user",
+						"content": [{
+							"type": "document",
+							"source": {"type": "file", "file_id": "file_123"}
+						}]
+					}],
+					"tools": [{"type": "computer_20250124", "name": "computer"}],
+					"mcp_servers": [{"type": "url", "url": "https://mcp.example.com", "name": "test"}]
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			processedBody := host.GetRequestBody()
+			betas := make(map[string]bool)
+			betaValues := gjson.GetBytes(processedBody, "anthropic_beta").Array()
+			for _, value := range betaValues {
+				betas[value.String()] = true
+			}
+			require.True(t, betas["context-1m-2025-08-07"])
+			require.True(t, betas["computer-use-2024-10-22"])
+			require.True(t, betas["output-128k-2025-02-19"])
+			require.True(t, betas["computer-use-2025-01-24"])
+			require.True(t, betas["files-api-2025-04-14"])
+			require.True(t, betas["code-execution-2025-05-22"])
+			require.True(t, betas["mcp-client-2025-04-04"])
+			require.Equal(t, 7, len(betas), "duplicate beta values should be removed")
+			require.Equal(t, len(betas), len(betaValues), "anthropic_beta array should not contain duplicates")
+			require.False(t, betas["prompt-caching-2024-07-31"], "Bedrock Invoke should not use prompt caching beta")
+		})
+
+		t.Run("bedrock anthropic messages request should keep runtime provider domain override", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockMessagesInvokeWithRuntimeProviderDomainConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}]
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost)
+			require.Equal(t, "bedrock-runtime.us-west-2.amazonaws.com:443", hostValue)
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath)
+			require.Equal(t, "/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/invoke", pathValue)
+		})
+
+		t.Run("bedrock anthropic messages request with ak sk should sign normalized runtime provider domain", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockMessagesInvokeWithRuntimeProviderDomainAkSkConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}]
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost)
+			require.Equal(t, "bedrock-runtime.us-west-2.amazonaws.com:443", hostValue)
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist")
+			require.Contains(t, authValue, "AWS4-HMAC-SHA256")
+			require.Contains(t, authValue, "/us-west-2/bedrock/aws4_request")
+		})
+
+		t.Run("bedrock anthropic messages request with ak sk should sign runtime invoke service", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockInvokeAkSkConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}]
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost, "Host header should exist")
+			require.Equal(t, "bedrock-runtime.us-east-1.amazonaws.com", hostValue)
+
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath, "Path header should exist")
+			require.Equal(t, "/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/invoke", pathValue)
+
+			authValue, hasAuth := test.GetHeaderValue(requestHeaders, "Authorization")
+			require.True(t, hasAuth, "Authorization header should exist")
+			require.Contains(t, authValue, "AWS4-HMAC-SHA256")
+			require.Contains(t, authValue, "/bedrock/aws4_request")
+			require.NotContains(t, authValue, "/bedrock-mantle/aws4_request")
+		})
+
+		t.Run("bedrock anthropic messages streaming request should use runtime invoke response stream", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockInvokeApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}],
+					"stream": true
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath, "Path header should exist")
+			require.Equal(t, "/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/invoke-with-response-stream", pathValue)
+
+			acceptValue, hasAccept := test.GetHeaderValue(requestHeaders, "Accept")
+			require.True(t, hasAccept, "Accept header should exist")
+			require.Equal(t, "application/vnd.amazon.eventstream", acceptValue)
+		})
+
+		t.Run("bedrock anthropic messages request should use mantle endpoint by default and preserve native body", func(t *testing.T) {
 			host, status := test.NewTestHost(bedrockMantleApiTokenConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
@@ -553,6 +1036,28 @@ func RunBedrockOnHttpRequestBodyTests(t *testing.T) {
 			require.True(t, hasAuth, "Authorization header should exist")
 			require.Contains(t, authValue, "AWS4-HMAC-SHA256")
 			require.Contains(t, authValue, "/bedrock-mantle/aws4_request")
+		})
+
+		t.Run("bedrock anthropic messages request should keep explicit mantle capability", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockExplicitMantleCapabilityApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestHeaders := host.GetRequestHeaders()
+			hostValue, hasHost := test.GetHeaderValue(requestHeaders, ":authority")
+			require.True(t, hasHost, "Host header should exist")
+			require.Equal(t, "bedrock-mantle.us-east-1.api.aws", hostValue)
+			pathValue, hasPath := test.GetHeaderValue(requestHeaders, ":path")
+			require.True(t, hasPath, "Path header should exist")
+			require.Equal(t, "/anthropic/v1/messages", pathValue)
 		})
 
 		t.Run("bedrock anthropic messages streaming request should keep mantle path and accept sse", func(t *testing.T) {
@@ -2030,6 +2535,35 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 			}
 			return ""
 		}
+		newBedrockInvokeMessagesStreamHost := func(t *testing.T) test.TestHost {
+			host, status := test.NewTestHost(bedrockInvokeApiTokenConfig)
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+				"model": "claude-request-model",
+				"max_tokens": 1024,
+				"messages": [{"role": "user", "content": "Hello"}],
+				"stream": true
+			}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			host.SetProperty([]string{"response", "code_details"}, []byte("via_upstream"))
+			action = host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"Content-Type", "application/vnd.amazon.eventstream"},
+			})
+			require.Equal(t, types.ActionContinue, action)
+			return host
+		}
 
 		t.Run("extract first data payload should return empty when no data line", func(t *testing.T) {
 			payload := extractFirstDataPayload([]byte("event: ping\n\n"))
@@ -2069,6 +2603,259 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 			action = host.CallOnHttpStreamingResponseBody(chunk, false)
 			require.Equal(t, types.ActionContinue, action)
 			require.Equal(t, chunk, host.GetResponseBody())
+		})
+
+		t.Run("bedrock anthropic messages runtime stream should convert eventstream to anthropic sse", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockInvokeApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}],
+					"stream": true
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			host.SetProperty([]string{"response", "code_details"}, []byte("via_upstream"))
+			action = host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"Content-Type", "application/vnd.amazon.eventstream"},
+			})
+			require.Equal(t, types.ActionContinue, action)
+
+			responseHeaders := host.GetResponseHeaders()
+			contentType, hasContentType := test.GetHeaderValue(responseHeaders, "Content-Type")
+			require.True(t, hasContentType, "Content-Type should exist")
+			require.Equal(t, "text/event-stream; charset=utf-8", contentType)
+
+			streamingChunk := buildBedrockEventStreamMessage(t, map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]interface{}{
+					"type": "text_delta",
+					"text": "Hi",
+				},
+			})
+			action = host.CallOnHttpStreamingResponseBody(streamingChunk, false)
+			require.Equal(t, types.ActionContinue, action)
+
+			responseBody := host.GetResponseBody()
+			require.Contains(t, string(responseBody), "event: content_block_delta")
+			payload := extractFirstDataPayload(responseBody)
+			require.Equal(t, "Hi", gjson.Parse(payload).Get("delta.text").String())
+
+			metricsChunk := buildBedrockEventStreamMessage(t, map[string]interface{}{
+				"type": "message_delta",
+				"delta": map[string]interface{}{
+					"stop_reason":   "end_turn",
+					"stop_sequence": nil,
+				},
+				"amazon-bedrock-invocationMetrics": map[string]interface{}{
+					"inputTokenCount":  10,
+					"outputTokenCount": 2,
+				},
+			})
+			action = host.CallOnHttpStreamingResponseBody(metricsChunk, false)
+			require.Equal(t, types.ActionContinue, action)
+
+			responseBody = host.GetResponseBody()
+			require.Contains(t, string(responseBody), "event: message_delta")
+			payload = extractFirstDataPayload(responseBody)
+			require.False(t, gjson.Parse(payload).Get("amazon-bedrock-invocationMetrics").Exists())
+			require.Equal(t, int64(10), gjson.Parse(payload).Get("usage.input_tokens").Int())
+			require.Equal(t, int64(2), gjson.Parse(payload).Get("usage.output_tokens").Int())
+		})
+
+		t.Run("bedrock anthropic messages runtime stream should handle split frames multiple frames and invalid payloads", func(t *testing.T) {
+			host, status := test.NewTestHost(bedrockInvokeApiTokenConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			action := host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/messages"},
+				{":method", "POST"},
+				{"Content-Type", "application/json"},
+			})
+			require.Equal(t, types.HeaderStopIteration, action)
+
+			requestBody := `{
+					"model": "claude-request-model",
+					"max_tokens": 1024,
+					"messages": [{"role": "user", "content": "Hello"}],
+					"stream": true
+				}`
+			action = host.CallOnHttpRequestBody([]byte(requestBody))
+			require.Equal(t, types.ActionContinue, action)
+
+			host.SetProperty([]string{"response", "code_details"}, []byte("via_upstream"))
+			action = host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"Content-Type", "application/vnd.amazon.eventstream; charset=utf-8"},
+			})
+			require.Equal(t, types.ActionContinue, action)
+
+			splitFrame := buildBedrockEventStreamMessage(t, map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]interface{}{
+					"type": "text_delta",
+					"text": "Split",
+				},
+			})
+			midpoint := len(splitFrame) / 2
+			action = host.CallOnHttpStreamingResponseBody(splitFrame[:midpoint], false)
+			require.Equal(t, types.ActionContinue, action)
+			require.Len(t, host.GetResponseBody(), 0, "partial eventstream frame should not emit SSE")
+
+			action = host.CallOnHttpStreamingResponseBody(splitFrame[midpoint:], false)
+			require.Equal(t, types.ActionContinue, action)
+			responseBody := host.GetResponseBody()
+			require.Contains(t, string(responseBody), "event: content_block_delta")
+			require.Equal(t, "Split", gjson.Parse(extractFirstDataPayload(responseBody)).Get("delta.text").String())
+
+			firstFrame := buildBedrockEventStreamMessage(t, map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]interface{}{
+					"type": "text_delta",
+					"text": "A",
+				},
+			})
+			secondFrame := buildBedrockEventStreamMessage(t, map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]interface{}{
+					"type": "text_delta",
+					"text": "B",
+				},
+			})
+			action = host.CallOnHttpStreamingResponseBody(append(firstFrame, secondFrame...), false)
+			require.Equal(t, types.ActionContinue, action)
+			responseBody = host.GetResponseBody()
+			require.Equal(t, 2, strings.Count(string(responseBody), "event: content_block_delta"))
+			require.Equal(t, 2, strings.Count(string(responseBody), "\n\n"))
+
+			rawFrame := buildBedrockEventStreamPayload(t, []byte("not-json\nbad"))
+			action = host.CallOnHttpStreamingResponseBody(rawFrame, false)
+			require.Equal(t, types.ActionContinue, action)
+			responseBody = host.GetResponseBody()
+			require.Contains(t, string(responseBody), "event: error")
+			require.NotContains(t, string(responseBody), "not-json")
+			require.Equal(t, 1, strings.Count(string(responseBody), "data: "))
+			errorPayload := extractFirstDataPayload(responseBody)
+			require.Equal(t, "error", gjson.Parse(errorPayload).Get("type").String())
+			require.Equal(t, "api_error", gjson.Parse(errorPayload).Get("error.type").String())
+			require.Equal(t, "invalid Bedrock Invoke eventstream payload", gjson.Parse(errorPayload).Get("error.message").String())
+
+			trailingPartialFrame := buildBedrockEventStreamMessage(t, map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]interface{}{
+					"type": "text_delta",
+					"text": "trailing",
+				},
+			})
+			action = host.CallOnHttpStreamingResponseBody(trailingPartialFrame[:len(trailingPartialFrame)/2], false)
+			require.Equal(t, types.ActionContinue, action)
+			require.Len(t, host.GetResponseBody(), 0, "partial eventstream frame should not emit SSE")
+
+			action = host.CallOnHttpStreamingResponseBody([]byte{}, true)
+			require.Equal(t, types.ActionContinue, action)
+			require.Len(t, host.GetResponseBody(), 0, "trailing partial eventstream frame should be discarded without DONE")
+			warnLogs := host.GetWarnLogs()
+			hasIncompleteFrameWarn := false
+			for _, logEntry := range warnLogs {
+				if strings.Contains(logEntry, "discarding incomplete Bedrock Invoke eventstream frame") {
+					hasIncompleteFrameWarn = true
+					break
+				}
+			}
+			require.True(t, hasIncompleteFrameWarn, "should warn about trailing incomplete frame, logs: %v", warnLogs)
+		})
+
+		t.Run("bedrock anthropic messages runtime stream should compact json and reject non object payloads", func(t *testing.T) {
+			host := newBedrockInvokeMessagesStreamHost(t)
+			defer host.Reset()
+
+			prettyPayload := []byte(`{
+				"type": "content_block_delta",
+				"index": 0,
+				"delta": {
+					"type": "text_delta",
+					"text": "Pretty"
+				}
+			}`)
+			action := host.CallOnHttpStreamingResponseBody(buildBedrockEventStreamPayload(t, prettyPayload), false)
+			require.Equal(t, types.ActionContinue, action)
+			responseBody := host.GetResponseBody()
+			require.Contains(t, string(responseBody), "event: content_block_delta")
+			payload := extractFirstDataPayload(responseBody)
+			require.Equal(t, "Pretty", gjson.Parse(payload).Get("delta.text").String())
+			require.NotContains(t, payload, "\n", "SSE data payload should stay on one line")
+
+			arrayPayload := []byte(`[{"type":"content_block_delta","delta":{"text":"array"}}]`)
+			action = host.CallOnHttpStreamingResponseBody(buildBedrockEventStreamPayload(t, arrayPayload), false)
+			require.Equal(t, types.ActionContinue, action)
+			responseBody = host.GetResponseBody()
+			require.Contains(t, string(responseBody), "event: error")
+			require.NotContains(t, string(responseBody), "array")
+			errorPayload := extractFirstDataPayload(responseBody)
+			require.Equal(t, "error", gjson.Parse(errorPayload).Get("type").String())
+			require.Equal(t, "api_error", gjson.Parse(errorPayload).Get("error.type").String())
+		})
+
+		t.Run("bedrock anthropic messages runtime stream should emit complete final frame and warn on trailing partial frame", func(t *testing.T) {
+			host := newBedrockInvokeMessagesStreamHost(t)
+			defer host.Reset()
+
+			completeFrame := buildBedrockEventStreamMessage(t, map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]interface{}{
+					"type": "text_delta",
+					"text": "complete-before-trailer",
+				},
+			})
+			partialFrame := buildBedrockEventStreamMessage(t, map[string]interface{}{
+				"type":  "content_block_delta",
+				"index": 0,
+				"delta": map[string]interface{}{
+					"type": "text_delta",
+					"text": "trailing",
+				},
+			})
+			finalChunk := make([]byte, 0, len(completeFrame)+len(partialFrame)/2)
+			finalChunk = append(finalChunk, completeFrame...)
+			finalChunk = append(finalChunk, partialFrame[:len(partialFrame)/2]...)
+
+			action := host.CallOnHttpStreamingResponseBody(finalChunk, true)
+			require.Equal(t, types.ActionContinue, action)
+			responseBody := host.GetResponseBody()
+			require.Contains(t, string(responseBody), "event: content_block_delta")
+			require.Equal(t, "complete-before-trailer", gjson.Parse(extractFirstDataPayload(responseBody)).Get("delta.text").String())
+			require.NotContains(t, string(responseBody), "data: [DONE]")
+
+			warnLogs := host.GetWarnLogs()
+			hasIncompleteFrameWarn := false
+			for _, logEntry := range warnLogs {
+				if strings.Contains(logEntry, "discarding incomplete Bedrock Invoke eventstream frame") {
+					hasIncompleteFrameWarn = true
+					break
+				}
+			}
+			require.True(t, hasIncompleteFrameWarn, "should warn about trailing incomplete frame, logs: %v", warnLogs)
 		})
 
 		t.Run("bedrock streaming parallel tool calls should use dense OpenAI indexes", func(t *testing.T) {
@@ -2414,7 +3201,10 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 func buildBedrockEventStreamMessage(t *testing.T, payload map[string]interface{}) []byte {
 	payloadBytes, err := json.Marshal(payload)
 	require.NoError(t, err)
+	return buildBedrockEventStreamPayload(t, payloadBytes)
+}
 
+func buildBedrockEventStreamPayload(t *testing.T, payloadBytes []byte) []byte {
 	totalLength := uint32(16 + len(payloadBytes))
 	headersLength := uint32(0)
 


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

本 PR 强化 Bedrock Provider 的 Anthropic Messages 支持，在保持 Bedrock Mantle 作为默认 `/v1/messages` 后端的基础上，新增 Bedrock Runtime `InvokeModel` / `InvokeModelWithResponseStream` 兼容路径。

### 背景

Bedrock Provider 已默认支持将 `/v1/messages` 转到 Bedrock Mantle 的 Anthropic 兼容端点：

- `https://bedrock-mantle.{awsRegion}.api.aws/anthropic/v1/messages`

Mantle 是默认行为，因为它是 AWS 提供的 Anthropic Messages 兼容入口，能最大程度保留 Anthropic 原生请求/响应语义。

但部分旧模型或区域仍可能不支持 Mantle。对于这些场景，需要支持将 `/v1/messages` 转换到 Bedrock Runtime Invoke API：

- 非流式：`/model/{modelId}/invoke`
- 流式：`/model/{modelId}/invoke-with-response-stream`

该兼容路径需要把 Anthropic Messages 请求体转换成 Bedrock Invoke 可接受的格式，并将 Bedrock EventStream 流式响应转换回 Anthropic SSE。

### 主要变更

1. **新增 `/v1/messages` -> Bedrock Runtime Invoke 兼容路径**
   - Mantle 仍为默认 endpoint
   - 当后端域名是 `bedrock-runtime.{region}.amazonaws.com`，或 capability 显式配置为 Invoke path 时，走 Bedrock Runtime Invoke
   - 非流式请求改写到 `/model/%s/invoke`
   - 流式请求改写到 `/model/%s/invoke-with-response-stream`
   - Runtime Invoke 签名 service 使用 `bedrock`
   - Mantle 签名 service 保持 `bedrock-mantle`

2. **收紧 Mantle / Runtime endpoint 判定**
   - 先规范化 `providerDomain`，提取 host、去除 scheme/path/port
   - 仅匹配 `bedrock-mantle.` / `bedrock-runtime.` host 前缀
   - 避免 `bedrock-runtime-proxy.internal.example.com` 这类代理域名被误判
   - 不可识别的域名回退到 `capabilities["anthropic/v1/messages"]` 判断

3. **转换 Invoke 请求体**
   - 删除 Anthropic 请求体中的 `model` 和 `stream`
   - 注入 `anthropic_version`，默认 `bedrock-2023-05-31`
   - 支持通过 `apiVersion` 覆盖 Bedrock Anthropic version
   - 将请求头 `anthropic-beta` 合并到 body 的 `anthropic_beta`
   - 支持 `bedrockAdditionalFields` 注入额外 Bedrock 请求字段
   - 保留 Anthropic 原生 Messages 结构，避免走 Converse 转换链路

4. **自动补充 Bedrock Invoke 所需 beta**
   - computer use:
     - `computer_20241022` -> `computer-use-2024-10-22`
     - `computer_20250124` -> `computer-use-2025-01-24`
   - file_id:
     - `files-api-2025-04-14`
     - `code-execution-2025-05-22`
   - MCP client:
     - `mcp-client-2025-04-04`
   - tool search:
     - 只要是 Claude model 且 tools 中出现 tool search tool，就注入 `tool-search-tool-2025-10-19`
     - 覆盖 `tool_search_tool_regex`、`tool_search_tool_regex_20251119`、`tool_search_tool_bm25_20251119`
   - beta 合并会去重，并保留用户显式传入的 beta

5. **清理 Bedrock Invoke 不支持的 cache_control.ttl**
   - Bedrock Invoke 支持 `cache_control`，但拒绝其中的 `ttl`
   - 清理范围覆盖：
     - `system` blocks
     - `messages[*].content` blocks
     - nested content blocks，例如 `tool_result.content[*]`
     - `tools[*].cache_control.ttl`
   - 避免误删 `input_schema` 等 schema 定义里的 `ttl`

6. **转换 Bedrock Invoke streaming EventStream 为 Anthropic SSE**
   - 将 Bedrock EventStream payload 提取为 Anthropic SSE:
     - `event: {payload.type}`
     - `data: {payload}`
   - 将 `amazon-bedrock-invocationMetrics` 转换为 Anthropic `usage`
   - 对流式拆包进行 buffer 重组
   - 流末尾若存在残帧，记录 warn 并丢弃，不补 `[DONE]`
   - 非法 JSON payload 不再原样透传，改为合法 Anthropic error SSE
   - 合法 JSON payload 会先 compact，避免格式化换行破坏 SSE 帧

7. **开放 Anthropic Messages capability 自定义**
   - `provider/provider.go` 中允许自定义 `ApiNameAnthropicMessages` capability
   - 用户可通过 capability 显式配置 Mantle path 或 Runtime Invoke path

### 行为对比

| 场景 | 变更前 | 变更后 |
|------|--------|--------|
| 默认 Bedrock `/v1/messages` | Mantle `/anthropic/v1/messages` | 保持 Mantle 默认 |
| Bedrock Runtime Invoke 兼容 | 不支持 | 支持 `/model/%s/invoke` |
| Bedrock Runtime streaming Invoke | 不支持 | 支持 `/model/%s/invoke-with-response-stream` |
| Runtime Invoke service name | 不适用 | `bedrock` |
| Mantle service name | `bedrock-mantle` | 保持不变 |
| `bedrock-runtime-proxy...` 代理域名 | 可能被宽松匹配误判 | 不误判，回退 capability |
| Invoke stream response | 不支持 | EventStream -> Anthropic SSE |
| Invoke invalid stream payload | 可能破坏 SSE | 转为 `event: error` |
| Invoke 末尾残帧 | 可能静默丢弃 | warn 后丢弃 |

## Ⅱ. Does this pull request fix one issue?

修复 Bedrock Provider 在部分旧模型或区域无法通过 Mantle 处理 `/v1/messages` 的兼容性缺口。

在这些场景中，用户需要继续使用 Bedrock Runtime Invoke API，但客户端入口仍希望保持 Anthropic Messages `/v1/messages`。本 PR 增加 Runtime Invoke 兼容路径，使 ai-proxy 能在 Mantle 默认行为之外支持旧模型兼容方案。

同时修复和规避了以下兼容性风险：

- endpoint 判定过宽导致代理域名误分类
- Invoke 不支持 `cache_control.ttl` 导致 400
- Invoke streaming EventStream 残帧被静默丢弃
- 非法 JSON payload 原样进入 SSE `data:` 破坏客户端解析
- Bedrock beta tag 和 tool type 日期后缀混淆

## Ⅲ. Why don't you add test cases (unit test/integration test)?

已补充测试，覆盖 Mantle 默认行为、Invoke 兼容路径、签名、请求体转换、流式转换和边缘场景。

### `provider/bedrock_sigv4_path_test.go`

- ✅ `TestBedrockAnthropicMessagesEndpointDetection`
  - 默认 capability 走 Mantle
  - `bedrock-mantle` host 走 Mantle
  - `bedrock-runtime` host 走 Invoke
  - 带 scheme/port/path 的 runtime host 正确识别
  - `bedrock-runtime-proxy...` 不误判，回退 capability
  - `bedrock-mantle-proxy...` 不误判，回退 capability
  - Mantle capability 选择 Mantle
  - Invoke capability 选择 Invoke
- ✅ `TestBedrockAnthropicMessagesInvokeProviderBasePathIsSigned`
  - 验证 `providerBasePath` 会参与 path 改写和 SigV4 签名
- ✅ `TestBedrockAnthropicMessagesAutoBetas`
  - 验证 computer use、tool search、file_id、MCP 自动 beta
  - 验证非 Claude model 不注入 Anthropic beta
- ✅ `TestBedrockAnthropicMessagesAutoBetasToolSearchClaudeModels`
  - 覆盖 `tool_search_tool_regex`
  - 覆盖 `tool_search_tool_regex_20251119`
  - 覆盖 `tool_search_tool_bm25_20251119`
  - 覆盖 Opus、Sonnet、Haiku、未来 Claude model
  - 覆盖非 Claude model
  - 覆盖 Claude 但非 tool-search tool

### `test/bedrock.go`

- ✅ Mantle 默认行为保持不变
  - 默认 Bedrock `/v1/messages` 仍走 `/anthropic/v1/messages`
  - Mantle token auth / AK/SK 行为保持
- ✅ Runtime Invoke 请求转换
  - host/path 改写到 Bedrock Runtime
  - `Accept` 设置为 `application/json`
  - stream 请求 `Accept` 设置为 `application/vnd.amazon.eventstream`
  - `model` / `stream` 从 body 删除
  - `anthropic_version` 自动注入
  - `apiVersion` 覆盖 `anthropic_version`
  - `bedrockAdditionalFields` 注入
  - `anthropic-beta` header 合并到 body
  - beta 去重
  - cache_control.ttl 清理覆盖 messages/system/tools/nested content
- ✅ Runtime Invoke 签名
  - token 模式请求头转换
  - AK/SK 模式 SigV4 使用 `bedrock` service
  - Mantle AK/SK 仍使用 `bedrock-mantle` service
- ✅ Runtime Invoke 非流式响应
  - Anthropic Messages body 原样透传
- ✅ Runtime Invoke streaming 响应转换
  - Bedrock EventStream 转 Anthropic SSE
  - metrics 转 `usage`
  - split frame 重组
  - 单 chunk 多 frame
  - 非法 payload 转 `event: error`
  - 格式化 JSON payload compact 后输出单行 SSE
  - 合法 JSON array 等非对象 payload 转 error
  - 末尾残帧 warn 丢弃，不补 `[DONE]`
  - final chunk 同时包含完整 frame 和残 frame 时，输出完整 frame 并 warn 残 frame

## Ⅳ. Describe how to verify it

### 方式一：运行全量测试

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test ./...
```

### 方式二：运行 Bedrock 相关测试

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test . -run '^TestBedrock$'
go test ./provider -run 'TestBedrockAnthropicMessages'
```

### 方式三：手动验证 Mantle 默认行为

配置 Bedrock Provider，不显式配置 Invoke capability：

```yaml
provider:
  type: bedrock
  apiTokens:
    - "YOUR_AWS_BEARER_TOKEN"
  awsRegion: "us-east-1"
  modelMapping:
    "*": "anthropic.claude-opus-4-20250514-v1:0"
```

发送请求：

```bash
curl -X POST http://your-gateway/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude",
    "max_tokens": 1024,
    "messages": [
      {
        "role": "user",
        "content": "hello"
      }
    ]
  }'
```

预期：

- 上游 host 为 `bedrock-mantle.us-east-1.api.aws`
- path 为 `/anthropic/v1/messages`
- 响应为 Anthropic Messages 原生格式

### 方式四：手动验证 Runtime Invoke 兼容路径

显式配置 Anthropic Messages capability 为 Runtime Invoke：

```yaml
provider:
  type: bedrock
  apiTokens:
    - "YOUR_AWS_BEARER_TOKEN"
  awsRegion: "us-east-1"
  capabilities:
    anthropic/v1/messages: /model/%s/invoke
  modelMapping:
    "*": "anthropic.claude-3-5-haiku-20241022-v1:0"
```

发送非流式请求：

```bash
curl -X POST http://your-gateway/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude",
    "max_tokens": 1024,
    "messages": [
      {
        "role": "user",
        "content": "hello"
      }
    ]
  }'
```

预期：

- 上游 path 为 `/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/invoke`
- body 中不包含 `model` / `stream`
- body 中包含 `anthropic_version: bedrock-2023-05-31`
- SigV4 service 为 `bedrock`

### 方式五：手动验证 Runtime streaming Invoke

```bash
curl -N -X POST http://your-gateway/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude",
    "max_tokens": 1024,
    "stream": true,
    "messages": [
      {
        "role": "user",
        "content": "hello"
      }
    ]
  }'
```

预期：

- 上游 path 为 `/model/{modelId}/invoke-with-response-stream`
- 上游 `Accept` 为 `application/vnd.amazon.eventstream`
- 下游响应 `Content-Type` 为 `text/event-stream; charset=utf-8`
- 下游收到 Anthropic SSE，不包含 OpenAI 风格 `[DONE]`

## Ⅴ. Special notes for reviews

1. Mantle 是默认行为。Runtime Invoke 是旧模型/旧区域的兼容方案，不应替换默认 Mantle endpoint。
2. Runtime Invoke 的选择不新增独立开关，优先通过后端域名和 capability 判断：
   - `bedrock-mantle.` -> Mantle
   - `bedrock-runtime.` -> Invoke
   - 其它域名 -> 回退 capability
3. `providerDomain` 匹配使用规范化后的 host 前缀，避免代理域名误分类。
4. Runtime Invoke streaming 返回的是 Bedrock EventStream，本 PR 会转换为 Anthropic SSE；Mantle streaming 本身就是 Anthropic SSE，仍原样透传。
5. Anthropic SSE 不需要 `[DONE]`，所以 Runtime Invoke Messages streaming 末尾不会额外追加 `[DONE]`。
6. `tool_search_tool_*_20251119` 是 tool type 版本后缀；Bedrock 实际要求的 beta tag 是 `tool-search-tool-2025-10-19`。
7. `cache_control.ttl` 清理只删除请求 payload 中实际 cache_control 的 ttl，不删除 schema 中描述 ttl 的字段。

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have included the AI Coding summary below

### AI Coding Summary

**关键决策：**

1. 保持 Bedrock Mantle 作为 `/v1/messages` 默认 endpoint。
2. 新增 Bedrock Runtime Invoke 作为兼容路径，而不是改变默认行为。
3. 通过规范化后的 `providerDomain` 和 capability 判断 Mantle / Invoke。
4. Runtime Invoke 请求只做 Bedrock 必需字段转换，不进入 Converse 转换链路。
5. Runtime Invoke streaming 统一转换为 Anthropic SSE，非法 payload 不原样透传。

**主要改动范围：**

1. `provider/bedrock.go`
   - 新增 Anthropic Messages Invoke 请求转换
   - 新增 Mantle / Invoke endpoint 判定
   - 新增 Runtime Invoke path 改写和 SigV4 service 选择
   - 新增 `anthropic_beta` 合并和自动 beta 注入
   - 新增 `cache_control.ttl` 清理
   - 新增 EventStream -> Anthropic SSE 转换
2. `provider/provider.go`
   - 允许 `ApiNameAnthropicMessages` 使用自定义 capability
3. `provider/bedrock_sigv4_path_test.go`
   - 补充 endpoint 判定、签名 path、auto beta 测试
4. `test/bedrock.go`
   - 补充 Mantle 默认行为、Runtime Invoke 请求/响应/streaming 测试

**验证结果：**

1. `go test ./provider -run 'TestBedrockAnthropicMessagesAutoBetas'` 通过
2. `go test . -run '^TestBedrock$'` 通过
3. `go test ./...` 通过

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Ⅰ. Describe what this PR did

This PR strengthens Bedrock Provider's Anthropic Messages support, and adds Bedrock Runtime `InvokeModel` / `InvokeModelWithResponseStream` compatible paths while maintaining Bedrock Mantle as the default `/v1/messages` backend.

### Background

The Bedrock Provider already supports routing `/v1/messages` to Bedrock Mantle's Anthropic-compatible endpoint by default:

- `https://bedrock-mantle.{awsRegion}.api.aws/anthropic/v1/messages`

Mantle is the default behavior because it is an Anthropic Messages-compatible entry provided by AWS and can retain Anthropic's native request/response semantics to the greatest extent.

However, some older models or regions may still not support Mantle. For these scenarios, support for converting `/v1/messages` to the Bedrock Runtime Invoke API is required:

- Non-streaming: `/model/{modelId}/invoke`
- Streaming: `/model/{modelId}/invoke-with-response-stream`

This compatibility path requires converting the Anthropic Messages request body into a format acceptable to Bedrock Invoke and converting the Bedrock EventStream streaming response back to Anthropic SSE.

### Major changes

1. **Added `/v1/messages` -> Bedrock Runtime Invoke compatible path**
   - Mantle remains the default endpoint
   - When the backend domain name is `bedrock-runtime.{region}.amazonaws.com`, or capability is explicitly configured as Invoke path, use Bedrock Runtime Invoke
   - Non-streaming requests are rewritten to `/model/%s/invoke`
   - Streaming requests are rewritten to `/model/%s/invoke-with-response-stream`
   - Runtime Invoke signature service uses `bedrock`
   - Mantle signature service maintains `bedrock-mantle`

2. **Tighten the Mantle / Runtime endpoint determination**
   - First normalize `providerDomain`, extract host and remove scheme/path/port
   - Matches only `bedrock-mantle.` / `bedrock-runtime.` host prefixes
   - Prevent proxy domain names such as `bedrock-runtime-proxy.internal.example.com` from being misjudged
   - Unrecognized domain names fall back to `capabilities["anthropic/v1/messages"]` judgment

3. **Convert Invoke request body**
   - Remove `model` and `stream` in Anthropic request body
   - Inject `anthropic_version`, default `bedrock-2023-05-31`
   - Support overriding Bedrock Anthropic version via `apiVersion`
   - Merge the request header `anthropic-beta` into the body's `anthropic_beta`
   - Support `bedrockAdditionalFields` to inject additional Bedrock request fields
   - Retain Anthropic's native Messages structure and avoid the Converse conversion link

4. **Automatically replenish the required beta for Bedrock Invoke**
   - computer use:
     - `computer_20241022` -> `computer-use-2024-10-22`
     - `computer_20250124` -> `computer-use-2025-01-24`
   - file_id:
     - `files-api-2025-04-14`
     - `code-execution-2025-05-22`
   - MCP client:
     - `mcp-client-2025-04-04`
   - tool search:
     - As long as it is Claude model and tool search tool appears in tools, inject `tool-search-tool-2025-10-19`
     - Override `tool_search_tool_regex`, `tool_search_tool_regex_20251119`, `tool_search_tool_bm25_20251119`
   - beta merging will remove duplicates and retain betas explicitly passed in by the user

5. **Clean up cache_control.ttl that is not supported by Bedrock Invoke**
   - Bedrock Invoke supports `cache_control` but rejects `ttl` in it
   - Cleaning range coverage:
     - `system` blocks
     - `messages[*].content` blocks
     - nested content blocks, such as `tool_result.content[*]`
     - `tools[*].cache_control.ttl`
   - Avoid accidentally deleting `ttl` in schema definitions such as `input_schema`

6. **Convert Bedrock Invoke streaming EventStream to Anthropic SSE**
   - Extract Bedrock EventStream payload as Anthropic SSE:
     - `event: {payload.type}`
     - `data: {payload}`
   - Convert `amazon-bedrock-invocationMetrics` to Anthropic `usage`
   - Buffer reassembly for streaming unpacking
   - If there are residual frames at the end of the stream, record warn and discard them without adding `[DONE]`
   - Illegal JSON payload is no longer transparently transmitted as it is, and is changed to legal Anthropic error SSE
   - Legal JSON payload will be compacted first to avoid formatting and line breaks from destroying SSE frames.

7. **Open Anthropic Messages capability for customization**
   - Allow custom `ApiNameAnthropicMessages` capability in `provider/provider.go`
   - Users can explicitly configure Mantle path or Runtime Invoke path through capability

### Behavior comparison

| Scenario | Before the change | After the change |
|------|--------|--------|
| Default Bedrock `/v1/messages` | Mantle `/anthropic/v1/messages` | Keep Mantle default |
| Bedrock Runtime Invoke compatible | Not supported | Supported `/model/%s/invoke` |
| Bedrock Runtime streaming Invoke | Not supported | Supported `/model/%s/invoke-with-response-stream` |
| Runtime Invoke service name | Not applicable | `bedrock` |
| Mantle service name | `bedrock-mantle` | Remain unchanged |
| `bedrock-runtime-proxy...` Proxy domain name | May be misjudged by loose matching | No misjudgement, fallback capability |
| Invoke stream response | Not supported | EventStream -> Anthropic SSE |
| Invoke invalid stream payload | May break SSE | Convert to `event: error` |
| Invoke the last remaining frame | May be discarded silently | Discarded after warn |

## Ⅱ. Does this pull request fix one issue?

Fixed a compatibility gap where Bedrock Provider could not handle `/v1/messages` through Mantle in some older models or areas.

In these scenarios, users need to continue using the Bedrock Runtime Invoke API, but the client portal still wants to keep Anthropic Messages `/v1/messages`. This PR adds a Runtime Invoke compatibility path so that ai-proxy can support old model compatibility solutions in addition to Mantle's default behavior.

At the same time, the following compatibility risks have been fixed and avoided:

- Endpoint determination is too wide, resulting in misclassification of proxy domain names
- Invoke does not support `cache_control.ttl` resulting in 400
- Invoke streaming EventStream residual frames are silently discarded
- Illegal JSON payload enters SSE `data:` as it is, destroying client parsing
- Bedrock beta tag and tool type date suffix confusion

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Supplementary tests have been added to cover Mantle default behavior, Invoke compatible paths, signatures, request body conversion, streaming conversion, and edge scenarios.

### `provider/bedrock_sigv4_path_test.go`

- ✅ `TestBedrockAnthropicMessagesEndpointDetection`
  - Default capability is Mantle
  - `bedrock-mantle` host Go Mantle
  - `bedrock-runtime` host Go Invoke
  - Runtime host with scheme/port/path correctly identified
  - `bedrock-runtime-proxy...` prevents misjudgment and rolls back capability
  - `bedrock-mantle-proxy...` No misjudgment, fallback capability
  - Mantle capability select Mantle
  - Invoke capability select Invoke
- ✅ `TestBedrockAnthropicMessagesInvokeProviderBasePathIsSigned`
  - Verify that `providerBasePath` will participate in path rewriting and SigV4 signing
- ✅ `TestBedrockAnthropicMessagesAutoBetas`
  - Verify computer use, tool search, file_id, MCP auto beta
  - Verify that non-Claude models do not inject Anthropic beta
- ✅ `TestBedrockAnthropicMessagesAutoBetasToolSearchClaudeModels`
  - Override `tool_search_tool_regex`
  - Override `tool_search_tool_regex_20251119`
  - Override `tool_search_tool_bm25_20251119`
  - Covers Opus, Sonnet, Haiku, and future Claude models
  - Covers non-Claude models
  - overrides Claude but not tool-search tool

### `test/bedrock.go`

- ✅ Mantle default behavior remains unchanged
  - Default Bedrock `/v1/messages` still goes to `/anthropic/v1/messages`
  - Mantle token auth / AK/SK behavior maintained
- ✅ Runtime Invoke request conversion
  - host/path rewritten to Bedrock Runtime
  - `Accept` is set to `application/json`
  - stream request `Accept` is set to `application/vnd.amazon.eventstream`
  - `model` / `stream` removed from body
  - `anthropic_version` automatically injected
  - `apiVersion` overrides `anthropic_version`
  - `bedrockAdditionalFields` injection
  - `anthropic-beta` header merged into body
  - beta deduplication
  - cache_control.ttl cleanup overwrite messages/system/tools/nested content
- ✅ Runtime Invoke signature
  - Token mode request header conversion
  - AK/SK mode SigV4 uses `bedrock` service
  - Mantle AK/SK still uses `bedrock-mantle` service
- ✅ Runtime Invoke non-streaming response
  - Anthropic Messages body transparently transmitted as it is
- ✅ Runtime Invoke streaming response conversion
  - Bedrock EventStream to Anthropic SSE
  - metrics to `usage`
  - split frame reorganization
  -Single chunk multiple frames
  - Illegal payload converted to `event: error`
  - Format JSON payload compact and output a single line to SSE
  - Convert non-object payloads such as legal JSON array to errors
  - Warn discards the remaining frames at the end without adding `[DONE]`
  - When the final chunk contains both a complete frame and a residual frame, output the complete frame and warn the residual frame.

## Ⅳ. Describe how to verify it

### Method 1: Run full test

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test ./...
```

### Method 2: Run Bedrock related tests

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test . -run '^TestBedrock$'
go test ./provider -run 'TestBedrockAnthropicMessages'
```

### Method 3: Manually verify Mantle’s default behavior

Configure the Bedrock Provider without explicitly configuring the Invoke capability:

```yaml
provider:
  type: bedrock
  apiTokens:
    - "YOUR_AWS_BEARER_TOKEN"
  awsRegion: "us-east-1"
  modelMapping:
    "*": "anthropic.claude-opus-4-20250514-v1:0"
```

Send request:

```bash
curl -X POST http://your-gateway/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude",
    "max_tokens": 1024,
    "messages": [
      {
        "role": "user",
        "content": "hello"
      }
    ]
  }'
```

Expected:

- The upstream host is `bedrock-mantle.us-east-1.api.aws`
- path is `/anthropic/v1/messages`
- Responses are in Anthropic Messages native format

### Method 4: Manually verify the Runtime Invoke compatible path

Explicitly configure the Anthropic Messages capability as Runtime Invoke:

```yaml
provider:
  type: bedrock
  apiTokens:
    - "YOUR_AWS_BEARER_TOKEN"
  awsRegion: "us-east-1"
  capabilities:
    anthropic/v1/messages: /model/%s/invoke
  modelMapping:
    "*": "anthropic.claude-3-5-haiku-20241022-v1:0"
```

Send a non-streaming request:

```bash
curl -X POST http://your-gateway/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude",
    "max_tokens": 1024,
    "messages": [
      {
        "role": "user",
        "content": "hello"
      }
    ]
  }'
```

Expected:

- The upstream path is `/model/anthropic.claude-3-5-haiku-20241022-v1%3A0/invoke`
- body does not contain `model` / `stream`
- body contains `anthropic_version: bedrock-2023-05-31`
- SigV4 service for `bedrock`

### Method 5: Manual verification Runtime streaming Invoke

```bash
curl -N -X POST http://your-gateway/v1/messages \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude",
    "max_tokens": 1024,
    "stream": true,
    "messages": [
      {
        "role": "user",
        "content": "hello"
      }
    ]
  }'
```

Expected:

- The upstream path is `/model/{modelId}/invoke-with-response-stream`
- The upstream `Accept` is `application/vnd.amazon.eventstream`
- The downstream response `Content-Type` is `text/event-stream; charset=utf-8`
- Downstream receives Anthropic SSE, does not contain OpenAI flavor `[DONE]`

## Ⅴ. Special notes for reviews

1. Mantle is the default behavior. Runtime Invoke is a compatibility scheme for old models/old regions and should not replace the default Mantle endpoint.
2. There is no new independent switch for Runtime Invoke selection. The backend domain name and capability will be used first to determine:
   - `bedrock-mantle.` -> Mantle
   - `bedrock-runtime.` -> Invoke
   - Other domain names -> Fallback capability
3. `providerDomain` matches the standardized host prefix to avoid misclassification of proxy domain names.
4. Runtime Invoke streaming returns Bedrock EventStream, and this PR will be converted to Anthropic SSE; Mantle streaming itself is Anthropic SSE and is still transparently transmitted as it is.
5. Anthropic SSE does not require `[DONE]`, so there will be no additional `[DONE]` appended to the end of Runtime Invoke Messages streaming.
6. `tool_search_tool_*_20251119` is the tool type version suffix; the beta tag actually required by Bedrock is `tool-search-tool-2025-10-19`.
7. `cache_control.ttl` cleaning only deletes the ttl of the actual cache_control in the request payload, and does not delete the field describing the ttl in the schema.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have included the AI Coding summary below

### AI Coding Summary

**Key Decisions:**

1. Keep Bedrock Mantle as the `/v1/messages` default endpoint.
2. Add Bedrock Runtime Invoke as a compatible path instead of changing the default behavior.
3. Judge Mantle / Invoke through the standardized `providerDomain` and capability.
4. The Runtime Invoke request only performs Bedrock required field conversion and does not enter the Converse conversion link.
5. Runtime Invoke streaming is uniformly converted to Anthropic SSE, and illegal payloads are not transparently transmitted as they are.

**Main scope of changes:**

1. `provider/bedrock.go`
   - Added Anthropic Messages Invoke request conversion
   - Added Mantle / Invoke endpoint judgment
   - Added Runtime Invoke path rewriting and SigV4 service selection
   - Added `anthropic_beta` merge and automatic beta injection
   - Added `cache_control.ttl` cleaning
   - Added EventStream -> Anthropic SSE conversion
2. `provider/provider.go`
   - Allow `ApiNameAnthropicMessages` to use custom capability
3. `provider/bedrock_sigv4_path_test.go`
   - Supplement endpoint determination, signature path, auto beta testing
4. `test/bedrock.go`
   - Added Mantle default behavior, Runtime Invoke request/response/streaming test

**Verification result:**

1. `go test ./provider -run 'TestBedrockAnthropicMessagesAutoBetas'` passed
2. `go test . -run '^TestBedrock$'` passed
3. `go test ./...` passed
