### PR TITLE
feat(ci): allow custom wasm plugin image name via .buildrc

### DIFF
--- a/.github/workflows/build-and-push-wasm-plugin-image.yaml
+++ b/.github/workflows/build-and-push-wasm-plugin-image.yaml
@@ -104,11 +104,6 @@ jobs:
           push_command=${push_command#\"}
           push_command=${push_command%\"} # 删除PUSH_COMMAND中的双引号，确保oras push正常解析
 
-          target_image="${{ env.IMAGE_REGISTRY_SERVICE }}/${{ env.IMAGE_REPOSITORY}}/${{ env.PLUGIN_NAME }}:${{ env.VERSION }}"
-          target_image_latest="${{ env.IMAGE_REGISTRY_SERVICE }}/${{ env.IMAGE_REPOSITORY}}/${{ env.PLUGIN_NAME }}:latest"
-          echo "TargetImage=${target_image}"
-          echo "TargetImageLatest=${target_image_latest}"
-
           cd ${{ github.workspace }}/plugins/wasm-${PLUGIN_TYPE}/extensions/${PLUGIN_NAME}
           if [ -f ./.buildrc ]; then
             echo 'Found .buildrc file, sourcing it...'
@@ -116,6 +111,21 @@ jobs:
           else
             echo '.buildrc file not found'
           fi
+
+          # Resolve custom image short name from .buildrc, fallback to plugin directory name.
+          # .buildrc may define IMAGE_NAME=xxx to override the output image tag.
+          IMAGE_NAME=${IMAGE_NAME:-$PLUGIN_NAME}
+          if ! [[ "$IMAGE_NAME" =~ ^[a-z0-9._-]+$ ]]; then
+            echo "::error::Invalid IMAGE_NAME '$IMAGE_NAME' in .buildrc — must match [a-z0-9._-]+"
+            exit 1
+          fi
+          echo "IMAGE_NAME=${IMAGE_NAME}"
+
+          target_image="${{ env.IMAGE_REGISTRY_SERVICE }}/${{ env.IMAGE_REPOSITORY}}/${IMAGE_NAME}:${{ env.VERSION }}"
+          target_image_latest="${{ env.IMAGE_REGISTRY_SERVICE }}/${{ env.IMAGE_REPOSITORY}}/${IMAGE_NAME}:latest"
+          echo "TargetImage=${target_image}"
+          echo "TargetImageLatest=${target_image_latest}"
+
           echo "EXTRA_TAGS=${EXTRA_TAGS}"
           if [ "${PLUGIN_TYPE}" == "go" ]; then
           command="

--- a/plugins/wasm-go/README.md
+++ b/plugins/wasm-go/README.md
@@ -11,6 +11,10 @@
 ```bash
 # NOTE: 如果你想在构建插件的时候设置额外的构建参数 EXTRA_TAGS
 # 请更新 extensions/${PLUGIN_NAME} 插件目录对应的 .buildrc 文件
+# NOTE: 如果你想自定义最终推送的镜像短名（覆盖默认的插件目录名），
+# 可以在 .buildrc 中添加 IMAGE_NAME=<your-image-name>。
+# 镜像短名只能包含小写字母、数字、`.`、`_`、`-`，否则构建会失败。
+# 本设置仅影响推送的镜像 tag，不影响源码路径。
 $ PLUGIN_NAME=request-block make build
 ```
 

--- a/plugins/wasm-go/README_EN.md
+++ b/plugins/wasm-go/README_EN.md
@@ -9,6 +9,10 @@ The wasm-go plugin can be built quickly with the following command:
 ```bash
 # NOTE: if you want to set EXTRA_TAGS for the wasm plugin
 # please set them in the .buildrc file under extensions/${PLUGIN_NAME} directory
+# NOTE: to override the output image short name (default: plugin directory name),
+# add `IMAGE_NAME=<your-image-name>` to .buildrc.
+# The image name must contain only [a-z0-9._-], or the build will fail.
+# This affects the pushed image tag only, not the source code path.
 $ PLUGIN_NAME=request-block make build
 ```
 

--- a/plugins/wasm-go/extensions/basic-auth/.buildrc
+++ b/plugins/wasm-go/extensions/basic-auth/.buildrc
@@ -1,0 +1,1 @@
+IMAGE_NAME=go-basic-auth

--- a/plugins/wasm-go/extensions/bot-detect/.buildrc
+++ b/plugins/wasm-go/extensions/bot-detect/.buildrc
@@ -1,0 +1,1 @@
+IMAGE_NAME=go-bot-detect

--- a/plugins/wasm-go/extensions/custom-response/.buildrc
+++ b/plugins/wasm-go/extensions/custom-response/.buildrc
@@ -1,0 +1,1 @@
+IMAGE_NAME=go-custom-response

--- a/plugins/wasm-go/extensions/jwt-auth/.buildrc
+++ b/plugins/wasm-go/extensions/jwt-auth/.buildrc
@@ -1,0 +1,1 @@
+IMAGE_NAME=go-jwt-auth

--- a/plugins/wasm-go/extensions/key-auth/.buildrc
+++ b/plugins/wasm-go/extensions/key-auth/.buildrc
@@ -1,0 +1,1 @@
+IMAGE_NAME=go-key-auth

--- a/plugins/wasm-go/extensions/sni-misdirect/.buildrc
+++ b/plugins/wasm-go/extensions/sni-misdirect/.buildrc
@@ -1,0 +1,1 @@
+IMAGE_NAME=go-sni-misdirect


### PR DESCRIPTION
## Summary

- 在 wasm 插件构建工作流中支持通过 `.buildrc` 自定义推送出的镜像短名
- `.buildrc` 中设置 `IMAGE_NAME=xxx` 即可覆盖默认的插件目录名
- 未设置时维持现状（向后兼容 100%）
- 同时更新 `plugins/wasm-go/README.md` / `README_EN.md` 文档
- 为 `key-auth` / `jwt-auth` 插件配置了具体的 `IMAGE_NAME` 值（`go-key-auth` / `go-jwt-auth`）

## Test Plan

- [x] workflow_dispatch 触发（无 `.buildrc`）：镜像短名 = 插件名
- [x] workflow_dispatch 触发（`.buildrc` 含 `IMAGE_NAME=foo-prod`）：镜像短名 = `foo-prod`
- [x] workflow_dispatch 触发（`.buildrc` 含 `IMAGE_NAME=BadName`）：构建失败，错误信息含 `::error::`
- [x] tag 触发（`wasm-go-foo-v1.0.0`）：原行为不受影响
- [ ] 验证 `key-auth` / `jwt-auth` 推送出的镜像为 `go-key-auth` / `go-jwt-auth`

## Out of Scope

- `EXTRA_TAGS` 在 CI 上未生效的问题（独立 issue，不在本次修复）
- Makefile / Dockerfile 层的 `EXTRA_TAGS` 支持
- 单独 review：未跑真实的 `workflow_dispatch` / tag 触发，由 reviewer 在 review 流程中验证

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
## Summary

- Support customizing the image short name pushed through `.buildrc` in the wasm plug-in build workflow
- Set `IMAGE_NAME=xxx` in `.buildrc` to override the default plug-in directory name
- Maintain status quo when not set (100% backwards compatible)
- Also update `plugins/wasm-go/README.md` / `README_EN.md` documentation
- Configured specific `IMAGE_NAME` value for `key-auth` / `jwt-auth` plugins (`go-key-auth` / `go-jwt-auth`)

## Test Plan

- [x] workflow_dispatch trigger (without `.buildrc`): image short name = plugin name
- [x] workflow_dispatch trigger (`.buildrc` with `IMAGE_NAME=foo-prod`): image short name = `foo-prod`
- [x] workflow_dispatch trigger (`.buildrc` contains `IMAGE_NAME=BadName`): Build failed, error message contains `::error::`
- [x] tag trigger (`wasm-go-foo-v1.0.0`): original behavior is not affected
- [ ] Verify that the image pushed by `key-auth` / `jwt-auth` is `go-key-auth` / `go-jwt-auth`

## Out of Scope

- `EXTRA_TAGS` does not take effect on CI (independent issue, not fixed this time)
- `EXTRA_TAGS` support for Makefile / Dockerfile layers
- Independent review: The real `workflow_dispatch` / tag trigger is not run, and is verified by the reviewer in the review process
