### PR TITLE
fix: handle unterminated Hunyuan stream chunks

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/hunyuan_bug_repro_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/hunyuan_bug_repro_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	wasmhost "github.com/higress-group/wasm-go/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHunyuanStreamingLastChunkWithoutTerminatorDoesNotPanic(t *testing.T) {
+	wasmhost.RunTest(t, func(t *testing.T) {
+		cfg, _ := json.Marshal(map[string]interface{}{
+			"provider": map[string]interface{}{
+				"type":           "hunyuan",
+				"hunyuanAuthId":  "12345678-1234-1234-1234-123456789012",
+				"hunyuanAuthKey": "12345678901234567890123456789012",
+			},
+		})
+
+		host, status := wasmhost.NewTestHost(cfg)
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "example.com"},
+			{":path", "/v1/chat/completions"},
+			{":method", "POST"},
+			{"Content-Type", "application/json"},
+		})
+		host.CallOnHttpRequestBody([]byte(`{"model":"hunyuan-lite","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+		host.SetProperty([]string{"response", "code_details"}, []byte("via_upstream"))
+		host.CallOnHttpResponseHeaders([][2]string{
+			{":status", "200"},
+			{"Content-Type", "text/event-stream"},
+		})
+
+		lastChunkWithoutTerminator := `data: {"Choices":[{"Delta":{"Role":"assistant","Content":"hello"},"FinishReason":"stop"}],"Created":1716359713,"Id":"hunyuan-test","Usage":{"PromptTokens":1,"CompletionTokens":1,"TotalTokens":2}}`
+
+		require.NotPanics(t, func() {
+			action := host.CallOnHttpStreamingResponseBody([]byte(lastChunkWithoutTerminator), true)
+			require.Equal(t, types.ActionContinue, action)
+		})
+	})
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
-	"github.com/higress-group/wasm-go/pkg/log"
-	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/log"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
 // hunyuanProvider is the provider for hunyuan AI service.
@@ -351,15 +351,23 @@ func (m *hunyuanProvider) OnStreamingResponseBody(ctx wrapper.HttpContext, name 
 
 		// 查找事件结束的位置（即下一个事件的开始）
 		newEventPivot = bytes.Index(newBufferedBody, []byte("\n\n"))
-		if newEventPivot == -1 && !isLastChunk {
-			// 未找到事件结束标识，跳出循环等待更多数据，若是最后一个chunk，不一定有2个换行符
-			break
+		var eventData []byte
+		if newEventPivot == -1 {
+			if !isLastChunk {
+				// 未找到事件结束标识，跳出循环等待更多数据，若是最后一个chunk，不一定有2个换行符
+				break
+			}
+			eventData = bytes.TrimSpace(newBufferedBody)
+			newBufferedBody = nil
+		} else {
+			// 提取并处理一个完整的事件
+			eventData = newBufferedBody[:newEventPivot]
+			// log.Debugf("@@@ <<< ori chun is: %s", string(newBufferedBody[:newEventPivot]))
+			newBufferedBody = newBufferedBody[newEventPivot+2:] // 跳过结束标识
 		}
-
-		// 提取并处理一个完整的事件
-		eventData := newBufferedBody[:newEventPivot]
-		// log.Debugf("@@@ <<< ori chun is: %s", string(newBufferedBody[:newEventPivot]))
-		newBufferedBody = newBufferedBody[newEventPivot+2:] // 跳过结束标识
+		if len(eventData) == 0 {
+			continue
+		}
 
 		// 转换并追加到输出缓冲区
 		convertedData, _ := m.convertChunkFromHunyuanToOpenAI(ctx, eventData)
@@ -378,6 +386,9 @@ func (m *hunyuanProvider) convertChunkFromHunyuanToOpenAI(ctx wrapper.HttpContex
 	// 将hunyuan的chunk转为openai的chunk
 	hunyuanFormattedChunk := &hunyuanTextGenDetailedResponseNonStreaming{}
 	if err := json.Unmarshal(hunyuanChunk, hunyuanFormattedChunk); err != nil {
+		return []byte(""), nil
+	}
+	if len(hunyuanFormattedChunk.Choices) == 0 {
 		return []byte(""), nil
 	}
 


### PR DESCRIPTION
## Summary
- parse the remaining Hunyuan stream buffer when the final SSE chunk has no trailing blank line
- ignore empty Hunyuan choice arrays instead of indexing `Choices[0]`
- add a wasm-host regression test for final chunks without terminators

## Tests
- `GOCACHE=/private/tmp/higress-go-cache go test -run TestHunyuanStreamingLastChunkWithoutTerminatorDoesNotPanic -count=1`
- `GOCACHE=/private/tmp/higress-go-cache go test ./provider`
