### PR TITLE
fix(helm): disable alpha Gateway API watches by default

### DIFF
--- a/helm/core/templates/controller-deployment.yaml
+++ b/helm/core/templates/controller-deployment.yaml
@@ -77,7 +77,7 @@ spec:
           - name: PILOT_ENABLE_GATEWAY_API
             value: "{{ .Values.global.enableGatewayAPI }}"
           - name: PILOT_ENABLE_ALPHA_GATEWAY_API
-            value: "{{ .Values.global.enableGatewayAPI }}"
+            value: "{{ .Values.global.enableAlphaGatewayAPI }}"
           {{- if .Values.global.enableInferenceExtension }}
           - name: ENABLE_GATEWAY_API_INFERENCE_EXTENSION
             value: "true"

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -47,6 +47,8 @@ global:
   enableIstioAPI: true
   # -- If true, Higress Controller will monitor Gateway API resources as well
   enableGatewayAPI: true
+  # -- If true, Higress Controller will monitor Gateway API resources that have not reached v1 yet
+  enableAlphaGatewayAPI: false
   # -- If true, enable Gateway API Inference Extension support
   enableInferenceExtension: false
   # -- Used to locate istiod.

--- a/helm/higress/README.md
+++ b/helm/higress/README.md
@@ -166,6 +166,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | global.defaultUpstreamConcurrencyThreshold | int | `10000` |  |
 | global.disableAlpnH2 | bool | `false` | Whether to disable HTTP/2 in ALPN |
 | global.enableDeltaXDS | bool | `true` | Whether to enable Istio delta xDS, default is false. |
+| global.enableAlphaGatewayAPI | bool | `false` | If true, Higress Controller will monitor Gateway API resources that have not reached v1 yet |
 | global.enableGatewayAPI | bool | `true` | If true, Higress Controller will monitor Gateway API resources as well |
 | global.enableH3 | bool | `false` |  |
 | global.enableIPv6 | bool | `false` |  |

--- a/helm/higress/README.md
+++ b/helm/higress/README.md
@@ -165,8 +165,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | global.defaultResources | object | `{"requests":{"cpu":"10m"}}` | A minimal set of requested resources to applied to all deployments so that Horizontal Pod Autoscaler will be able to function (if set). Each component can overwrite these default values by adding its own resources block in the relevant section below and setting the desired resources values. |
 | global.defaultUpstreamConcurrencyThreshold | int | `10000` |  |
 | global.disableAlpnH2 | bool | `false` | Whether to disable HTTP/2 in ALPN |
-| global.enableDeltaXDS | bool | `true` | Whether to enable Istio delta xDS, default is false. |
 | global.enableAlphaGatewayAPI | bool | `false` | If true, Higress Controller will monitor Gateway API resources that have not reached v1 yet |
+| global.enableDeltaXDS | bool | `true` | Whether to enable Istio delta xDS, default is false. |
 | global.enableGatewayAPI | bool | `true` | If true, Higress Controller will monitor Gateway API resources as well |
 | global.enableH3 | bool | `false` |  |
 | global.enableIPv6 | bool | `false` |  |

--- a/helm/higress/README.zh.md
+++ b/helm/higress/README.zh.md
@@ -146,6 +146,7 @@ helm delete higress -n higress-system
 | gateway.service.ports[1].targetPort | int | `443` | 靶向端口 |
 | gateway.service.type | string | `"LoadBalancer"` | 服务类型 |
 | global.disableAlpnH2 | bool | `false` | 设置是否禁用 ALPN 中的 http/2 |
+| global.enableAlphaGatewayAPI | bool | `false` | 是否监听 alpha 阶段的 Gateway API 资源 |
 | global.enableInferenceExtension | bool | `false` | 是否启用 Gateway API Inference Extension 支持 |
 | ... | ... | ... | ... |
 


### PR DESCRIPTION
## Summary
- add `global.enableAlphaGatewayAPI`, defaulting to `false`
- bind `PILOT_ENABLE_ALPHA_GATEWAY_API` to the new Helm value instead of `global.enableGatewayAPI`
- document the new Helm value in English and Chinese chart docs

## Background
Gateway API versions are evolving quickly. In Gateway API v1.5.0 standard install, `TLSRoute` is served as `gateway.networking.k8s.io/v1`, while alpha versions such as `v1alpha2` and `v1alpha3` are not served. Higress currently enables alpha Gateway API watches whenever `global.enableGatewayAPI=true`, so the controller can try to watch alpha resources that are not served by the installed CRDs and fail to start or sync correctly.

This change keeps stable Gateway API support enabled by default while making alpha resources opt-in. Users that still need alpha Gateway API resources can explicitly set `global.enableAlphaGatewayAPI=true`.

## Verification
- `helm template higress helm/core --namespace higress-system --show-only templates/controller-deployment.yaml` renders `PILOT_ENABLE_GATEWAY_API=true` and `PILOT_ENABLE_ALPHA_GATEWAY_API=false` by default.
- `helm template higress helm/core --namespace higress-system --set global.enableAlphaGatewayAPI=true --show-only templates/controller-deployment.yaml` renders `PILOT_ENABLE_ALPHA_GATEWAY_API=true`.
- Checked Gateway API v1.5.0 release manifests: standard install serves `TLSRoute` as `v1` and marks `v1alpha2/v1alpha3` as not served; `XBackendTrafficPolicy` remains experimental `v1alpha1` in experimental install.

## Related issues
- Fixes #3902.
- Related to #3578. This PR provides a temporary mitigation only; full TLSRoute support for newer Gateway API versions will continue to be tracked in that issue.
