### PR TITLE
fix(wasm): remove request-count rebuild triggers

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/main.go
+++ b/plugins/wasm-go/extensions/ai-cache/main.go
@@ -38,7 +38,6 @@ func init() {
 		wrapper.ProcessRequestBodyBy(onHttpRequestBody),
 		wrapper.ProcessResponseHeadersBy(onHttpResponseHeaders),
 		wrapper.ProcessStreamingResponseBodyBy(onHttpResponseBody),
-		wrapper.WithRebuildAfterRequests[config.PluginConfig](1000),
 	)
 }
 

--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -111,7 +111,6 @@ func init() {
 		wrapper.ProcessResponseHeaders(onHttpResponseHeaders),
 		wrapper.ProcessStreamingResponseBody(onStreamingResponseBody),
 		wrapper.ProcessResponseBody(onHttpResponseBody),
-		wrapper.WithRebuildAfterRequests[config.PluginConfig](1000),
 		wrapper.WithRebuildMaxMemBytes[config.PluginConfig](200*1024*1024),
 	)
 }

--- a/plugins/wasm-go/extensions/ai-security-guard/main.go
+++ b/plugins/wasm-go/extensions/ai-security-guard/main.go
@@ -22,7 +22,6 @@ func init() {
 		wrapper.ProcessResponseHeaders(onHttpResponseHeaders),
 		wrapper.ProcessStreamingResponseBody(onHttpStreamingResponseBody),
 		wrapper.ProcessResponseBody(onHttpResponseBody),
-		wrapper.WithRebuildAfterRequests[cfg.AISecurityConfig](1000),
 	)
 }
 

--- a/plugins/wasm-go/extensions/ai-statistics/main.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main.go
@@ -39,7 +39,6 @@ func init() {
 		wrapper.ProcessResponseHeaders(onHttpResponseHeaders),
 		wrapper.ProcessStreamingResponseBody(onHttpStreamingBody),
 		wrapper.ProcessResponseBody(onHttpResponseBody),
-		wrapper.WithRebuildAfterRequests[AIStatisticsConfig](1000),
 		wrapper.WithRebuildMaxMemBytes[AIStatisticsConfig](200*1024*1024),
 	)
 }

--- a/plugins/wasm-go/extensions/model-mapper/main.go
+++ b/plugins/wasm-go/extensions/model-mapper/main.go
@@ -26,7 +26,6 @@ func init() {
 		wrapper.ParseConfig(parseConfig),
 		wrapper.ProcessRequestHeaders(onHttpRequestHeaders),
 		wrapper.ProcessRequestBody(onHttpRequestBody),
-		wrapper.WithRebuildAfterRequests[Config](1000),
 		wrapper.WithRebuildMaxMemBytes[Config](200*1024*1024),
 	)
 }

--- a/plugins/wasm-go/extensions/model-router/main.go
+++ b/plugins/wasm-go/extensions/model-router/main.go
@@ -32,7 +32,6 @@ func init() {
 		wrapper.ParseConfig(parseConfig),
 		wrapper.ProcessRequestHeaders(onHttpRequestHeaders),
 		wrapper.ProcessRequestBody(onHttpRequestBody),
-		wrapper.WithRebuildAfterRequests[ModelRouterConfig](1000),
 		wrapper.WithRebuildMaxMemBytes[ModelRouterConfig](200*1024*1024),
 	)
 }

--- a/plugins/wasm-go/extensions/transformer/main.go
+++ b/plugins/wasm-go/extensions/transformer/main.go
@@ -39,7 +39,6 @@ func init() {
 		wrapper.ProcessRequestBodyBy(onHttpRequestBody),
 		wrapper.ProcessResponseHeadersBy(onHttpResponseHeaders),
 		wrapper.ProcessResponseBodyBy(onHttpResponseBody),
-		wrapper.WithRebuildAfterRequests[TransformerConfig](1000),
 	)
 }
 


### PR DESCRIPTION
## Summary

- Remove request-count based proactive rebuild triggers from WASM extensions.
- Keep memory-threshold based rebuild triggers where they already exist.
- Reduce unnecessary WASM VM rebuilds while investigating the Envoy memory growth reported in #3920.

## Context

In #3920, Envoy RSS can keep growing and `wasm.envoy.wasm.runtime.v8.active` was observed to be much higher than the expected worker/main-thread VM count. Before the exact root cause is confirmed, request-count based rebuilds can add extra churn under steady traffic. Existing memory-threshold rebuilds are kept for the plugins that already use them.

## Validation

- `grep -R "WithRebuildAfterRequests" plugins/wasm-go/extensions --include='*.go'` returns no matches.
- Compile-only checks passed for changed extensions:
  - `go test -run '^$' -timeout 60s ./...` in `ai-proxy`, `ai-cache`, `ai-security-guard`, `ai-statistics`, `model-mapper`, `model-router`
  - `go test -vet=off -run '^$' -timeout 60s ./...` in `transformer`

Note: `transformer` has a pre-existing vet failure on a non-constant `errors.Wrapf` format string; compile-only check passes with vet disabled.

Related to #3920
