### PR TITLE
fix(ai-proxy): use custom domain as Host header in Claude provider

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 
@@ -314,15 +315,53 @@ func (c *claudeProviderInitializer) DefaultCapabilities() map[string]string {
 }
 
 func (c *claudeProviderInitializer) CreateProvider(config ProviderConfig) (Provider, error) {
-	config.setDefaultCapabilities(c.DefaultCapabilities())
+	if config.claudeCustomUrl == "" {
+		config.setDefaultCapabilities(c.DefaultCapabilities())
+		return &claudeProvider{
+			config:       config,
+			contextCache: createContextCache(&config),
+		}, nil
+	}
+
+	// claudeCustomUrl supports:
+	// - https://api.anthropic.com
+	// - https://example.com/anthropic (path prefix)
+	// - https://example.com/anthropic/v1/messages (direct messages endpoint)
+	customUrl := strings.TrimPrefix(strings.TrimPrefix(config.claudeCustomUrl, "http://"), "https://")
+	pairs := strings.SplitN(customUrl, "/", 2)
+	customDomain := pairs[0]
+	customPath := "/"
+	if len(pairs) == 2 {
+		customPath += pairs[1]
+	}
+
+	capabilities := c.DefaultCapabilities()
+	isDirectMessagesEndpoint := strings.HasSuffix(customPath, PathAnthropicMessages) || strings.HasSuffix(customPath, "/messages")
+	if isDirectMessagesEndpoint {
+		// Only override messages capabilities with the direct endpoint path, leave other capabilities unchanged.
+		capabilities[string(ApiNameChatCompletion)] = customPath
+		capabilities[string(ApiNameAnthropicMessages)] = customPath
+	} else if customPath != "/" {
+		// Treat customPath as a prefix and prepend it to all default capability paths.
+		for key, p := range capabilities {
+			capabilities[key] = path.Join(customPath, strings.TrimPrefix(p, "/"))
+		}
+	}
+
+	config.setDefaultCapabilities(capabilities)
+	log.Debugf("ai-proxy: claude provider customDomain:%s, customPath:%s, isDirectMessagesEndpoint:%v, capabilities:%v",
+		customDomain, customPath, isDirectMessagesEndpoint, capabilities)
+
 	return &claudeProvider{
-		config:       config,
-		contextCache: createContextCache(&config),
+		config:             config,
+		customDomain:       customDomain,
+		contextCache:       createContextCache(&config),
 	}, nil
 }
 
 type claudeProvider struct {
 	config       ProviderConfig
+	customDomain string
 	contextCache *contextCache
 
 	messageId   string
@@ -341,7 +380,12 @@ func (c *claudeProvider) OnRequestHeaders(ctx wrapper.HttpContext, apiName ApiNa
 
 func (c *claudeProvider) TransformRequestHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
 	util.OverwriteRequestPathHeaderByCapability(headers, string(apiName), c.config.capabilities)
-	util.OverwriteRequestHostHeader(headers, claudeDomain)
+	if c.customDomain != "" {
+		util.OverwriteRequestHostHeader(headers, c.customDomain)
+	} else {
+		domain := c.config.resolveDomain("", claudeDomain)
+		util.OverwriteRequestHostHeader(headers, domain)
+	}
 
 	if c.config.apiVersion == "" {
 		c.config.apiVersion = claudeDefaultVersion

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -331,6 +331,9 @@ type ProviderConfig struct {
 	// @Title zh-CN 基于OpenAI协议的自定义后端URL
 	// @Description zh-CN 仅适用于支持 openai 协议的服务。
 	openaiCustomUrl string `required:"false" yaml:"openaiCustomUrl" json:"openaiCustomUrl"`
+	// @Title zh-CN 基于Claude(Anthropic)协议的自定义后端URL
+	// @Description zh-CN 仅适用于 Claude(Anthropic) 协议的服务，可用于配置自定义域名/路径前缀，例如: <https://api.anthropic.com> 或 <https://example.com/anthropic>
+	claudeCustomUrl string `required:"false" yaml:"claudeCustomUrl" json:"claudeCustomUrl"`
 	// @Title zh-CN Moonshot File ID
 	// @Description zh-CN 仅适用于Moonshot AI服务。Moonshot AI服务的文件ID，其内容用于补充AI请求上下文
 	moonshotFileId string `required:"false" yaml:"moonshotFileId" json:"moonshotFileId"`
@@ -567,6 +570,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 	// first byte timeout
 	c.firstByteTimeout = uint32(json.Get("firstByteTimeout").Uint())
 	c.openaiCustomUrl = json.Get("openaiCustomUrl").String()
+	c.claudeCustomUrl = json.Get("claudeCustomUrl").String()
 	c.moonshotFileId = json.Get("moonshotFileId").String()
 	c.azureServiceUrl = json.Get("azureServiceUrl").String()
 	c.qwenFileIds = make([]string, 0)


### PR DESCRIPTION
## Description

When `claudeCustomUrl` is configured in a Claude provider, the `TransformRequestHeaders` method unconditionally overwrites the `Host` header to `api.anthropic.com`. This causes requests to third-party Anthropic-compatible gateways (Huawei Cloud ModelArts, AWS Bedrock proxies, LiteLLM, etc.) to be rejected with 404, because the upstream gateway/WAF validates the Host header and rejects unknown hosts.

## Changes

### `claude.go`

1. **Added `"path"` import** for path joining when computing custom capability paths.
2. **`CreateProvider`** — When `claudeCustomUrl` is set, parses the URL to extract:
   - `customDomain` — the host portion, stored on the provider struct
   - `customPath` — the path portion, used to adjust API capabilities
   - Supports plain origin, path prefix, and direct `/v1/messages` endpoint URLs
3. **`claudeProvider` struct** — Added `customDomain string` field.
4. **`TransformRequestHeaders`** — Uses `customDomain` when configured instead of hardcoded `claudeDomain`. Falls back to `resolveDomain("", claudeDomain)` when no custom URL is set.

### `provider.go`

1. **`ProviderConfig`** — Added `claudeCustomUrl` field with JSON/YAML tags.
2. **`FromJson`** — Parses `claudeCustomUrl` from JSON config.

## Verification

- The behavior when `claudeCustomUrl` is empty is unchanged (uses `resolveDomain("", claudeDomain)`).
- The behavior mirrors the OpenAI provider (`openai.go`), which already does the same for `openaiCustomUrl`.

## Related

Fixes #3934
Ref: #3671 (unmerged prior attempt by @ThxCode-Chen)