### PR TITLE
test(e2e): add vertex conformance cases for ai-proxy

### DIFF
--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,52 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "vertex case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "aiplatform.googleapis.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:           200,
+						ContentType:          http.ContentTypeApplicationJson,
+						JsonBodyIgnoreFields: []string{"id", "created"},
+						Body:                 []byte(`{"id":"chatcmpl-llm-mock","choices":[{"index":0,"message":{"role":"assistant","content":"This is a mock response from Vertex provider. You said: 你好，你是谁？"},"finish_reason":"STOP","logprobs":null}],"created":10,"model":"gemini-2.0-flash","object":"chat.completion","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10,"completion_tokens_details":{}}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "vertex case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "aiplatform.googleapis.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+					},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,25 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-vertex
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "aiplatform.googleapis.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +626,14 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": gemini-2.0-flash
+            "*": gemini-2.0-flash
+          type: vertex
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-vertex
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add e2e conformance testcases for the **Vertex** provider of the ai-proxy plugin (the higress-side half of #2718), mirroring the gemini cases in #4075:

- **vertex case 1 (non-streaming)**: JSON body assertion (ignoring `id`/`created`). Vertex yields `finish_reason: "STOP"` (the vertex provider passes `finishReason` through without lower-casing, unlike gemini) and a usage block that includes `completion_tokens_details`.
- **vertex case 2 (streaming)**: asserts status code 200 and `text/event-stream` content type.

The provider runs in **Express Mode** (`apiTokens`) so no OAuth token exchange happens; ai-proxy rewrites the request to `aiplatform.googleapis.com` on `/v1/publishers/google/models/{model}:generateContent`, which the llm-mock-server Vertex simulation answers.

## Ⅱ. Does this pull request fix one issue?
fixes #2718

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR *adds* the e2e conformance test cases themselves, following the existing declarative ai-proxy pattern.

## Ⅳ. Describe how to verify it

Run the Higress conformance suite with the `go-wasm-ai-proxy` test enabled, against a `llm-mock-server` image that includes the Vertex simulation (higress-group/mock-server#15). The cases assert the ai-proxy Vertex transform round-trips correctly against the mock.

## Ⅴ. Special notes for reviews

- Depends on **higress-group/mock-server#15** (the Vertex mock simulation) being merged and a new `:latest` llm-mock-server image published before this PR's e2e CI can pass — that is the inherent cross-repo sequencing for #2718.
- Auth is intentionally lenient in the mock (Express Mode does not attach the API key on the transformed chat path).
- `finish_reason` is `"STOP"` (uppercase) for Vertex — this is correct, not a bug: the vertex provider does not lower-case `finishReason`, whereas gemini does.
