### PR TITLE
fix: bump envoy submodule to skip Redis async client teardown on unchanged config

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -151,7 +151,7 @@ docker-buildx-push: clean-env docker.higress-buildx
 export PARENT_GIT_TAG:=$(shell cat VERSION)
 export PARENT_GIT_REVISION:=$(TAG)
 
-export ENVOY_PACKAGE_URL_PATTERN?=https://github.com/higress-group/proxy/releases/download/v2.2.3/envoy-symbol-ARCH.tar.gz
+export ENVOY_PACKAGE_URL_PATTERN?=https://github.com/higress-group/proxy/releases/download/v2.2.4-rc.2-test-cpp-host/envoy-symbol-ARCH.tar.gz
 
 build-envoy: prebuild
 	./tools/hack/build-envoy.sh
@@ -205,7 +205,7 @@ install: pre-install
 	helm install higress helm/higress -n higress-system --create-namespace --set 'global.local=true'
 
 HIGRESS_LATEST_IMAGE_TAG ?= latest
-ENVOY_LATEST_IMAGE_TAG ?= 91244c578aef498af93cacb2cf353f3878b92fc4
+ENVOY_LATEST_IMAGE_TAG ?= 481184afc44176eb23d64e0011dc3ea1ae6a410c
 ISTIO_LATEST_IMAGE_TAG ?= de2c9628294f51b13c4a70b3a862b4372890797a
 
 install-dev: pre-install


### PR DESCRIPTION
## What this PR does

Bumps the `envoy/envoy` submodule from `f468a1a3` to `4491e678` (envoy-1.36), pulling in higress-group/envoy#29.

## Why

Fixes #4086. On plugin reload, `AsyncClientImpl::initialize()` unconditionally tore down all healthy Redis connections and rewrote config even when the Redis config was unchanged, failing in-flight async requests during the lazy-reconnect window. The envoy-side fix short-circuits `initialize()` when the incoming `AsyncClientConfig` equals the currently installed config.

Proposal #4094 / design #4096 / implement #4097.

## Note

`ENVOY_LATEST_IMAGE_TAG` is intentionally left unchanged in this PR; the gateway image will be built and published separately, and the tag bumped in a follow-up.