### PR TITLE
feat: support OpenAI responses subpaths

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -67,6 +67,8 @@ var (
 		{provider.PathOpenAIModels, provider.ApiNameModels},
 		{provider.PathOpenAIFineTuningJobs, provider.ApiNameFineTuningJobs},
 		{provider.PathOpenAIResponses, provider.ApiNameResponses},
+		{provider.PathOpenAICompactResponse, provider.ApiNameCompactResponse},
+		{provider.PathOpenAIResponseInputTokens, provider.ApiNameResponseInputTokens},
 		{provider.PathOpenAIVideos, provider.ApiNameVideos},
 		// Anthropic style
 		{provider.PathAnthropicMessagesCountTokens, provider.ApiNameAnthropicCountTokens},
@@ -82,6 +84,9 @@ var (
 		// OpenAI style
 		{util.RegRetrieveBatchPath, provider.ApiNameRetrieveBatch},
 		{util.RegCancelBatchPath, provider.ApiNameCancelBatch},
+		{util.RegRetrieveResponsePath, provider.ApiNameRetrieveResponse},
+		{util.RegCancelResponsePath, provider.ApiNameCancelResponse},
+		{util.RegListResponseInputItemsPath, provider.ApiNameListResponseInputItems},
 		{util.RegRetrieveFilePath, provider.ApiNameRetrieveFile},
 		{util.RegRetrieveFileContentPath, provider.ApiNameRetrieveFileContent},
 		{util.RegRetrieveVideoPath, provider.ApiNameRetrieveVideo},

--- a/plugins/wasm-go/extensions/ai-proxy/main_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main_test.go
@@ -53,6 +53,12 @@ func Test_getApiName(t *testing.T) {
 		{"openai fine tuning checkpoint permissions", "/v1/fine_tuning/checkpoints/checkpointid/permissions", provider.ApiNameFineTuningCheckpointPermissions},
 		{"openai delete fine tuning checkpoint permission", "/v1/fine_tuning/checkpoints/checkpointid/permissions/permissionid", provider.ApiNameDeleteFineTuningCheckpointPermission},
 		{"openai responses", "/v1/responses", provider.ApiNameResponses},
+		{"openai retrieve response", "/v1/responses/resp_123", provider.ApiNameRetrieveResponse},
+		{"openai cancel response", "/v1/responses/resp_123/cancel", provider.ApiNameCancelResponse},
+		{"openai compact response", "/v1/responses/compact", provider.ApiNameCompactResponse},
+		{"openai list response input items", "/v1/responses/resp_123/input_items", provider.ApiNameListResponseInputItems},
+		{"openai response input tokens", "/v1/responses/input_tokens", provider.ApiNameResponseInputTokens},
+		{"openai retrieve response with prefix", "/gateway/openai/v1/responses/resp_123", provider.ApiNameRetrieveResponse},
 		// Anthropic
 		{"anthropic count_tokens", "/v1/messages/count_tokens", provider.ApiNameAnthropicCountTokens},
 		{"anthropic messages", "/v1/messages", provider.ApiNameAnthropicMessages},

--- a/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
@@ -45,6 +45,11 @@ func (m *openaiProviderInitializer) DefaultCapabilities() map[string]string {
 		string(ApiNameRetrieveBatch):                        PathOpenAIRetrieveBatch,
 		string(ApiNameCancelBatch):                          PathOpenAICancelBatch,
 		string(ApiNameResponses):                            PathOpenAIResponses,
+		string(ApiNameRetrieveResponse):                     PathOpenAIRetrieveResponse,
+		string(ApiNameCancelResponse):                       PathOpenAICancelResponse,
+		string(ApiNameCompactResponse):                      PathOpenAICompactResponse,
+		string(ApiNameListResponseInputItems):               PathOpenAIListResponseInputItems,
+		string(ApiNameResponseInputTokens):                  PathOpenAIResponseInputTokens,
 		string(ApiNameFineTuningJobs):                       PathOpenAIFineTuningJobs,
 		string(ApiNameRetrieveFineTuningJob):                PathOpenAIRetrieveFineTuningJob,
 		string(ApiNameFineTuningJobEvents):                  PathOpenAIFineTuningJobEvents,
@@ -73,6 +78,8 @@ func isDirectPath(path string) bool {
 		strings.HasSuffix(path, "/images/edits") ||
 		strings.HasSuffix(path, "/models") ||
 		strings.HasSuffix(path, "/responses") ||
+		strings.HasSuffix(path, "/responses/compact") ||
+		strings.HasSuffix(path, "/responses/input_tokens") ||
 		strings.HasSuffix(path, "/fine_tuning/jobs") ||
 		strings.HasSuffix(path, "/fine_tuning/checkpoints") ||
 		strings.HasSuffix(path, "/realtime") ||

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -52,6 +52,11 @@ const (
 	ApiNameCancelBatch                          ApiName = "openai/v1/cancelbatch"
 	ApiNameModels                               ApiName = "openai/v1/models"
 	ApiNameResponses                            ApiName = "openai/v1/responses"
+	ApiNameRetrieveResponse                     ApiName = "openai/v1/retrieveresponse"
+	ApiNameCancelResponse                       ApiName = "openai/v1/cancelresponse"
+	ApiNameCompactResponse                      ApiName = "openai/v1/compactresponse"
+	ApiNameListResponseInputItems               ApiName = "openai/v1/listresponseinputitems"
+	ApiNameResponseInputTokens                  ApiName = "openai/v1/responseinputtokens"
 	ApiNameFineTuningJobs                       ApiName = "openai/v1/fine-tuningjobs"
 	ApiNameRetrieveFineTuningJob                ApiName = "openai/v1/retrievefine-tuningjob"
 	ApiNameFineTuningJobEvents                  ApiName = "openai/v1/fine-tuningjobsevents"
@@ -101,6 +106,11 @@ const (
 	PathOpenAIAudioTranslations                    = "/v1/audio/translations"
 	PathOpenAIRealtime                             = "/v1/realtime"
 	PathOpenAIResponses                            = "/v1/responses"
+	PathOpenAIRetrieveResponse                     = "/v1/responses/{response_id}"
+	PathOpenAICancelResponse                       = "/v1/responses/{response_id}/cancel"
+	PathOpenAICompactResponse                      = "/v1/responses/compact"
+	PathOpenAIListResponseInputItems               = "/v1/responses/{response_id}/input_items"
+	PathOpenAIResponseInputTokens                  = "/v1/responses/input_tokens"
 	PathOpenAIFineTuningJobs                       = "/v1/fine_tuning/jobs"
 	PathOpenAIRetrieveFineTuningJob                = "/v1/fine_tuning/jobs/{fine_tuning_job_id}"
 	PathOpenAIFineTuningJobEvents                  = "/v1/fine_tuning/jobs/{fine_tuning_job_id}/events"
@@ -729,6 +739,11 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 			string(ApiNameAudioTranslation),
 			string(ApiNameRealtime),
 			string(ApiNameResponses),
+			string(ApiNameRetrieveResponse),
+			string(ApiNameCancelResponse),
+			string(ApiNameCompactResponse),
+			string(ApiNameListResponseInputItems),
+			string(ApiNameResponseInputTokens),
 			string(ApiNameCohereV1Rerank),
 			string(ApiNameVideos),
 			string(ApiNameRetrieveVideo),
@@ -858,6 +873,9 @@ func isStatefulAPI(apiName string) bool {
 	// These APIs maintain session state and should be routed to the same provider consistently
 	statefulAPIs := map[string]bool{
 		string(ApiNameResponses):                true, // Response API - uses previous_response_id
+		string(ApiNameRetrieveResponse):         true, // Response retrieval/delete - depends on response state
+		string(ApiNameCancelResponse):           true, // Response cancellation - depends on response state
+		string(ApiNameListResponseInputItems):   true, // Response input items - depends on response state
 		string(ApiNameFiles):                    true, // Files API - maintains file state
 		string(ApiNameRetrieveFile):             true, // File retrieval - depends on file upload
 		string(ApiNameRetrieveFileContent):      true, // File content - depends on file upload
@@ -1478,6 +1496,8 @@ func (c *ProviderConfig) needToProcessRequestBody(apiName ApiName) bool {
 		ApiNameAudioSpeech,
 		ApiNameFineTuningJobs,
 		ApiNameResponses,
+		ApiNameCompactResponse,
+		ApiNameResponseInputTokens,
 		ApiNameGeminiGenerateContent,
 		ApiNameGeminiStreamGenerateContent,
 		ApiNameAnthropicMessages,

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
@@ -21,6 +21,21 @@ func TestIsStatefulAPI(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "retrieve_response_api",
+			apiName:  string(ApiNameRetrieveResponse),
+			expected: true,
+		},
+		{
+			name:     "cancel_response_api",
+			apiName:  string(ApiNameCancelResponse),
+			expected: true,
+		},
+		{
+			name:     "list_response_input_items_api",
+			apiName:  string(ApiNameListResponseInputItems),
+			expected: true,
+		},
+		{
 			name:     "files_api",
 			apiName:  string(ApiNameFiles),
 			expected: true,
@@ -130,6 +145,28 @@ func TestIsStatefulAPI(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestOpenAIProviderInitializer_DefaultCapabilitiesResponses(t *testing.T) {
+	capabilities := (&openaiProviderInitializer{}).DefaultCapabilities()
+
+	assert.Equal(t, PathOpenAIResponses, capabilities[string(ApiNameResponses)])
+	assert.Equal(t, PathOpenAIRetrieveResponse, capabilities[string(ApiNameRetrieveResponse)])
+	assert.Equal(t, PathOpenAICancelResponse, capabilities[string(ApiNameCancelResponse)])
+	assert.Equal(t, PathOpenAICompactResponse, capabilities[string(ApiNameCompactResponse)])
+	assert.Equal(t, PathOpenAIListResponseInputItems, capabilities[string(ApiNameListResponseInputItems)])
+	assert.Equal(t, PathOpenAIResponseInputTokens, capabilities[string(ApiNameResponseInputTokens)])
+}
+
+func TestProviderConfig_NeedToProcessResponsesRequestBody(t *testing.T) {
+	cfg := ProviderConfig{}
+
+	assert.True(t, cfg.needToProcessRequestBody(ApiNameResponses))
+	assert.True(t, cfg.needToProcessRequestBody(ApiNameCompactResponse))
+	assert.True(t, cfg.needToProcessRequestBody(ApiNameResponseInputTokens))
+	assert.False(t, cfg.needToProcessRequestBody(ApiNameRetrieveResponse))
+	assert.False(t, cfg.needToProcessRequestBody(ApiNameCancelResponse))
+	assert.False(t, cfg.needToProcessRequestBody(ApiNameListResponseInputItems))
 }
 
 func TestGetTokenWithConsumerAffinity(t *testing.T) {
@@ -318,6 +355,28 @@ func TestProviderBasePath_Config(t *testing.T) {
 		assert.Equal(t, "/api/v1", config.providerBasePath)
 		assert.Equal(t, "proxy.example.com", config.providerDomain)
 	})
+}
+
+func TestProviderConfig_FromJsonResponseCapabilities(t *testing.T) {
+	config := ProviderConfig{}
+	jsonStr := `{
+		"capabilities": {
+			"openai/v1/retrieveresponse": "/proxy/responses/{response_id}",
+			"openai/v1/cancelresponse": "/proxy/responses/{response_id}/cancel",
+			"openai/v1/compactresponse": "/proxy/responses/compact",
+			"openai/v1/listresponseinputitems": "/proxy/responses/{response_id}/input_items",
+			"openai/v1/responseinputtokens": "/proxy/responses/input_tokens",
+			"openai/v1/unknownresponse": "/proxy/unknown"
+		}
+	}`
+	config.FromJson(gjson.Parse(jsonStr))
+
+	assert.Equal(t, "/proxy/responses/{response_id}", config.capabilities[string(ApiNameRetrieveResponse)])
+	assert.Equal(t, "/proxy/responses/{response_id}/cancel", config.capabilities[string(ApiNameCancelResponse)])
+	assert.Equal(t, "/proxy/responses/compact", config.capabilities[string(ApiNameCompactResponse)])
+	assert.Equal(t, "/proxy/responses/{response_id}/input_items", config.capabilities[string(ApiNameListResponseInputItems)])
+	assert.Equal(t, "/proxy/responses/input_tokens", config.capabilities[string(ApiNameResponseInputTokens)])
+	assert.NotContains(t, config.capabilities, "openai/v1/unknownresponse")
 }
 
 func TestApplyProviderBasePath(t *testing.T) {

--- a/plugins/wasm-go/extensions/ai-proxy/test/util.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/util.go
@@ -75,6 +75,33 @@ func RunMapRequestPathByCapabilityTests(t *testing.T) {
 			expected: "/v1/batches/batch-002/cancel",
 		},
 		{
+			name:    "retrieve response replaces response id",
+			apiName: "openai/v1/retrieveresponse",
+			origin:  "/openai/v1/responses/resp_abc",
+			mapping: map[string]string{
+				"openai/v1/retrieveresponse": "/v1/responses/{response_id}",
+			},
+			expected: "/v1/responses/resp_abc",
+		},
+		{
+			name:    "cancel response replaces response id",
+			apiName: "openai/v1/cancelresponse",
+			origin:  "/openai/v1/responses/resp_abc/cancel",
+			mapping: map[string]string{
+				"openai/v1/cancelresponse": "/v1/responses/{response_id}/cancel",
+			},
+			expected: "/v1/responses/resp_abc/cancel",
+		},
+		{
+			name:    "response input items keeps query parameters",
+			apiName: "openai/v1/listresponseinputitems",
+			origin:  "/openai/v1/responses/resp_abc/input_items?after=item_1",
+			mapping: map[string]string{
+				"openai/v1/listresponseinputitems": "/v1/responses/{response_id}/input_items",
+			},
+			expected: "/v1/responses/resp_abc/input_items?after=item_1",
+		},
+		{
 			name:    "video placeholder is replaced",
 			apiName: "openai/v1/retrievevideo",
 			origin:  "/openai/v1/videos/video-xyz",

--- a/plugins/wasm-go/extensions/ai-proxy/util/http.go
+++ b/plugins/wasm-go/extensions/ai-proxy/util/http.go
@@ -47,6 +47,9 @@ const (
 var (
 	RegRetrieveBatchPath                        = regexp.MustCompile(`^.*/v1/batches/(?P<batch_id>[^/]+)$`)
 	RegCancelBatchPath                          = regexp.MustCompile(`^.*/v1/batches/(?P<batch_id>[^/]+)/cancel$`)
+	RegRetrieveResponsePath                     = regexp.MustCompile(`^.*/v1/responses/(?P<response_id>[^/]+)$`)
+	RegCancelResponsePath                       = regexp.MustCompile(`^.*/v1/responses/(?P<response_id>[^/]+)/cancel$`)
+	RegListResponseInputItemsPath               = regexp.MustCompile(`^.*/v1/responses/(?P<response_id>[^/]+)/input_items$`)
 	RegRetrieveFilePath                         = regexp.MustCompile(`^.*/v1/files/(?P<file_id>[^/]+)$`)
 	RegRetrieveFileContentPath                  = regexp.MustCompile(`^.*/v1/files/(?P<file_id>[^/]+)/content$`)
 	RegRetrieveVideoPath                        = regexp.MustCompile(`^.*/v1/videos/(?P<video_id>[^/]+)$`)
@@ -136,6 +139,9 @@ func MapRequestPathByCapability(apiName string, originPath string, mapping map[s
 			{RegRetrieveFileContentPath, "file_id"},
 			{RegRetrieveBatchPath, "batch_id"},
 			{RegCancelBatchPath, "batch_id"},
+			{RegRetrieveResponsePath, "response_id"},
+			{RegCancelResponsePath, "response_id"},
+			{RegListResponseInputItemsPath, "response_id"},
 			{RegRetrieveVideoPath, "video_id"},
 			{RegRetrieveVideoContentPath, "video_id"},
 			{RegVideoRemixPath, "video_id"},


### PR DESCRIPTION
## Summary

Extend the AI proxy OpenAI Responses API coverage beyond `POST /v1/responses` by adding the currently documented Responses subpaths:

- `/v1/responses/{response_id}`
- `/v1/responses/{response_id}/cancel`
- `/v1/responses/compact`
- `/v1/responses/{response_id}/input_items`
- `/v1/responses/input_tokens`

This keeps Higress' OpenAI-compatible gateway path detection and capability mapping aligned with the expanded Responses API surface.

## Motivation

Higress positions the AI gateway as a unified OpenAI-compatible entrypoint. The provider already supports several OpenAI stateful resource subpaths for files, batches, videos, and fine-tuning jobs, but Responses only had the create endpoint. Requests to retrieve/cancel/list response items or use compact/input token endpoints could not be classified into a dedicated capability and therefore could not be remapped by capability path.

## Changes

- Add Responses subpath `ApiName` and path constants.
- Add OpenAI default capability entries for the new subpaths.
- Add route matching for exact Responses endpoints and `{response_id}` regex endpoints.
- Add `{response_id}` placeholder substitution in `MapRequestPathByCapability`.
- Mark response resource subpaths as stateful for consumer affinity.
- Treat `compact` and `input_tokens` as body-carrying APIs.
- Allow the new response capabilities in provider JSON configuration.
- Add regression tests for API detection, path remapping, default capabilities, config parsing, stateful API classification, and body-processing behavior.

Reference: OpenAI Responses API reference documents create, retrieve, delete, cancel, compact, input-items, and input-token endpoints under `/v1/responses`.

## Tests

```bash
GOCACHE=/private/tmp/higress-go-cache go test ./... -run 'Test_getApiName|TestProviderConfig_FromJsonResponseCapabilities|TestOpenAIProviderInitializer_DefaultCapabilitiesResponses|TestProviderConfig_NeedToProcessResponsesRequestBody|TestIsStatefulAPI|TestRunMapRequestPathByCapability|TestMapRequestPathByCapability' -count=1
GOCACHE=/private/tmp/higress-go-cache go test . -run 'TestUtil' -count=1
GOCACHE=/private/tmp/higress-go-cache go test ./...
```
