### PR TITLE
refactor: deduplicate ingress load balancer status helpers

### DIFF
--- a/pkg/ingress/kube/common/tool.go
+++ b/pkg/ingress/kube/common/tool.go
@@ -389,70 +389,61 @@ func getSvcIpList(svcList []*v1.Service) []string {
 	return out
 }
 
-func SortLbIngressList(lbi []v1.LoadBalancerIngress) func(int, int) bool {
-	return func(i int, j int) bool {
-		return loadBalancerIngressAddress(lbi[i].IP, lbi[i].Hostname) <
-			loadBalancerIngressAddress(lbi[j].IP, lbi[j].Hostname)
+func buildLoadBalancerIngressList[T any](svcList []*v1.Service, build func(ip, hostname string) T, less func([]T) func(int, int) bool) []T {
+	svcIpList := getSvcIpList(svcList)
+	lbi := make([]T, 0, len(svcIpList))
+	for _, ep := range svcIpList {
+		if net.ParseIP(ep) != nil {
+			lbi = append(lbi, build(ep, ""))
+		} else {
+			lbi = append(lbi, build("", ep))
+		}
 	}
+
+	sort.SliceStable(lbi, less(lbi))
+	return lbi
+}
+
+func sortLoadBalancerIngressList[T any](lbi []T, address func(T) string) func(int, int) bool {
+	return func(i int, j int) bool {
+		return address(lbi[i]) < address(lbi[j])
+	}
+}
+
+func SortLbIngressList(lbi []v1.LoadBalancerIngress) func(int, int) bool {
+	return sortLoadBalancerIngressList(lbi, func(item v1.LoadBalancerIngress) string {
+		return loadBalancerIngressAddress(item.IP, item.Hostname)
+	})
 }
 
 func GetLbStatusList(svcList []*v1.Service) []v1.LoadBalancerIngress {
-	svcIpList := getSvcIpList(svcList)
-	lbi := make([]v1.LoadBalancerIngress, 0, len(svcIpList))
-	for _, ep := range svcIpList {
-		if net.ParseIP(ep) != nil {
-			lbi = append(lbi, v1.LoadBalancerIngress{IP: ep})
-		} else {
-			lbi = append(lbi, v1.LoadBalancerIngress{Hostname: ep})
-		}
-	}
-
-	sort.SliceStable(lbi, SortLbIngressList(lbi))
-	return lbi
+	return buildLoadBalancerIngressList(svcList, func(ip, hostname string) v1.LoadBalancerIngress {
+		return v1.LoadBalancerIngress{IP: ip, Hostname: hostname}
+	}, SortLbIngressList)
 }
 
 func SortLbIngressListV1(lbi []networkingv1.IngressLoadBalancerIngress) func(int, int) bool {
-	return func(i int, j int) bool {
-		return loadBalancerIngressAddress(lbi[i].IP, lbi[i].Hostname) <
-			loadBalancerIngressAddress(lbi[j].IP, lbi[j].Hostname)
-	}
+	return sortLoadBalancerIngressList(lbi, func(item networkingv1.IngressLoadBalancerIngress) string {
+		return loadBalancerIngressAddress(item.IP, item.Hostname)
+	})
 }
 
 func GetLbStatusListV1(svcList []*v1.Service) []networkingv1.IngressLoadBalancerIngress {
-	svcIpList := getSvcIpList(svcList)
-	lbi := make([]networkingv1.IngressLoadBalancerIngress, 0, len(svcIpList))
-	for _, ep := range svcIpList {
-		if net.ParseIP(ep) != nil {
-			lbi = append(lbi, networkingv1.IngressLoadBalancerIngress{IP: ep})
-		} else {
-			lbi = append(lbi, networkingv1.IngressLoadBalancerIngress{Hostname: ep})
-		}
-	}
-
-	sort.SliceStable(lbi, SortLbIngressListV1(lbi))
-	return lbi
+	return buildLoadBalancerIngressList(svcList, func(ip, hostname string) networkingv1.IngressLoadBalancerIngress {
+		return networkingv1.IngressLoadBalancerIngress{IP: ip, Hostname: hostname}
+	}, SortLbIngressListV1)
 }
 
 func SortLbIngressListV1Beta1(lbi []networkingv1beta1.IngressLoadBalancerIngress) func(int, int) bool {
-	return func(i int, j int) bool {
-		return loadBalancerIngressAddress(lbi[i].IP, lbi[i].Hostname) <
-			loadBalancerIngressAddress(lbi[j].IP, lbi[j].Hostname)
-	}
+	return sortLoadBalancerIngressList(lbi, func(item networkingv1beta1.IngressLoadBalancerIngress) string {
+		return loadBalancerIngressAddress(item.IP, item.Hostname)
+	})
 }
 
 func GetLbStatusListV1Beta1(svcList []*v1.Service) []networkingv1beta1.IngressLoadBalancerIngress {
-	svcIpList := getSvcIpList(svcList)
-	lbi := make([]networkingv1beta1.IngressLoadBalancerIngress, 0, len(svcIpList))
-	for _, ep := range svcIpList {
-		if net.ParseIP(ep) != nil {
-			lbi = append(lbi, networkingv1beta1.IngressLoadBalancerIngress{IP: ep})
-		} else {
-			lbi = append(lbi, networkingv1beta1.IngressLoadBalancerIngress{Hostname: ep})
-		}
-	}
-
-	sort.SliceStable(lbi, SortLbIngressListV1Beta1(lbi))
-	return lbi
+	return buildLoadBalancerIngressList(svcList, func(ip, hostname string) networkingv1beta1.IngressLoadBalancerIngress {
+		return networkingv1beta1.IngressLoadBalancerIngress{IP: ip, Hostname: hostname}
+	}, SortLbIngressListV1Beta1)
 }
 
 func loadBalancerIngressAddress(ip, hostname string) string {


### PR DESCRIPTION
## What this PR does

Deduplicates the load balancer ingress status construction helpers in `pkg/ingress/kube/common/tool.go`.

`GetLbStatusList`, `GetLbStatusListV1`, and `GetLbStatusListV1Beta1` previously repeated the same steps:

- collect candidate service load balancer endpoints
- split each endpoint into either `IP` or `Hostname`
- sort the resulting ingress status list

The public helpers keep the same names and return types, but now share one internal builder and one internal sorter helper. This keeps behavior aligned across the core, `networking/v1`, and `networking/v1beta1` status paths and reduces the chance of future drift.

## Testing

- `GOCACHE=/private/tmp/higress-go-cache go test ./pkg/ingress/kube/common`
- `GOCACHE=/private/tmp/higress-go-cache go test ./pkg/ingress/kube/common ./pkg/ingress/kube/ingress ./pkg/ingress/kube/ingressv1 ./pkg/ingress/kube/kingress`
