### PR TITLE
fix(ai-context-limit): prepare vocabulary before plugin image build

### DIFF
--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -122,6 +122,7 @@ jobs:
           set -e
           cd /workspace/plugins/wasm-go/extensions/${PLUGIN_NAME}
           go mod tidy
+          if [ -f prepare.sh ]; then sh ./prepare.sh; fi
           GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o plugin.wasm .
           tar czvf plugin.tar.gz plugin.wasm
           echo ${{ secrets.REGISTRY_PASSWORD }} | oras login -u ${{ secrets.REGISTRY_USERNAME }} --password-stdin ${{ env.IMAGE_REGISTRY_SERVICE }}


### PR DESCRIPTION
Fixes #4021. @EndlessSeeker @CH3CHO 

The plugin image build workflow invokes `go build` directly and bypasses the plugin Makefile. Since `ai-context-limit` embeds the BPE vocabulary via `go:embed` and the vocabulary file is not committed, the build must run `prepare.sh` before `go build`.

This change adds a conditional prepare step before building Go wasm plugins:

```bash
if [ -f prepare.sh ]; then sh ./prepare.sh; fi