### PR TITLE
fix: guard ai-transformer frame parsing

### DIFF
--- a/plugins/wasm-go/extensions/ai-transformer/bug_repro_test.go
+++ b/plugins/wasm-go/extensions/ai-transformer/bug_repro_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractHttpFrameMissingSeparatorReturnsError(t *testing.T) {
+	require.NotPanics(t, func() {
+		headers, body, err := extraceHttpFrame("plain model output without an HTTP separator")
+		require.Error(t, err)
+		require.Nil(t, headers)
+		require.Nil(t, body)
+	})
+}
+
+func TestExtractHttpFrameCRLFSeparator(t *testing.T) {
+	headers, body, err := extraceHttpFrame("content-type: application/json\r\nx-test: ok\r\n\r\n{\"ok\":true}")
+	require.NoError(t, err)
+	require.Equal(t, [][2]string{
+		{"content-type", " application/json"},
+		{"x-test", " ok"},
+	}, headers)
+	require.Equal(t, []byte(`{"ok":true}`), body)
+}

--- a/plugins/wasm-go/extensions/ai-transformer/main.go
+++ b/plugins/wasm-go/extensions/ai-transformer/main.go
@@ -80,15 +80,24 @@ func getSplitPos(header string) int {
 
 func extraceHttpFrame(frame string) ([][2]string, []byte, error) {
 	pos := strings.Index(frame, "\n\n")
+	separatorLen := len("\n\n")
+	if pos == -1 {
+		pos = strings.Index(frame, "\r\n\r\n")
+		separatorLen = len("\r\n\r\n")
+	}
+	if pos == -1 {
+		return nil, nil, errors.New("missing http frame separator")
+	}
 	headers := [][2]string{}
 	for _, header := range strings.Split(frame[:pos], "\n") {
+		header = strings.TrimRight(header, "\r")
 		splitPos := getSplitPos(header)
 		if splitPos == -1 {
 			return nil, nil, errors.New("invalid http frame.")
 		}
 		headers = append(headers, [2]string{header[:splitPos], header[splitPos+1:]})
 	}
-	body := []byte(frame[pos+2:])
+	body := []byte(frame[pos+separatorLen:])
 	return headers, body, nil
 }
 


### PR DESCRIPTION
## Summary
- return an error instead of slicing when the LLM output has no HTTP frame separator
- support CRLF HTTP frame separators
- add regression coverage for plain model output without separators

## Tests
- `GOCACHE=/private/tmp/higress-go-cache go test -run 'TestExtractHttpFrame(MissingSeparatorReturnsError|CRLFSeparator)' -count=1`
- `GOCACHE=/private/tmp/higress-go-cache go test ./...`
