### PR TITLE
feat: extend ai-proxy configurable capabilities

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -718,24 +718,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 	c.capabilities = make(map[string]string)
 	for capability, pathJson := range json.Get("capabilities").Map() {
 		// 过滤掉不受支持的能力
-		switch capability {
-		case string(ApiNameChatCompletion),
-			string(ApiNameEmbeddings),
-			string(ApiNameImageGeneration),
-			string(ApiNameImageVariation),
-			string(ApiNameImageEdit),
-			string(ApiNameAudioSpeech),
-			string(ApiNameAudioTranscription),
-			string(ApiNameAudioTranslation),
-			string(ApiNameRealtime),
-			string(ApiNameResponses),
-			string(ApiNameCohereV1Rerank),
-			string(ApiNameVideos),
-			string(ApiNameRetrieveVideo),
-			string(ApiNameKlingImageToVideo),
-			string(ApiNameKlingRetrieveImageVideo),
-			string(ApiNameRetrieveVideoContent),
-			string(ApiNameVideoRemix):
+		if isConfigurableCapability(capability) {
 			c.capabilities[capability] = pathJson.String()
 		}
 	}
@@ -1176,6 +1159,57 @@ func (c *ProviderConfig) isSupportedAPI(apiName ApiName) bool {
 
 func (c *ProviderConfig) IsSupportedAPI(apiName ApiName) bool {
 	return c.isSupportedAPI(apiName)
+}
+
+func isConfigurableCapability(capability string) bool {
+	switch ApiName(capability) {
+	case ApiNameCompletion,
+		ApiNameChatCompletion,
+		ApiNameEmbeddings,
+		ApiNameImageGeneration,
+		ApiNameImageVariation,
+		ApiNameImageEdit,
+		ApiNameAudioSpeech,
+		ApiNameAudioTranscription,
+		ApiNameAudioTranslation,
+		ApiNameRealtime,
+		ApiNameModels,
+		ApiNameFiles,
+		ApiNameRetrieveFile,
+		ApiNameRetrieveFileContent,
+		ApiNameBatches,
+		ApiNameRetrieveBatch,
+		ApiNameCancelBatch,
+		ApiNameResponses,
+		ApiNameFineTuningJobs,
+		ApiNameRetrieveFineTuningJob,
+		ApiNameFineTuningJobEvents,
+		ApiNameFineTuningJobCheckpoints,
+		ApiNameCancelFineTuningJob,
+		ApiNameResumeFineTuningJob,
+		ApiNamePauseFineTuningJob,
+		ApiNameFineTuningCheckpointPermissions,
+		ApiNameDeleteFineTuningCheckpointPermission,
+		ApiNameVideos,
+		ApiNameRetrieveVideo,
+		ApiNameVideoRemix,
+		ApiNameRetrieveVideoContent,
+		ApiNameKlingImageToVideo,
+		ApiNameKlingRetrieveImageVideo,
+		ApiNameCohereV1Rerank,
+		ApiNameQwenAsyncAIGC,
+		ApiNameQwenAsyncTask,
+		ApiNameQwenV1Rerank,
+		ApiNameQwenV1Conversations,
+		ApiNameGeminiGenerateContent,
+		ApiNameGeminiStreamGenerateContent,
+		ApiNameAnthropicMessages,
+		ApiNameAnthropicCountTokens,
+		ApiNameAnthropicComplete,
+		ApiNameVertexRaw:
+		return true
+	}
+	return false
 }
 
 func (c *ProviderConfig) setDefaultCapabilities(capabilities map[string]string) {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -757,6 +758,52 @@ func TestProviderConfig_SetDefaultCapabilities(t *testing.T) {
 
 		assert.Equal(t, "/custom/chat/completions", config.capabilities[string(ApiNameChatCompletion)])
 	})
+}
+
+func TestProviderConfig_FromJsonCapabilities(t *testing.T) {
+	configuredCapabilities := map[string]string{
+		string(ApiNameCompletion):                           "/custom/completions",
+		string(ApiNameModels):                               "/custom/models",
+		string(ApiNameFiles):                                "/custom/files",
+		string(ApiNameRetrieveFile):                         "/custom/files/{file_id}",
+		string(ApiNameRetrieveFileContent):                  "/custom/files/{file_id}/content",
+		string(ApiNameBatches):                              "/custom/batches",
+		string(ApiNameRetrieveBatch):                        "/custom/batches/{batch_id}",
+		string(ApiNameCancelBatch):                          "/custom/batches/{batch_id}/cancel",
+		string(ApiNameFineTuningJobs):                       "/custom/fine_tuning/jobs",
+		string(ApiNameRetrieveFineTuningJob):                "/custom/fine_tuning/jobs/{fine_tuning_job_id}",
+		string(ApiNameFineTuningJobEvents):                  "/custom/fine_tuning/jobs/{fine_tuning_job_id}/events",
+		string(ApiNameFineTuningJobCheckpoints):             "/custom/fine_tuning/jobs/{fine_tuning_job_id}/checkpoints",
+		string(ApiNameCancelFineTuningJob):                  "/custom/fine_tuning/jobs/{fine_tuning_job_id}/cancel",
+		string(ApiNameResumeFineTuningJob):                  "/custom/fine_tuning/jobs/{fine_tuning_job_id}/resume",
+		string(ApiNamePauseFineTuningJob):                   "/custom/fine_tuning/jobs/{fine_tuning_job_id}/pause",
+		string(ApiNameFineTuningCheckpointPermissions):      "/custom/fine_tuning/checkpoints/{fine_tuned_model_checkpoint}/permissions",
+		string(ApiNameDeleteFineTuningCheckpointPermission): "/custom/fine_tuning/checkpoints/{fine_tuned_model_checkpoint}/permissions/{permission_id}",
+		string(ApiNameQwenAsyncAIGC):                        "/custom/qwen/services/aigc",
+		string(ApiNameQwenAsyncTask):                        "/custom/qwen/tasks/{task_id}",
+		string(ApiNameAnthropicMessages):                    "/custom/anthropic/messages",
+		string(ApiNameAnthropicCountTokens):                 "/custom/anthropic/messages/count_tokens",
+		string(ApiNameGeminiGenerateContent):                "/custom/gemini/{model}:generateContent",
+		string(ApiNameVertexRaw):                            "/custom/vertex/raw",
+	}
+	configuredCapabilities["unknown/v1/not-supported"] = "/custom/unknown"
+
+	rawConfig, err := json.Marshal(map[string]any{
+		"type":         "openai",
+		"capabilities": configuredCapabilities,
+	})
+	assert.NoError(t, err)
+
+	var config ProviderConfig
+	config.FromJson(gjson.ParseBytes(rawConfig))
+
+	for capability, path := range configuredCapabilities {
+		if capability == "unknown/v1/not-supported" {
+			assert.NotContains(t, config.capabilities, capability)
+			continue
+		}
+		assert.Equal(t, path, config.capabilities[capability])
+	}
 }
 
 func TestCreateProvider(t *testing.T) {


### PR DESCRIPTION
## What this PR does

Extends the `ai-proxy` provider `capabilities` configuration whitelist so users can override all known API capabilities that Higress already supports internally.

Before this change, the default provider capabilities covered OpenAI-compatible APIs such as completions, models, files, batches, fine-tuning, and several provider-native APIs, but `ProviderConfig.FromJson` only accepted a smaller subset from user configuration. That meant some APIs could work with default paths but could not be remapped for custom OpenAI-compatible backends.

This PR:

- moves the capability whitelist into a dedicated `isConfigurableCapability` helper
- includes stateful OpenAI APIs such as files, batches, and fine-tuning jobs
- includes provider-native capabilities such as Qwen async task APIs, Anthropic messages/count-tokens, Gemini content generation, and Vertex raw passthrough
- keeps unknown capability names filtered out

## Why

Higress positions `ai-proxy` as a unified AI gateway for mainstream and OpenAI-compatible model providers. Custom capability paths are important when routing to private deployments, compatibility layers, or providers with non-standard base paths.

## Testing

- `GOCACHE=/private/tmp/higress-go-cache go test ./provider -run 'TestProviderConfig_(FromJsonCapabilities|SetDefaultCapabilities|IsSupportedAPI)' -count=1`
- `GOCACHE=/private/tmp/higress-go-cache go test ./provider`
- `GOCACHE=/private/tmp/higress-go-cache go test ./...`
