### PR TITLE
fix: rebuild mcp filter on high memory usage

### DIFF
--- a/plugins/wasm-go/pkg/mcp/filter/plugin.go
+++ b/plugins/wasm-go/pkg/mcp/filter/plugin.go
@@ -20,8 +20,8 @@ import (
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
 
-	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/alibaba/higress/plugins/wasm-go/pkg/mcp/utils"
+	"github.com/higress-group/wasm-go/pkg/log"
 	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
@@ -209,6 +209,7 @@ func Initialize() {
 		wrapper.ProcessResponseHeaders(onHttpResponseHeaders),
 		wrapper.ProcessRequestBody(onHttpRequestBody),
 		wrapper.ProcessResponseBody(onHttpResponseBody),
+		wrapper.WithRebuildMaxMemBytes[mcpFilterConfig](200*1024*1024),
 	)
 
 }


### PR DESCRIPTION
## Summary
- add a max memory rebuild threshold for the MCP filter context
- align the MCP filter behavior with plugins such as ai-proxy to recreate the VM after memory usage exceeds 200 MiB

## Testing
- go test ./... (from plugins/wasm-go/extensions/mcp-server)

Addresses #3917