### PR TITLE
fix(helm): apply imagePullPolicy to controller container and promtail sidecar

### DIFF
--- a/helm/core/templates/_pod.tpl
+++ b/helm/core/templates/_pod.tpl
@@ -211,7 +211,9 @@ template:
         {{- $config := $o11y.promtail }}
       - name: promtail
         image: {{ $config.image.repository | default (printf "%s/higress/promtail" .Values.global.hub) }}:{{ $config.image.tag }}
-        imagePullPolicy: IfNotPresent
+        {{- if .Values.global.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        {{- end }}
         args:
           - -config.file=/etc/promtail/promtail.yaml
         env:

--- a/helm/core/templates/controller-deployment.yaml
+++ b/helm/core/templates/controller-deployment.yaml
@@ -39,6 +39,11 @@ spec:
           securityContext:
             {{- toYaml .Values.controller.securityContext | nindent 12 }}
           image: "{{ .Values.controller.hub | default .Values.global.hub }}/higress/{{ .Values.controller.image | default "higress" }}:{{ .Values.controller.tag | default .Chart.AppVersion }}"
+          {{- if .Values.controller.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.controller.imagePullPolicy }}
+          {{- else if .Values.global.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          {{- end }}
           args:
           - "serve"
           - --gatewaySelectorKey=higress


### PR DESCRIPTION
## Summary

Apply the container-level `imagePullPolicy` setting to the two remaining containers in the Higress Helm chart where the user's value was not honored. Followup to #3924.

## Background

#3924 moved `imagePullPolicy` from PodSpec level to container level in the gateway pod template (`_pod.tpl`), but the same issue affected two more containers in the chart: when users set `--set global.imagePullPolicy=IfNotPresent`, those containers did not receive it. The setting therefore did not cover all Pods, as called out in the review comment on #3924.

## Fixes

### 1. Controller container in `controller-deployment.yaml`

The controller Deployment contains two containers (`{{ .Chart.Name }}` and `discovery`). Only `discovery` had an `imagePullPolicy` block; the higress controller container relied on the Kubernetes default. Apply the same container-level block as in `discovery`, using `controller.imagePullPolicy` with `global.imagePullPolicy` as fallback (matching the existing pattern in the chart).

### 2. Promtail sidecar in `_pod.tpl`

The `promtail` sidecar (enabled when `global.o11y.enabled=true`, runs in the gateway Pod) had a hardcoded `imagePullPolicy: IfNotPresent`, so `global.imagePullPolicy` did not apply to it. Replace the hardcoded value with a template block that renders the imagePullPolicy only when `global.imagePullPolicy` is set, matching the pattern used by the redis subchart (a similar supporting component without a per-component imagePullPolicy field).

When `global.imagePullPolicy` is not set, no `imagePullPolicy` line is rendered and Kubernetes uses the default `IfNotPresent` for the pinned `2.9.4` tag, preserving the previous behavior. The promtail sidecar is intentionally not given its own `o11y.promtail.imagePullPolicy` field — it is a supporting component (not a top-level component like `gateway`, `controller`, or `pluginServer`), and adding a new value would expand the API surface without a clear need.

No changes to `values.yaml` or `helm/higress/README.md` are needed: the `controller.imagePullPolicy` and `global.imagePullPolicy` fields already exist, and no new field is introduced.

## Pattern Used

Both blocks use the same template pattern, matching what was introduced by #3924 and used elsewhere in the chart:

```yaml
{{- if <component>.imagePullPolicy }}
imagePullPolicy: {{ <component>.imagePullPolicy }}
{{- else if .Values.global.imagePullPolicy }}
imagePullPolicy: {{ .Values.global.imagePullPolicy }}
{{- end }}
```

- For the controller container in `controller-deployment.yaml`: `<component>` is `controller`, reusing the existing `controller.imagePullPolicy` field in `values.yaml`.
- For the promtail sidecar in `_pod.tpl`: only `global.imagePullPolicy` is checked (no per-component field), matching the redis subchart template at `helm/core/charts/redis/templates/statefulset.yaml`.

## Verification

Rendered with `helm template` and confirmed across all scenarios:

| Setting | controller | discovery | gateway | promtail |
|---|---|---|---|---|
| `--set global.imagePullPolicy=IfNotPresent` | `IfNotPresent` | `IfNotPresent` | `IfNotPresent` | `IfNotPresent` |
| `--set controller.imagePullPolicy=Never` | `Never` | `Never` | (default) | (default) |
| `--set gateway.imagePullPolicy=Always` | (default) | (default) | `Always` | (default) |
| `--set gateway.imagePullPolicy=Always` (with o11y) | (default) | (default) | `Always` | (default) |
| No value set | (no line) | (no line) | (no line) | (no line) |

The "no line" rows mean Kubernetes uses its default pull behavior (`IfNotPresent` for pinned tags), which matches the previous behavior of the promtail sidecar.

Confirmed working in both `gateway.kind=Deployment` and `gateway.kind=DaemonSet` modes.

## Test Plan

- [x] `helm template` with `global.imagePullPolicy=IfNotPresent` — all four containers get `IfNotPresent`
- [x] `helm template` with `controller.imagePullPolicy=Never` — controller + discovery get `Never`
- [x] `helm template` with `gateway.imagePullPolicy=Always` and o11y enabled — only gateway gets `Always`; promtail unaffected
- [x] `helm template` with nothing set — no `imagePullPolicy` lines rendered
- [x] DaemonSet mode (`gateway.kind=DaemonSet`) renders correctly with all settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)