### PR TITLE
test: add moonshot e2e test cases for ai-proxy plugin

### DIFF
--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -699,6 +699,70 @@ data: [DONE]
 			},
 			{
 				Meta: http.AssertionMeta{
+					TestCaseName:  "moonshot case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.moonshot.cn",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"id":"chatcmpl-llm-mock","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "moonshot case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.moonshot.cn",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeTextEventStream,
+						Body: []byte(`data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null,"logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"好"},"finish_reason":null,"logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"，"},"finish_reason":null,"logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"是"},"finish_reason":null,"logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"谁"},"finish_reason":null,"logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"？"},"finish_reason":null,"logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk"}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{},"finish_reason":"stop","logprobs":null}],"created":10,"model":"moonshot-v1-8k","object":"chat.completion.chunk","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}
+
+data: [DONE]
+
+`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
 					TestCaseName:  "qwen case 3: non-streaming request",
 					CompareTarget: http.CompareTargetResponse,
 				},

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -204,6 +204,25 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: wasmplugin-ai-proxy-moonshot
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "api.moonshot.cn"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
   name: wasmplugin-ai-proxy-qwen-compatible-mode
   namespace: higress-conformance-ai-backend
 spec:
@@ -504,6 +523,16 @@ spec:
           type: mistral
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-mistral
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": moonshot-v1-8k
+            "*": moonshot-v1-32k
+          type: moonshot
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-moonshot
     - config:
         provider:
           apiTokens:


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add e2e conformance test cases for the `moonshot` provider of the ai-proxy plugin:

- **moonshot case 1**: non-streaming chat completion — full JSON body assertion.
- **moonshot case 2**: streaming chat completion — full SSE payload assertion. The expected stream mirrors the real moonshot shape ([official docs](https://platform.kimi.com/docs/api/chat)): a role-only first chunk, per-token content chunks, and a separate end block. The upstream nests usage inside `choices[0].usage`, so this case asserts the **top-level `usage`** relocated by the provider's `OnStreamingEvent` — previously uncovered moonshot-specific logic.

Supporting infrastructure in `go-wasm-ai-proxy.yaml`: an Ingress rule routing `api.moonshot.cn` to `llm-mock-service:3000`, and an ai-proxy matchRule with `type: moonshot` and model mapping.

## Ⅱ. Does this pull request fix one issue?

fixes #1717

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR itself adds test cases (e2e conformance tests).

## Ⅳ. Describe how to verify it

```bash
go test -v -tags conformance ./test/e2e/e2e_test.go -isWasmPluginTest=true \
  -wasmPluginType=GO -wasmPluginName=ai-proxy --ingress-class=higress \
  --test-area=all --execute-tests=WasmPluginAiProxy
```

Verified locally on a kind cluster with the updated mock image: full `WasmPluginAiProxy` suite passes (140s), no regressions. The mock's stream shape was additionally validated against the live moonshot API.

## Ⅴ. Special notes for reviews

- **Depends on higress-group/mock-server#14** (moonshot handler for the mock). Draft until it merges and `llm-mock-server:latest` is rebuilt.
- The request sends `model: "gpt-3"` and the response asserts `model: "moonshot-v1-8k"`, proving the modelMapping end to end.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Implement e2e conformance test cases for the moonshot provider of the ai-proxy plugin per issue #1717, following the existing provider case conventions. Verify the stream shape against the official moonshot docs and the live API, and validate on a local kind cluster.

### AI Coding Summary

- Key decisions: reproduce the real moonshot stream shape in the mock (usage nested in `choices[0].usage`) so the streaming case covers the provider's `OnStreamingEvent` relocation; assert the mapped model name to prove modelMapping end to end.
- Major changes: two test cases plus Ingress and matchRule (+93 lines).
- Limitations: assertions are mock-based; live-API behavior was verified manually, not in CI.
