### PR TITLE
feat(ai-load-balancer): 新增 endpoint_hash 会话保持负载均衡策略  || feat(ai-load-balancer): Added endpoint_hash session maintenance load balancing strategy

### DIFF
--- a/plugins/wasm-go/extensions/ai-load-balancer/README.md
+++ b/plugins/wasm-go/extensions/ai-load-balancer/README.md
@@ -24,6 +24,7 @@ description: 针对LLM服务的负载均衡策略
 - `global_least_request`: 基于redis实现的全局最小请求数负载均衡
 - `prefix_cache`: 基于 prompt 前缀匹配选择后端节点，如果通过前缀匹配无法匹配到节点，则通过全局最小请求数进行服务节点的选择
 - `endpoint_metrics`: 基于 llm 服务暴露的 metrics 进行负载均衡
+- `endpoint_hash`: 基于 Redis 的有状态会话保持。读取指定请求头作为 key，将相同 key 的请求始终路由到同一个后端节点（host）；首次出现的 key 由服务自身默认 LB 选址并记录，后续请求复用；当请求缺少该 key 时，退化为服务自身的默认负载均衡策略
 
 `lb_type` 为 `cluster` 时支持的负载均衡策略包括：
 - `cluster_metrics`: 基于网关统计的不同service的指标进行服务之间的负载均衡
@@ -238,6 +239,79 @@ lb_config:
   - outbound|80||test-1.dns
   - outbound|80||test-2.static
 ```
+
+# Endpoint Hash（基于 Redis 的有状态会话保持）
+
+## 功能说明
+
+读取指定请求头的值作为 key，把相同 key 的请求**粘性**路由到同一个后端节点（host），实现会话保持。映射关系保存在 Redis 中，跨网关实例共享、重启不丢失。
+
+选址顺序：
+
+1. 请求**缺少** `hash_header` 指定的请求头 → 不介入选址，直接走服务自身默认 LB，不记录状态。
+2. key 存在 → 用 FNV-1a 对 key 做 hash，按 `路由名:集群名:hash` 作为 Redis key 查询：
+   - **命中**且记录的 host 仍健康 → `SetUpstreamOverrideHost` 固定到该 host，并刷新 TTL。
+   - **未命中**（首次出现）或记录的 host 已不健康 → 不 override，让**服务自身默认 LB**选址；在响应阶段读取实际选中的 host（`upstream.address`），写回 Redis 供后续请求复用。
+
+与 `cluster_hash` 的区别：
+- `endpoint_hash` 作用在 **endpoint 级**，通过 `SetUpstreamOverrideHost` 在已选定的 cluster 内部固定 host（机制与 `global_least_request` 一致），无需配合 EnvoyFilter。
+- **有状态**：首次选址由默认 LB（如 least-request）决定，兼顾负载均衡；之后稳定粘住，且记录写入 Redis 后**不随扩缩容迁移**（除非该 host 不健康才重新选址）。
+- Redis 不可用 / 缺 header / 无健康节点时，均**优雅退化**为服务自身默认 LB，不拒绝请求。
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant H as Higress
+    participant R as Redis
+    participant LB as 默认 LB
+    participant Ht as Host(目标)
+
+    C ->> H: 发起请求(携带 hash_header)
+    H ->> R: GET 路由名:集群名:hash(key)
+    alt 命中且 host 健康
+        R ->> H: 返回已绑定 host
+        H ->> R: EXPIRE 续期 TTL
+        H ->> Ht: SetUpstreamOverrideHost，转发到绑定 host
+    else 未命中 / host 失效
+        R ->> H: 空 / 失效
+        H ->> LB: 不 override，交给服务默认 LB 选址
+        LB ->> Ht: 转发到默认 LB 选中的 host
+        H ->> R: 响应头阶段读取 upstream.address，SETEX 写回映射
+    end
+    Ht ->> H: 返回响应
+    H ->> C: 返回响应
+```
+
+## 配置说明
+
+| 名称 | 数据类型 | 填写要求 | 默认值 | 描述 |
+|------|----------|----------|--------|------|
+| `hash_header` | string | 选填 | `x-mse-consumer` | 读取 hash key 的请求头名称 |
+| `stickyTimeout` | int | 选填 | `60` | 粘性映射的过期时间（分钟），命中时自动续期 |
+| `serviceFQDN` | string | 必填 | - | Redis 服务的 FQDN |
+| `servicePort` | int | 必填 | - | Redis 服务端口 |
+| `username` | string | 选填 | - | Redis 用户名（Redis 6+ ACL 一般为 `default`） |
+| `password` | string | 选填 | - | Redis 密码。**若 Redis 开启鉴权必须填写**，否则每次读写都会 `NOAUTH` 失败，导致粘性完全不生效 |
+| `timeout` | int | 选填 | `3000` | Redis 操作超时（毫秒） |
+| `database` | int | 选填 | `0` | Redis database 编号 |
+
+## 配置示例
+
+```yaml
+lb_type: endpoint
+lb_policy: endpoint_hash
+lb_config:
+  hash_header: x-mse-consumer
+  stickyTimeout: 60
+  serviceFQDN: redis.dns
+  servicePort: 6379
+  username: default
+  password: "123456"
+  timeout: 3000
+  database: 0
+```
+
+> 当请求不含 `hash_header` 指定的请求头时，本策略不介入选址，请求按服务原本的负载均衡策略转发。
 
 # Cluster Hash（一致性 Hash 路由）
 

--- a/plugins/wasm-go/extensions/ai-load-balancer/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-load-balancer/README_EN.md
@@ -24,6 +24,7 @@ When `lb_type = endpoint`, current supported load balance policies are:
 - `global_least_request`: global least request based on redis
 - `prefix_cache`: Select the backend node based on the prompt prefix match. If the node cannot be matched by prefix matching, the service node is selected based on the global minimum number of requests.
 - `endpoint_metrics`: Load balancing based on metrics exposed by the llm service
+- `endpoint_hash`: Redis-backed stateful session affinity. Reads a specified request header as the key and sticks requests with the same key to the same backend host (endpoint). The first time a key is seen, the host is chosen by the service's own default LB and recorded; subsequent requests reuse it. When the key is absent, it degrades to the service's own default load balancing policy.
 
 When `lb_type = cluster`, current supported load balance policies are:
 - `cluster_metrics`: Load balancing based on metrics of clusters
@@ -282,3 +283,76 @@ lb_config:
 ```
 
 If the request is missing the hash header, the plugin returns **403** directly.
+
+# Endpoint Hash (Redis-backed Stateful Session Affinity)
+
+## Introduction
+
+Reads a specified request header value as the key and **sticks** requests with the same key to the same backend host (endpoint) to achieve session affinity. The mapping is stored in Redis, so it is shared across gateway instances and survives restarts.
+
+Selection order:
+
+1. The request is **missing** the header named by `hash_header` → no override, use the service's own default LB, record nothing.
+2. The key exists → FNV-1a hash it and look it up in Redis under `route:cluster:hash`:
+   - **Hit** and the recorded host is still healthy → `SetUpstreamOverrideHost` pins the request to that host and refreshes the TTL.
+   - **Miss** (first time) or the recorded host is no longer healthy → do not override, let the service's **own default LB** pick a host; in the response-header phase read the actually selected host (`upstream.address`) and write it back to Redis for reuse.
+
+Differences from `cluster_hash`:
+- `endpoint_hash` works at the **endpoint level** via `SetUpstreamOverrideHost`, pinning a host inside the already-selected cluster (same mechanism as `global_least_request`); no EnvoyFilter required.
+- **Stateful**: the first selection is made by the default LB (e.g. least-request) for load balancing, then it sticks; once written to Redis the mapping **does not migrate on scaling** (unless the host becomes unhealthy and is re-picked).
+- When Redis is unavailable / the header is missing / there is no healthy host, it **gracefully degrades** to the service's own default LB rather than rejecting the request.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant H as Higress
+    participant R as Redis
+    participant LB as Default LB
+    participant Ht as Host(target)
+
+    C ->> H: Send request (with hash_header)
+    H ->> R: GET route:cluster:hash(key)
+    alt Hit and host healthy
+        R ->> H: Return bound host
+        H ->> R: EXPIRE to refresh TTL
+        H ->> Ht: SetUpstreamOverrideHost, forward to bound host
+    else Miss / host stale
+        R ->> H: Empty / stale
+        H ->> LB: No override, let the default LB pick
+        LB ->> Ht: Forward to the host chosen by default LB
+        H ->> R: In response-header phase read upstream.address, SETEX the mapping
+    end
+    Ht ->> H: Response
+    H ->> C: Response
+```
+
+## Configuration
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `hash_header` | string | optional | `x-mse-consumer` | Request header name to read the hash key from |
+| `stickyTimeout` | int | optional | `60` | TTL of a sticky mapping (minutes); auto-refreshed on hit |
+| `serviceFQDN` | string | required | - | Redis service FQDN |
+| `servicePort` | int | required | - | Redis service port |
+| `username` | string | optional | - | Redis username (usually `default` for Redis 6+ ACL) |
+| `password` | string | optional | - | Redis password. **Required if Redis auth is enabled**, otherwise every read/write fails with `NOAUTH` and stickiness never works |
+| `timeout` | int | optional | `3000` | Redis operation timeout (ms) |
+| `database` | int | optional | `0` | Redis database number |
+
+## Configuration Example
+
+```yaml
+lb_type: endpoint
+lb_policy: endpoint_hash
+lb_config:
+  hash_header: x-mse-consumer
+  stickyTimeout: 60
+  serviceFQDN: redis.dns
+  servicePort: 6379
+  username: default
+  password: "123456"
+  timeout: 3000
+  database: 0
+```
+
+> When the request does not carry the header named by `hash_header`, this policy does not intervene and the request is forwarded by the service's original load balancing policy.

--- a/plugins/wasm-go/extensions/ai-load-balancer/endpoint_hash/lb_policy.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/endpoint_hash/lb_policy.go
@@ -1,0 +1,257 @@
+package endpoint_hash
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/utils"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/log"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/resp"
+)
+
+const (
+	DefaultHashHeader = "x-mse-consumer"
+	// RedisKeyFormat: higress:endpoint_hash_table:{routeName}:{clusterName}:{stateKey}
+	// value = the bound upstream host address ("ip:port").
+	RedisKeyFormat = "higress:endpoint_hash_table:%s:%s:%s"
+
+	ctxStateKey = "endpoint_hash_state_key"
+	ctxNeedSave = "endpoint_hash_need_save"
+	ctxHashKey  = "endpoint_hash_hash_key"
+	ctxRecorded = "endpoint_hash_recorded"
+
+	logTag = "[ai-load-balancer/endpoint_hash]"
+)
+
+// EndpointHashLoadBalancer implements stateful sticky routing:
+//   - With a hash key, it looks up the key's bound host in Redis. On a hit
+//     (and the host still healthy) the request is pinned to that host.
+//   - On a miss (first time the key is seen, or the bound host is gone), it
+//     does NOT override and lets the service's own default LB pick a host,
+//     then persists key -> chosen host to Redis for subsequent requests.
+//   - Without a hash key, it never overrides — the request just uses the
+//     default LB and no state is recorded.
+type EndpointHashLoadBalancer struct {
+	redisClient   wrapper.RedisClient
+	HashHeader    string
+	stickyTimeout int // TTL of a sticky entry, in seconds
+}
+
+func NewEndpointHashLoadBalancer(json gjson.Result) (EndpointHashLoadBalancer, error) {
+	lb := EndpointHashLoadBalancer{}
+
+	lb.HashHeader = json.Get("hash_header").String()
+	if lb.HashHeader == "" {
+		lb.HashHeader = DefaultHashHeader
+	}
+
+	// stickyTimeout is configured in minutes; default 60 minutes.
+	stickyTimeout := json.Get("stickyTimeout").Int()
+	if stickyTimeout == 0 {
+		stickyTimeout = 60
+	}
+	lb.stickyTimeout = int(stickyTimeout) * 60
+
+	serviceFQDN := json.Get("serviceFQDN").String()
+	servicePort := json.Get("servicePort").Int()
+	if serviceFQDN == "" || servicePort == 0 {
+		log.Errorf("invalid redis service, serviceFQDN: %s, servicePort: %d", serviceFQDN, servicePort)
+		return lb, errors.New("invalid redis service config")
+	}
+	lb.redisClient = wrapper.NewRedisClusterClient(wrapper.FQDNCluster{
+		FQDN: serviceFQDN,
+		Port: servicePort,
+	})
+	username := json.Get("username").String()
+	password := json.Get("password").String()
+	if password == "" {
+		log.Warnf("%s redis password is empty; if your Redis requires authentication, every read/write will fail with NOAUTH and stickiness will not work", logTag)
+	}
+	timeout := json.Get("timeout").Int()
+	if timeout == 0 {
+		timeout = 3000
+	}
+	database := json.Get("database").Int()
+	log.Infof("endpoint_hash redis init, serviceFQDN: %s, servicePort: %d, timeout: %d, database: %d, hashHeader: %s, stickyTimeout: %d minutes",
+		serviceFQDN, servicePort, timeout, database, lb.HashHeader, lb.stickyTimeout/60)
+	return lb, lb.redisClient.Init(username, password, int64(timeout), wrapper.WithDataBase(int(database)))
+}
+
+// stateKey derives the Redis key for a hash header value using FNV-1a, scoped
+// by route + cluster so different routes/clusters keep independent mappings.
+func stateKey(routeName, clusterName, hashKey string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(hashKey))
+	return fmt.Sprintf(RedisKeyFormat, routeName, clusterName, fmt.Sprintf("%08x", h.Sum32()))
+}
+
+// readUpstreamAddress returns the address ("ip:port") of the host actually
+// chosen by the upstream (default LB), or "" if it is not available yet.
+func readUpstreamAddress() string {
+	if addr, err := proxywasm.GetProperty([]string{"upstream", "address"}); err == nil && len(addr) > 0 {
+		return string(addr)
+	}
+	return ""
+}
+
+// record persists key -> chosen host with TTL. It MUST be called from a live
+// request/response phase (e.g. response headers), NOT from HandleHttpStreamDone:
+// in the stream-done phase the filter context is being torn down and the async
+// Redis dispatch never actually reaches Redis (the local dispatch still returns
+// OK, which silently loses the write). The callback logs the real Redis reply
+// so a lost/failed write is traceable.
+func (lb EndpointHashLoadBalancer) record(ctx wrapper.HttpContext, hashKey, sKey, host string) {
+	err := lb.redisClient.SetEx(sKey, host, lb.stickyTimeout, func(response resp.Value) {
+		if response.Error() != nil {
+			log.Errorf("%s record_reply_err key=%q skey=%s host=%s err=%v", logTag, hashKey, sKey, host, response.Error())
+			return
+		}
+		ctx.SetContext(ctxRecorded, true)
+		log.Infof("%s record_ok key=%q skey=%s host=%s ttl=%ds reply=%s", logTag, hashKey, sKey, host, lb.stickyTimeout, response.String())
+	})
+	if err != nil {
+		log.Errorf("%s record_dispatch_failed key=%q skey=%s host=%s err=%v", logTag, hashKey, sKey, host, err)
+	}
+}
+
+func (lb EndpointHashLoadBalancer) HandleHttpRequestHeaders(ctx wrapper.HttpContext) types.Action {
+	// Defer to the body phase: SetUpstreamOverrideHost only takes effect after
+	// the route/cluster is resolved (same constraint as global_least_request).
+	return types.HeaderStopIteration
+}
+
+func (lb EndpointHashLoadBalancer) HandleHttpRequestBody(ctx wrapper.HttpContext, body []byte) types.Action {
+	hashKey, err := proxywasm.GetHttpRequestHeader(lb.HashHeader)
+	if err != nil || hashKey == "" {
+		// No hash key -> never override, no state recorded, use default LB.
+		log.Debugf("%s decision=NO_KEY header=%q -> default lb (no stickiness)", logTag, lb.HashHeader)
+		return types.ActionContinue
+	}
+
+	routeName, err := utils.GetRouteName()
+	if err != nil || routeName == "" {
+		log.Warnf("%s decision=DEGRADE key=%q reason=get_route_name_failed err=%v -> default lb", logTag, hashKey, err)
+		return types.ActionContinue
+	}
+	clusterName, err := utils.GetClusterName()
+	if err != nil || clusterName == "" {
+		log.Warnf("%s decision=DEGRADE key=%q reason=get_cluster_name_failed err=%v -> default lb", logTag, hashKey, err)
+		return types.ActionContinue
+	}
+
+	// Snapshot the current healthy host set; used to validate a stored host.
+	hostInfos, err := proxywasm.GetUpstreamHosts()
+	if err != nil {
+		log.Warnf("%s decision=DEGRADE key=%q route=%s cluster=%s reason=get_upstream_hosts_failed err=%v -> default lb", logTag, hashKey, routeName, clusterName, err)
+		return types.ActionContinue
+	}
+	healthySet := make(map[string]struct{}, len(hostInfos))
+	for _, hostInfo := range hostInfos {
+		if gjson.Get(hostInfo[1], "health_status").String() == "Healthy" {
+			healthySet[hostInfo[0]] = struct{}{}
+		}
+	}
+	if len(healthySet) == 0 {
+		log.Warnf("%s decision=DEGRADE key=%q route=%s cluster=%s reason=no_healthy_host -> default lb", logTag, hashKey, routeName, clusterName)
+		return types.ActionContinue
+	}
+
+	sKey := stateKey(routeName, clusterName, hashKey)
+	ctx.SetContext(ctxStateKey, sKey)
+	ctx.SetContext(ctxHashKey, hashKey)
+
+	err = lb.redisClient.Get(sKey, func(response resp.Value) {
+		storedHost := ""
+		if response.Error() != nil {
+			log.Errorf("%s redis_get_err key=%q skey=%s err=%v -> treat as miss", logTag, hashKey, sKey, response.Error())
+		} else {
+			storedHost = response.String()
+		}
+
+		if storedHost != "" {
+			if _, ok := healthySet[storedHost]; ok {
+				// HIT: pin to the stored host.
+				if err := proxywasm.SetUpstreamOverrideHost([]byte(storedHost)); err != nil {
+					log.Errorf("%s decision=HIT_FALLBACK key=%q skey=%s host=%s reason=override_failed err=%v -> default lb, will record", logTag, hashKey, sKey, storedHost, err)
+				} else {
+					// Refresh TTL so active keys don't expire (best-effort).
+					_ = lb.redisClient.Expire(sKey, lb.stickyTimeout, nil)
+					log.Infof("%s decision=HIT key=%q skey=%s host=%s ttl_refreshed=%ds (override)", logTag, hashKey, sKey, storedHost, lb.stickyTimeout)
+					proxywasm.ResumeHttpRequest()
+					return
+				}
+			} else {
+				log.Infof("%s decision=STALE key=%q skey=%s stored_host=%s reason=unhealthy -> default lb, will record", logTag, hashKey, sKey, storedHost)
+			}
+		} else {
+			log.Infof("%s decision=MISS key=%q skey=%s -> default lb, will record", logTag, hashKey, sKey)
+		}
+
+		// MISS / STALE / override-failed: let the default LB pick, then persist
+		// the chosen host in the response/done phase.
+		ctx.SetContext(ctxNeedSave, true)
+		proxywasm.ResumeHttpRequest()
+	})
+	if err != nil {
+		// Redis unavailable -> degrade to default LB without stickiness.
+		log.Warnf("%s decision=DEGRADE key=%q skey=%s reason=redis_get_dispatch_failed err=%v -> default lb", logTag, hashKey, sKey, err)
+		return types.ActionContinue
+	}
+	return types.ActionPause
+}
+
+func (lb EndpointHashLoadBalancer) HandleHttpResponseHeaders(ctx wrapper.HttpContext) types.Action {
+	needSave, _ := ctx.GetContext(ctxNeedSave).(bool)
+	if !needSave {
+		return types.ActionContinue
+	}
+	// Persist the default-LB choice HERE (a live phase), not in StreamDone — the
+	// upstream host is already selected, the context is still alive, so the async
+	// SETEX actually reaches Redis.
+	sKey, _ := ctx.GetContext(ctxStateKey).(string)
+	hashKey, _ := ctx.GetContext(ctxHashKey).(string)
+	host := readUpstreamAddress()
+	if sKey == "" || host == "" {
+		// upstream.address not ready yet -> StreamDone will retry as a fallback.
+		log.Warnf("%s record_deferred key=%q skey=%s reason=upstream_address_not_ready_at_response_headers", logTag, hashKey, sKey)
+		return types.ActionContinue
+	}
+	lb.record(ctx, hashKey, sKey, host)
+	return types.ActionContinue
+}
+
+func (lb EndpointHashLoadBalancer) HandleHttpStreamingResponseBody(ctx wrapper.HttpContext, data []byte, endOfStream bool) []byte {
+	return data
+}
+
+func (lb EndpointHashLoadBalancer) HandleHttpResponseBody(ctx wrapper.HttpContext, body []byte) types.Action {
+	return types.ActionContinue
+}
+
+func (lb EndpointHashLoadBalancer) HandleHttpStreamDone(ctx wrapper.HttpContext) {
+	needSave, _ := ctx.GetContext(ctxNeedSave).(bool)
+	if !needSave {
+		return
+	}
+	// If the write already happened in the response-header phase, nothing to do.
+	if recorded, _ := ctx.GetContext(ctxRecorded).(bool); recorded {
+		return
+	}
+	// Fallback path: the write was deferred because upstream.address was not
+	// ready at response headers. This is best-effort only — async Redis calls in
+	// the stream-done phase may not reach Redis — so we log it as a fallback.
+	sKey, _ := ctx.GetContext(ctxStateKey).(string)
+	hashKey, _ := ctx.GetContext(ctxHashKey).(string)
+	host := readUpstreamAddress()
+	if sKey == "" || host == "" {
+		log.Warnf("%s record_skipped key=%q skey=%s reason=upstream_address_unavailable", logTag, hashKey, sKey)
+		return
+	}
+	log.Warnf("%s record_fallback_in_stream_done key=%q skey=%s host=%s (may not persist)", logTag, hashKey, sKey, host)
+	lb.record(ctx, hashKey, sKey, host)
+}

--- a/plugins/wasm-go/extensions/ai-load-balancer/endpoint_hash/lb_policy_test.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/endpoint_hash/lb_policy_test.go
@@ -1,0 +1,35 @@
+package endpoint_hash
+
+import (
+	"strings"
+	"testing"
+)
+
+// Note: NewEndpointHashLoadBalancer and the request/response handlers depend on
+// the wasm host (proxywasm log, redis, properties) and cannot run under native
+// `go test`; they are exercised via build-image + gateway integration. Here we
+// only unit-test the pure stateKey derivation.
+
+func TestStateKey_Deterministic(t *testing.T) {
+	k1 := stateKey("route-a", "cluster-a", "alice")
+	k2 := stateKey("route-a", "cluster-a", "alice")
+	if k1 != k2 {
+		t.Errorf("stateKey must be deterministic: %q != %q", k1, k2)
+	}
+	if !strings.HasPrefix(k1, "higress:endpoint_hash_table:route-a:cluster-a:") {
+		t.Errorf("unexpected stateKey format: %q", k1)
+	}
+}
+
+func TestStateKey_ScopedByRouteAndCluster(t *testing.T) {
+	base := stateKey("route-a", "cluster-a", "alice")
+	if got := stateKey("route-b", "cluster-a", "alice"); got == base {
+		t.Error("different routes must yield different state keys")
+	}
+	if got := stateKey("route-a", "cluster-b", "alice"); got == base {
+		t.Error("different clusters must yield different state keys")
+	}
+	if got := stateKey("route-a", "cluster-a", "bob"); got == base {
+		t.Error("different hash keys must yield different state keys")
+	}
+}

--- a/plugins/wasm-go/extensions/ai-load-balancer/main.go
+++ b/plugins/wasm-go/extensions/ai-load-balancer/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/cluster_metrics"
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/cluster_hash"
+	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/endpoint_hash"
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/endpoint_metrics"
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/global_least_request"
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-load-balancer/prefix_cache"
@@ -55,6 +56,7 @@ const (
 	MetricsBasedEndpointDeprecated = "metrics_based" // Compatible with old configurations, equal to `endpoint_metrics`
 	GlobalLeastRequestEndpoint     = "global_least_request"
 	PrefixCacheEndpoint            = "prefix_cache"
+	EndpointHashEndpoint           = "endpoint_hash"
 )
 
 func parseConfig(json gjson.Result, config *Config) error {
@@ -83,6 +85,8 @@ func parseConfig(json gjson.Result, config *Config) error {
 			config.lb, err = global_least_request.NewGlobalLeastRequestLoadBalancer(json.Get("lb_config"))
 		case PrefixCacheEndpoint:
 			config.lb, err = prefix_cache.NewPrefixCacheLoadBalancer(json.Get("lb_config"))
+		case EndpointHashEndpoint:
+			config.lb, err = endpoint_hash.NewEndpointHashLoadBalancer(json.Get("lb_config"))
 		default:
 			err = fmt.Errorf("lb_psolicy %s is not supported", config.lbPolicy)
 		}


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

为 `ai-load-balancer` 插件新增一种基于 Redis 的**有状态会话保持**端点负载均衡策略`endpoint_hash`：读取指定请求头作为 key，将相同 key 的请求始终路由到同一个后端节点（host）。

工作机制：
- 首次出现的 key：由服务自身默认 LB 选址，并在「响应头阶段」把选中的 host （`upstream.address`）记录到 Redis；后续同 key 请求通过 `SetUpstreamOverrideHost`  复用该 host。
- 优雅降级：缺少 key / 无健康节点 / Redis 异常时，均回退到服务默认 LB，而非拒绝请求。
- 可观测：输出结构化可追踪日志（`decision=HIT/MISS/STALE/DEGRADE`、`record_ok`）并在 Redis 密码为空时打印启动告警。
- 在 `main.go` 注册策略，并在中英文 README 中补充说明与时序图。

## Ⅱ. Does this pull request fix one issue?

  <!-- 如对应某 issue，请在此填写 fixes #xxx -->     

## Ⅲ. Why don't you add test cases (unit test/integration test)?

已包含针对 state key 的单元测试（`endpoint_hash/lb_policy_test.go`）：
- `TestStateKey_Deterministic`：状态 key 生成的确定性；
- `TestStateKey_ScopedByRouteAndCluster`：key 按 route + cluster 维度隔离。

（节点绑定/复用、Redis 命中与降级等涉及 Redis 与 host 选择的路径，依赖运行时环境，     
建议通过下方手动验证步骤覆盖。）

## Ⅳ. Describe how to verify it

1. 配置 `ai-load-balancer` 使用 `endpoint_hash` 策略：

     ```yaml     
     lb_type: endpoint 
     lb_policy: endpoint_hash
     lb_config:  
 hash_header: x-mse-consumer   # 作为会话 key 的请求头，默认 x-mse-consumer  
 stickyTimeout: 60 # 粘滞条目 TTL，单位分钟，默认 60 
 serviceFQDN: redis.static   
 servicePort: 6379     
 username: default     
 password: '123456'    
     
2. 携带相同 hash_header 多次请求，确认始终命中同一后端 host：

curl -H "x-mse-consumer: tenant-A" http://<gateway>/...   # 多次执行
# 期望：首次 MISS 并记录，后续 HIT 复用同一 host
3. 不带该头请求，确认回退到默认 LB（DEGRADE），请求不被拒绝。
4. 故意停掉 Redis 或绑定 host 下线，确认优雅降级到默认 LB（DEGRADE / STALE）。

Ⅴ. Special notes for reviews

- 主机选定发生在「响应头阶段」记录，请关注首请求选址与后续复用的时序正确性。
- 所有异常路径均降级而非拒绝，保证可用性优先。
- Redis key 形如 higress:endpoint_hash_table:{routeName}:{clusterName}:{stateKey}按路由与集群维度隔离。    
  Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] For regular updates/changes (not new plugins):
    - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
    - [x] I have included the AI Coding summary below

AI Coding Prompts (for regular updates)

为 ai-load-balancer 插件新增一种基于 Redis 的会话保持端点负载均衡策略 endpoint_hash：  按指定请求头作为 key，将相同 key 的请求固定路由到同一后端 host；首次由默认 LB 选址     并记录到 Redis，后续复用；缺 key / 无健康节点 / Redis 异常时降级到默认 LB；补充中英文  README、时序图与单元测试。

AI Coding Summary

- 关键决策：在响应头阶段记录选中 host 以复用，所有失败路径降级而非拒绝（可用性优先）。
- 主要实现：新增 endpoint_hash 子包并在 main.go 注册，Redis 持久化 key→host，    
  结构化决策日志（HIT/MISS/STALE/DEGRADE）。
- 限制：Redis 相关运行时路径以手动验证为主，单测覆盖 state key 生成逻辑。  


<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Ⅰ. Describe what this PR did

A new Redis-based **stateful session persistence** endpoint load balancing strategy `endpoint_hash` is added to the `ai-load-balancer` plug-in: read the specified request header as a key, and always route requests with the same key to the same backend node (host).

Working mechanism:
- The key that appears for the first time: the service itself selects the default LB address, and records the selected host (`upstream.address`) to Redis in the "response header stage"; subsequent requests with the same key reuse the host through `SetUpstreamOverrideHost`.
- Graceful degradation: When there is a missing key/no healthy node/Redis exception, it will fall back to the service default LB instead of rejecting the request.
- Observable: Output structured traceable logs (`decision=HIT/MISS/STALE/DEGRADE`, `record_ok`) and print startup alerts when the Redis password is empty.
- Register the strategy in `main.go` and add instructions and sequence diagrams in Chinese and English README.

## Ⅱ. Does this pull request fix one issue?

  <!-- If it corresponds to an issue, please fill in fixes #xxx here -->

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Unit test for state key has been included (`endpoint_hash/lb_policy_test.go`):
- `TestStateKey_Deterministic`: Deterministic state key generation;
- `TestStateKey_ScopedByRouteAndCluster`: keys are isolated by route + cluster dimensions.

(Node binding/reuse, Redis hit and downgrade, etc. involve the path selected by Redis and host, and depend on the runtime environment.
It is recommended to override through the manual verification steps below. )

## Ⅳ. Describe how to verify it

1. Configure `ai-load-balancer` to use `endpoint_hash` strategy:

     ```yaml
     lb_type: endpoint
     lb_policy: endpoint_hash
     lb_config:
 hash_header: x-mse-consumer # Request header as session key, default x-mse-consumer
 stickyTimeout: 60 # Sticky entry TTL, unit is minutes, default 60
 serviceFQDN: redis.static
 servicePort: 6379
 username:default
 password: '123456'
     
2. Make multiple requests carrying the same hash_header and confirm that the same backend host is always hit:

curl -H "x-mse-consumer: tenant-A" http://<gateway>/... # Execute multiple times
# Expectation: The first MISS will be recorded, and subsequent HIT will reuse the same host.
3. Request without this header, confirm the fallback to the default LB (DEGRADE), and the request will not be rejected.
4. Deliberately stop Redis or bind the host offline, and confirm the graceful downgrade to the default LB (DEGRADE / STALE).

Ⅴ. Special notes for reviews

- Host selection occurs in the "response header stage" record. Please pay attention to the timing correctness of the first request address selection and subsequent reuse.
- All abnormal paths are downgraded rather than rejected to ensure availability first.
- Redis key is in the form of higress:endpoint_hash_table:{routeName}:{clusterName}:{stateKey} and is isolated from the cluster dimension by route.    
  Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] For regular updates/changes (not new plugins):
    - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
    - [x] I have included the AI Coding summary below

AI Coding Prompts (for regular updates)

A new Redis-based session persistence endpoint load balancing strategy endpoint_hash is added to the ai-load-balancer plug-in: use the specified request header as the key to route requests with the same key to the same backend host; the default LB is selected for the first time and recorded to Redis for subsequent reuse; the key is missing / no healthy node / Redis is abnormal and downgraded to the default LB; Chinese and English README, sequence diagram and unit test are added.

AI Coding Summary

- Key decision: Record selected host for reuse in response header stage, and all failed paths are downgraded instead of rejected (availability takes precedence).
- Main implementation: Add endpoint_hash sub-package and register it in main.go, Redis persistence key→host,
  Structured decision log (HIT/MISS/STALE/DEGRADE).
- Limitation: Redis-related runtime paths are mainly manually verified, and single tests cover the state key generation logic.
