### PR TITLE
test(e2e): add conformance tests for load-balance annotations

### DIFF
--- a/test/e2e/conformance/tests/httproute-load-balance.go
+++ b/test/e2e/conformance/tests/httproute-load-balance.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/http"
+	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/suite"
+)
+
+func init() {
+	Register(HTTPRouteLoadBalance)
+}
+
+var HTTPRouteLoadBalance = suite.ConformanceTest{
+	ShortName:   "HTTPRouteLoadBalance",
+	Description: "Ingresses in the higress-conformance-infra namespace use the nginx load-balance annotation to select the upstream load balancing algorithm (round_robin and least_request).",
+	Manifests:   []string{"tests/httproute-load-balance.yaml"},
+	Features:    []suite.SupportedFeature{suite.HTTPConformanceFeature},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		testcases := []http.Assertion{
+			// round_robin: the annotation value must be accepted and routing must still work.
+			{
+				Meta: http.AssertionMeta{
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/round-robin",
+						Host: "loadbalance.higress.io",
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+			// least_request: a different valid algorithm value.
+			{
+				Meta: http.AssertionMeta{
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/least-request",
+						Host: "loadbalance.higress.io",
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+		}
+
+		t.Run("Ingress with nginx load-balance annotation reaches the backend", func(t *testing.T) {
+			for _, testcase := range testcases {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcase)
+			}
+		})
+	},
+}

--- a/test/e2e/conformance/tests/httproute-load-balance.yaml
+++ b/test/e2e/conformance/tests/httproute-load-balance.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test load-balance annotation with the round_robin algorithm
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/load-balance: round_robin
+  name: ingress-echo-load-balance-round-robin
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: loadbalance.higress.io
+      http:
+        paths:
+          - path: /round-robin
+            pathType: Exact
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+---
+# Test load-balance annotation with the least_request algorithm
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/load-balance: least_request
+  name: ingress-echo-load-balance-least-request
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: loadbalance.higress.io
+      http:
+        paths:
+          - path: /least-request
+            pathType: Exact
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080

--- a/test/e2e/conformance/tests/httproute-upstream-hash-by.go
+++ b/test/e2e/conformance/tests/httproute-upstream-hash-by.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/http"
+	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/suite"
+)
+
+func init() {
+	Register(HTTPRouteUpstreamHashBy)
+}
+
+var HTTPRouteUpstreamHashBy = suite.ConformanceTest{
+	ShortName:   "HTTPRouteUpstreamHashBy",
+	Description: "An Ingress in the higress-conformance-infra namespace uses the nginx upstream-hash-by annotation to enable consistent hashing by a request header.",
+	Manifests:   []string{"tests/httproute-upstream-hash-by.yaml"},
+	Features:    []suite.SupportedFeature{suite.HTTPConformanceFeature},
+	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		testcases := []http.Assertion{
+			// A request carrying the hashed header must be routed successfully to the backend.
+			{
+				Meta: http.AssertionMeta{
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Path: "/hash-by",
+						Host: "hashby.higress.io",
+						Headers: map[string]string{
+							"x-test-hash": "consistent-value",
+						},
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+					},
+				},
+			},
+		}
+
+		t.Run("Ingress with nginx upstream-hash-by annotation reaches the backend", func(t *testing.T) {
+			for _, testcase := range testcases {
+				http.MakeRequestAndExpectEventuallyConsistentResponse(t, suite.RoundTripper, suite.TimeoutConfig, suite.GatewayAddress, testcase)
+			}
+		})
+	},
+}

--- a/test/e2e/conformance/tests/httproute-upstream-hash-by.yaml
+++ b/test/e2e/conformance/tests/httproute-upstream-hash-by.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test upstream-hash-by annotation: consistent hashing by the x-test-hash request header.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/upstream-hash-by: "$http_x_test_hash"
+  name: ingress-echo-upstream-hash-by
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: hashby.higress.io
+      http:
+        paths:
+          - path: /hash-by
+            pathType: Exact
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add e2e conformance testcases for the nginx-style load balancing annotations requested in #195:

- `nginx.ingress.kubernetes.io/load-balance`: verify the annotation is accepted for both `round_robin` and `least_request` algorithms, and that requests are still routed to the backend.
- `nginx.ingress.kubernetes.io/upstream-hash-by`: verify consistent hashing by a request header (`$http_x_test_hash`) is accepted, and that requests are still routed to the backend.

The testcases follow the existing declarative conformance pattern used by `httproute-canary-*` / `httproute-hostname-*` (annotation acceptance + correct routing).

## Ⅱ. Does this pull request fix one issue?
fixes #195

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR *adds* the e2e conformance test cases themselves — `httproute-load-balance` and `httproute-upstream-hash-by` — under the conformance test suite, following the existing declarative test pattern.

## Ⅳ. Describe how to verify it

Run the Higress conformance test suite with the two new testcases enabled. They assert:
- The `load-balance` and `upstream-hash-by` annotations are accepted by the gateway (no route rejection / `ResolvedRefs` error).
- Requests are still routed to the backend service and receive a response.

## Ⅴ. Special notes for reviews

Verifying request *distribution* across endpoints / hash *stickiness* across pods requires pod-level response inspection, which the conformance harness does not currently expose. That stronger verification is intentionally left as follow-up work. These tests cover annotation acceptance + basic routing correctness, consistent with the existing canary/hostname conformance tests.
