### PR TITLE
fix: correct typos across wasm-go plugins and e2e tests

### DIFF
--- a/plugins/wasm-go/extensions/ai-prompt-decorator/README.md
+++ b/plugins/wasm-go/extensions/ai-prompt-decorator/README.md
@@ -155,7 +155,7 @@ curl http://localhost/test \
 
 geo-ip插件配置示例：
 ```yaml
-ipProtocal: "ipv4"
+ipProtocol: "ipv4"
 ```
 
 

--- a/plugins/wasm-go/extensions/ai-prompt-decorator/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-prompt-decorator/README_EN.md
@@ -144,7 +144,7 @@ If you need to include user geographic location information before and after the
 
 Example configuration for the geo-ip plugin:
 ```yaml
-ipProtocal: "ipv4"
+ipProtocol: "ipv4"
 ```
 
 An example configuration for the AI Prompt Decorator plugin is as follows:

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -1025,7 +1025,7 @@ func doGetMappedModel(model string, modelMapping map[string]string) string {
 	}
 
 	if v, ok := modelMapping[model]; ok {
-		log.Debugf("model [%s] is mapped to [%s] explictly", model, v)
+		log.Debugf("model [%s] is mapped to [%s] explicitly", model, v)
 		return v
 	}
 

--- a/plugins/wasm-go/extensions/cors/config/cors_config_test.go
+++ b/plugins/wasm-go/extensions/cors/config/cors_config_test.go
@@ -60,7 +60,7 @@ func TestCorsConfig_getHostAndPort(t *testing.T) {
 		},
 
 		{
-			name:     "protocal is not http",
+			name:     "protocol is not http",
 			scheme:   "wss",
 			host:     "hTTp.Example.com",
 			wantHost: "http.example.com",
@@ -68,7 +68,7 @@ func TestCorsConfig_getHostAndPort(t *testing.T) {
 		},
 
 		{
-			name:     "protocal is not http",
+			name:     "protocol is not http",
 			scheme:   "wss",
 			host:     "hTTp.Example.com:8080",
 			wantHost: "http.example.com",
@@ -362,7 +362,7 @@ func TestCorsConfig_checkOrigin(t *testing.T) {
 		},
 
 		{
-			name:         "OriginPattern pattern match case with specail port 1",
+			name:         "OriginPattern pattern match case with special port 1",
 			allowOrigins: []string{},
 			allowOriginPatterns: []OriginPattern{
 				newOriginPatternFromString("http://*.example.com:[8080,9090]"),
@@ -373,7 +373,7 @@ func TestCorsConfig_checkOrigin(t *testing.T) {
 		},
 
 		{
-			name:         "OriginPattern pattern match case with specail port 2",
+			name:         "OriginPattern pattern match case with special port 2",
 			allowOrigins: []string{},
 			allowOriginPatterns: []OriginPattern{
 				newOriginPatternFromString("http://*.example.com:[8080,9090]"),
@@ -384,7 +384,7 @@ func TestCorsConfig_checkOrigin(t *testing.T) {
 		},
 
 		{
-			name:         "OriginPattern pattern match case with specail port 3",
+			name:         "OriginPattern pattern match case with special port 3",
 			allowOrigins: []string{},
 			allowOriginPatterns: []OriginPattern{
 				newOriginPatternFromString("http://*.example.com:[8080,9090]"),

--- a/plugins/wasm-go/extensions/transformer/main.go
+++ b/plugins/wasm-go/extensions/transformer/main.go
@@ -911,7 +911,7 @@ type jsonHandler struct {
 }
 
 func (h kvHandler) handle(host, path string, kvs map[string][]string, mapSourceData map[string]MapSourceData) error {
-	// arbitary order. for example: remove → rename → replace → add → append → map → dedupe
+	// arbitrary order. for example: remove → rename → replace → add → append → map → dedupe
 
 	for _, kvtOp := range h.kvtOps {
 		switch kvtOp.kvtOpType {
@@ -1036,7 +1036,7 @@ func (h kvHandler) handle(host, path string, kvs map[string][]string, mapSourceD
 
 // only for body
 func (h jsonHandler) handle(host, path string, oriData []byte, mapSourceData map[string]MapSourceData) (data []byte, err error) {
-	// arbitary order. for example: remove → rename → replace → add → append → map → dedupe
+	// arbitrary order. for example: remove → rename → replace → add → append → map → dedupe
 	if !gjson.ValidBytes(oriData) {
 		return nil, errors.New("invalid json body")
 	}

--- a/test/e2e/conformance/tests/go-wasm-transformer.yaml
+++ b/test/e2e/conformance/tests/go-wasm-transformer.yaml
@@ -76,7 +76,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-  name: wasmplugin-transform-request-arbitary-rule-order
+  name: wasmplugin-transform-request-arbitrary-rule-order
   namespace: higress-conformance-infra
 spec:
   ingressClassName: higress
@@ -96,7 +96,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-  name: wasmplugin-transform-response-arbitary-rule-order
+  name: wasmplugin-transform-response-arbitrary-rule-order
   namespace: higress-conformance-infra
 spec:
   ingressClassName: higress
@@ -603,7 +603,7 @@ spec:
                 toKey: X-map
 
     - ingress:
-        - higress-conformance-infra/wasmplugin-transform-request-arbitary-rule-order
+        - higress-conformance-infra/wasmplugin-transform-request-arbitrary-rule-order
       configDisable: false
       config:
         reqRules:
@@ -663,7 +663,7 @@ spec:
               - key: k1
 
     - ingress:
-        - higress-conformance-infra/wasmplugin-transform-response-arbitary-rule-order
+        - higress-conformance-infra/wasmplugin-transform-response-arbitrary-rule-order
       configDisable: false
       config:
         respRules:


### PR DESCRIPTION
## Summary
Fixes #4068

Corrects spelling mistakes in wasm-go plugin code, test names, and comments.

### Changes
| File | Typo | Correction |
|------|------|------------|
| `ai-proxy/provider/provider.go` | `explictly` | `explicitly` |
| `transformer/main.go` (x2) | `arbitary` | `arbitrary` |
| `cors/config/cors_config_test.go` (x2) | `protocal` | `protocol` |
| `cors/config/cors_config_test.go` (x3) | `specail` | `special` |
| `ai-prompt-decorator/README.md` | `ipProtocal` | `ipProtocol` |
| `ai-prompt-decorator/README_EN.md` | `ipProtocal` | `ipProtocol` |
| `go-wasm-transformer.yaml` (x4) | `arbitary` | `arbitrary` (ingress names) |

### Note
The MCP tool name `bussiness-credit-rating` was intentionally **not** renamed to `business-credit-rating` to avoid breaking existing MCP client configurations that reference the tool by name.

### Checklist
- [x] DCO signed
- [x] No runtime behavior changes
- [x] E2e test ingress name changes are self-contained (both definitions and references updated consistently)