### PR TITLE
fix: handle empty ai-rag embeddings

### DIFF
--- a/plugins/wasm-go/extensions/ai-rag/bug_repro_test.go
+++ b/plugins/wasm-go/extensions/ai-rag/bug_repro_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDashScopeEmptyEmbeddingsDoesNotPanic(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(basicConfig)
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/v1/chat/completions"},
+			{":method", "POST"},
+		})
+
+		action := host.CallOnHttpRequestBody([]byte(`{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"What is AI?"}]}`))
+		require.Equal(t, types.ActionPause, action)
+
+		emptyEmbeddingResponse := `{"output":{"embeddings":[]},"usage":{"total_tokens":0},"request_id":"req-empty"}`
+		require.NotPanics(t, func() {
+			host.CallOnHttpCall([][2]string{
+				{":status", "200"},
+				{"content-type", "application/json"},
+			}, []byte(emptyEmbeddingResponse))
+		})
+	})
+}

--- a/plugins/wasm-go/extensions/ai-rag/main.go
+++ b/plugins/wasm-go/extensions/ai-rag/main.go
@@ -119,26 +119,55 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config AIRagConfig, body []byte,
 	}
 	headers := [][2]string{{"Content-Type", "application/json"}, {"Authorization", "Bearer " + config.DashScopeAPIKey}}
 	reqEmbeddingSerialized, _ := json.Marshal(requestEmbedding)
-	config.DashScopeClient.Post(
+	err := config.DashScopeClient.Post(
 		"/api/v1/services/embeddings/text-embedding/text-embedding",
 		headers,
 		reqEmbeddingSerialized,
 		func(statusCode int, responseHeaders http.Header, responseBody []byte) {
+			if statusCode != http.StatusOK {
+				log.Debugf("DashScope embedding request failed, statusCode: %d", statusCode)
+				proxywasm.ResumeHttpRequest()
+				return
+			}
 			var responseEmbedding dashscope.Response
-			_ = json.Unmarshal(responseBody, &responseEmbedding)
+			if err := json.Unmarshal(responseBody, &responseEmbedding); err != nil {
+				log.Debugf("DashScope embedding response unmarshal failed: %s", err.Error())
+				proxywasm.ResumeHttpRequest()
+				return
+			}
+			if len(responseEmbedding.Output.Embeddings) == 0 {
+				log.Debug("DashScope embedding response has no embeddings")
+				proxywasm.ResumeHttpRequest()
+				return
+			}
+			embedding := responseEmbedding.Output.Embeddings[0].Embedding
+			if len(embedding) == 0 {
+				log.Debug("DashScope embedding vector is empty")
+				proxywasm.ResumeHttpRequest()
+				return
+			}
 			requestQuery := dashvector.Request{
 				TopK:         config.DashVectorTopK,
 				OutputFileds: []string{config.DashVectorField},
-				Vector:       responseEmbedding.Output.Embeddings[0].Embedding,
+				Vector:       embedding,
 			}
 			requestQuerySerialized, _ := json.Marshal(requestQuery)
-			config.DashVectorClient.Post(
+			err := config.DashVectorClient.Post(
 				fmt.Sprintf("/v1/collections/%s/query", config.DashVectorCollection),
 				[][2]string{{"Content-Type", "application/json"}, {"dashvector-auth-token", config.DashVectorAPIKey}},
 				requestQuerySerialized,
 				func(statusCode int, responseHeaders http.Header, responseBody []byte) {
+					if statusCode != http.StatusOK {
+						log.Debugf("DashVector query failed, statusCode: %d", statusCode)
+						proxywasm.ResumeHttpRequest()
+						return
+					}
 					var response dashvector.Response
-					_ = json.Unmarshal(responseBody, &response)
+					if err := json.Unmarshal(responseBody, &response); err != nil {
+						log.Debugf("DashVector query response unmarshal failed: %s", err.Error())
+						proxywasm.ResumeHttpRequest()
+						return
+					}
 					recallDocIds := []string{}
 					recallDocs := []string{}
 					for _, output := range response.Output {
@@ -163,9 +192,17 @@ func onHttpRequestBody(ctx wrapper.HttpContext, config AIRagConfig, body []byte,
 					proxywasm.ResumeHttpRequest()
 				},
 			)
+			if err != nil {
+				log.Debugf("DashVector query dispatch failed: %s", err.Error())
+				proxywasm.ResumeHttpRequest()
+			}
 		},
 		50000,
 	)
+	if err != nil {
+		log.Debugf("DashScope embedding dispatch failed: %s", err.Error())
+		return types.ActionContinue
+	}
 	return types.ActionPause
 }
 


### PR DESCRIPTION
## Summary
- validate DashScope status, JSON decode, and embedding length before querying DashVector
- validate DashVector status and JSON decode before applying recall results
- resume the original request when the RAG recall path fails

## Tests
- `GOCACHE=/private/tmp/higress-go-cache go test -run TestDashScopeEmptyEmbeddingsDoesNotPanic -count=1`
- `GOCACHE=/private/tmp/higress-go-cache go test ./...`
