### PR TITLE
fix(helm): use Chart.Version as default plugin-server image tag

### DIFF
--- a/helm/core/templates/plugin-server-deployment.yaml
+++ b/helm/core/templates/plugin-server-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ .Values.pluginServer.hub | default .Values.global.hub }}/higress/{{ .Values.pluginServer.image | default "plugin-server" }}:{{ .Values.pluginServer.tag | default "1.0.0" }}
+          image: {{ .Values.pluginServer.hub | default .Values.global.hub }}/higress/{{ .Values.pluginServer.image | default "plugin-server" }}:{{ .Values.pluginServer.tag | default .Chart.Version }}
           {{- if .Values.pluginServer.imagePullPolicy }}
           imagePullPolicy: {{ .Values.pluginServer.imagePullPolicy }}
           {{- else if .Values.global.imagePullPolicy }}


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Replace the hardcoded `1.0.0` default for plugin-server image tag with `.Chart.Version` in the Helm template. This ensures the plugin-server image version stays aligned with the Higress Chart version when `pluginServer.tag` is not explicitly set.

## Ⅱ. Does this pull request fix one issue?

fixes #3982

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This is a one-line Helm template change. The fix can be verified by rendering the template with `helm template` and checking the resulting image tag matches the Chart version.

## Ⅳ. Describe how to verify it

1. `helm template` the chart without setting `pluginServer.tag`
2. Verify the plugin-server container image tag equals the Chart version (e.g., `2.2.2`) instead of `1.0.0`
3. `helm template` with `--set pluginServer.tag=custom` and verify the custom tag is still respected

## Ⅴ. Special notes for reviews

The OpenAI provider and other components already follow this pattern of using Chart.Version as default. This change simply aligns plugin-server with the same convention.

## Ⅵ. AI Coding Tool Usage Checklist

- **Prompt/instruction given to AI tool**: Fix issue #3982 - change the default plugin-server image tag from hardcoded "1.0.0" to .Chart.Version in the Helm deployment template
- **AI tool work summary**:
  - Key decision: Use `.Chart.Version` (same approach suggested in the issue) as the fallback default
  - Main change: Single line modification in `helm/core/templates/plugin-server-deployment.yaml` line 26
  - Note: User-specified `pluginServer.tag` still takes precedence via Helm's `default` function behavior