### PR TITLE
fix: harden cluster key rate limit cookie parsing

### DIFF
--- a/plugins/wasm-go/extensions/cluster-key-rate-limit/util/utils.go
+++ b/plugins/wasm-go/extensions/cluster-key-rate-limit/util/utils.go
@@ -50,8 +50,8 @@ func ExtractCookieValueByKey(cookie string, key string) (value string) {
 	pairs := strings.Split(cookie, ";")
 	for _, pair := range pairs {
 		pair = strings.TrimSpace(pair)
-		kv := strings.Split(pair, "=")
-		if kv[0] == key {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) == 2 && kv[0] == key {
 			value = kv[1]
 			break
 		}

--- a/plugins/wasm-go/extensions/cluster-key-rate-limit/util/utils_test.go
+++ b/plugins/wasm-go/extensions/cluster-key-rate-limit/util/utils_test.go
@@ -1,0 +1,39 @@
+package util
+
+import "testing"
+
+func TestExtractCookieValueByKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		cookie string
+		key    string
+		want   string
+	}{
+		{
+			name:   "extracts matching cookie value",
+			cookie: "user=alice; other=value",
+			key:    "user",
+			want:   "alice",
+		},
+		{
+			name:   "skips segment without equals sign",
+			cookie: "user; other=value",
+			key:    "user",
+			want:   "",
+		},
+		{
+			name:   "keeps equals signs in cookie value",
+			cookie: "user=alice=admin; other=value",
+			key:    "user",
+			want:   "alice=admin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractCookieValueByKey(tt.cookie, tt.key); got != tt.want {
+				t.Fatalf("ExtractCookieValueByKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Skip malformed cookie segments without `=` before reading cookie values in `cluster-key-rate-limit`.
- Use `SplitN` so cookie values containing `=` are preserved.
- Add regression coverage for malformed and `=`-containing cookie values.

## Tests
- `cd plugins/wasm-go/extensions/cluster-key-rate-limit && go test ./...`