### PR TITLE
feat(log-request-response): set WASM plugin rebuild max memory to 200MB

### DIFF
--- a/plugins/wasm-go/extensions/log-request-response/main.go
+++ b/plugins/wasm-go/extensions/log-request-response/main.go
@@ -52,6 +52,8 @@ func init() {
 		wrapper.ProcessResponseHeaders(onHttpResponseHeaders),
 		// Set custom function for processing streaming response body
 		wrapper.ProcessStreamingResponseBody(onStreamingResponseBody),
+		// Set the maximum memory limit for WASM plugin rebuild to 200MB
+		wrapper.WithRebuildMaxMemBytes[PluginConfig](200*1024*1024),
 	)
 }
 


### PR DESCRIPTION
## 改动说明

在 `log-request-response` 插件的 `init()` 函数中增加内存上限配置：

```go
wrapper.WithRebuildMaxMemBytes[PluginConfig](200*1024*1024)
```

### 背景

插件在处理大体积请求/响应 Body 时，流式处理会触发 WASM 实例的内存重建（rebuild）。如果不设上限，极端场景下可能导致网关 OOM。

### 改动

在 `wrapper.SetCtx` 调用中追加 `wrapper.WithRebuildMaxMemBytes[PluginConfig](200*1024*1024)`，将 rebuild 内存上限限制为 200MB，防止异常场景下的内存失控。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Change description

Add the memory limit configuration in the `init()` function of the `log-request-response` plugin:

```go
wrapper.WithRebuildMaxMemBytes[PluginConfig](200*1024*1024)
```

### Background

When the plug-in processes a large request/response body, streaming processing will trigger a memory rebuild of the WASM instance. If no upper limit is set, gateway OOM may occur in extreme scenarios.

### Changes

Add `wrapper.WithRebuildMaxMemBytes[PluginConfig](200*1024*1024)` to the `wrapper.SetCtx` call to limit the rebuild memory limit to 200MB to prevent memory loss in abnormal scenarios.
