### PR TITLE
feat: support OpenAI model subpaths

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/main.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main.go
@@ -82,6 +82,7 @@ var (
 		// OpenAI style
 		{util.RegRetrieveBatchPath, provider.ApiNameRetrieveBatch},
 		{util.RegCancelBatchPath, provider.ApiNameCancelBatch},
+		{util.RegRetrieveModelPath, provider.ApiNameRetrieveModel},
 		{util.RegRetrieveFilePath, provider.ApiNameRetrieveFile},
 		{util.RegRetrieveFileContentPath, provider.ApiNameRetrieveFileContent},
 		{util.RegRetrieveVideoPath, provider.ApiNameRetrieveVideo},

--- a/plugins/wasm-go/extensions/ai-proxy/main_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/main_test.go
@@ -43,6 +43,8 @@ func Test_getApiName(t *testing.T) {
 		{"openai retrieve video content", "/v1/videos/videoid/content", provider.ApiNameRetrieveVideoContent},
 		{"openai video remix", "/v1/videos/videoid/remix", provider.ApiNameVideoRemix},
 		{"openai models", "/v1/models", provider.ApiNameModels},
+		{"openai retrieve model", "/v1/models/gpt-4o-mini", provider.ApiNameRetrieveModel},
+		{"openai retrieve model with prefix", "/gateway/openai/v1/models/gpt-4o-mini", provider.ApiNameRetrieveModel},
 		{"openai fine tuning jobs", "/v1/fine_tuning/jobs", provider.ApiNameFineTuningJobs},
 		{"openai retrieve fine tuning job", "/v1/fine_tuning/jobs/jobid", provider.ApiNameRetrieveFineTuningJob},
 		{"openai fine tuning job events", "/v1/fine_tuning/jobs/jobid/events", provider.ApiNameFineTuningJobEvents},

--- a/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/openai.go
@@ -38,6 +38,7 @@ func (m *openaiProviderInitializer) DefaultCapabilities() map[string]string {
 		string(ApiNameAudioTranslation):                     PathOpenAIAudioTranslations,
 		string(ApiNameRealtime):                             PathOpenAIRealtime,
 		string(ApiNameModels):                               PathOpenAIModels,
+		string(ApiNameRetrieveModel):                        PathOpenAIRetrieveModel,
 		string(ApiNameFiles):                                PathOpenAIFiles,
 		string(ApiNameRetrieveFile):                         PathOpenAIRetrieveFile,
 		string(ApiNameRetrieveFileContent):                  PathOpenAIRetrieveFileContent,

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider.go
@@ -51,6 +51,7 @@ const (
 	ApiNameRetrieveBatch                        ApiName = "openai/v1/retrievebatch"
 	ApiNameCancelBatch                          ApiName = "openai/v1/cancelbatch"
 	ApiNameModels                               ApiName = "openai/v1/models"
+	ApiNameRetrieveModel                        ApiName = "openai/v1/retrievemodel"
 	ApiNameResponses                            ApiName = "openai/v1/responses"
 	ApiNameFineTuningJobs                       ApiName = "openai/v1/fine-tuningjobs"
 	ApiNameRetrieveFineTuningJob                ApiName = "openai/v1/retrievefine-tuningjob"
@@ -93,6 +94,7 @@ const (
 	PathOpenAIRetrieveBatch                        = "/v1/batches/{batch_id}"
 	PathOpenAICancelBatch                          = "/v1/batches/{batch_id}/cancel"
 	PathOpenAIModels                               = "/v1/models"
+	PathOpenAIRetrieveModel                        = "/v1/models/{model_id}"
 	PathOpenAIImageGeneration                      = "/v1/images/generations"
 	PathOpenAIImageEdit                            = "/v1/images/edits"
 	PathOpenAIImageVariation                       = "/v1/images/variations"
@@ -729,6 +731,7 @@ func (c *ProviderConfig) FromJson(json gjson.Result) {
 			string(ApiNameAudioTranslation),
 			string(ApiNameRealtime),
 			string(ApiNameResponses),
+			string(ApiNameRetrieveModel),
 			string(ApiNameCohereV1Rerank),
 			string(ApiNameVideos),
 			string(ApiNameRetrieveVideo),

--- a/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/provider_test.go
@@ -132,6 +132,13 @@ func TestIsStatefulAPI(t *testing.T) {
 	}
 }
 
+func TestOpenAIProviderInitializer_DefaultCapabilitiesModels(t *testing.T) {
+	capabilities := (&openaiProviderInitializer{}).DefaultCapabilities()
+
+	assert.Equal(t, PathOpenAIModels, capabilities[string(ApiNameModels)])
+	assert.Equal(t, PathOpenAIRetrieveModel, capabilities[string(ApiNameRetrieveModel)])
+}
+
 func TestGetTokenWithConsumerAffinity(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -318,6 +325,20 @@ func TestProviderBasePath_Config(t *testing.T) {
 		assert.Equal(t, "/api/v1", config.providerBasePath)
 		assert.Equal(t, "proxy.example.com", config.providerDomain)
 	})
+}
+
+func TestProviderConfig_FromJsonModelCapabilities(t *testing.T) {
+	config := ProviderConfig{}
+	jsonStr := `{
+		"capabilities": {
+			"openai/v1/retrievemodel": "/proxy/models/{model_id}",
+			"openai/v1/unknownmodel": "/proxy/unknown"
+		}
+	}`
+	config.FromJson(gjson.Parse(jsonStr))
+
+	assert.Equal(t, "/proxy/models/{model_id}", config.capabilities[string(ApiNameRetrieveModel)])
+	assert.NotContains(t, config.capabilities, "openai/v1/unknownmodel")
 }
 
 func TestApplyProviderBasePath(t *testing.T) {

--- a/plugins/wasm-go/extensions/ai-proxy/test/util.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/util.go
@@ -75,6 +75,15 @@ func RunMapRequestPathByCapabilityTests(t *testing.T) {
 			expected: "/v1/batches/batch-002/cancel",
 		},
 		{
+			name:    "retrieve model replaces model id",
+			apiName: "openai/v1/retrievemodel",
+			origin:  "/openai/v1/models/ft:gpt-4o-mini:org:abc123?include=metadata",
+			mapping: map[string]string{
+				"openai/v1/retrievemodel": "/v1/models/{model_id}",
+			},
+			expected: "/v1/models/ft:gpt-4o-mini:org:abc123?include=metadata",
+		},
+		{
 			name:    "video placeholder is replaced",
 			apiName: "openai/v1/retrievevideo",
 			origin:  "/openai/v1/videos/video-xyz",

--- a/plugins/wasm-go/extensions/ai-proxy/util/http.go
+++ b/plugins/wasm-go/extensions/ai-proxy/util/http.go
@@ -47,6 +47,7 @@ const (
 var (
 	RegRetrieveBatchPath                        = regexp.MustCompile(`^.*/v1/batches/(?P<batch_id>[^/]+)$`)
 	RegCancelBatchPath                          = regexp.MustCompile(`^.*/v1/batches/(?P<batch_id>[^/]+)/cancel$`)
+	RegRetrieveModelPath                        = regexp.MustCompile(`^.*/v1/models/(?P<model_id>[^/]+)$`)
 	RegRetrieveFilePath                         = regexp.MustCompile(`^.*/v1/files/(?P<file_id>[^/]+)$`)
 	RegRetrieveFileContentPath                  = regexp.MustCompile(`^.*/v1/files/(?P<file_id>[^/]+)/content$`)
 	RegRetrieveVideoPath                        = regexp.MustCompile(`^.*/v1/videos/(?P<video_id>[^/]+)$`)
@@ -136,6 +137,7 @@ func MapRequestPathByCapability(apiName string, originPath string, mapping map[s
 			{RegRetrieveFileContentPath, "file_id"},
 			{RegRetrieveBatchPath, "batch_id"},
 			{RegCancelBatchPath, "batch_id"},
+			{RegRetrieveModelPath, "model_id"},
 			{RegRetrieveVideoPath, "video_id"},
 			{RegRetrieveVideoContentPath, "video_id"},
 			{RegVideoRemixPath, "video_id"},


### PR DESCRIPTION
## Summary

Add OpenAI model resource subpath support for `/v1/models/{model}` in the AI proxy.

Higress already recognizes the model list endpoint `/v1/models`, but the OpenAI Models API also includes retrieving a model and deleting a fine-tuned model through the model resource path. Without a dedicated capability, these resource requests cannot be classified or remapped by capability path.

## Changes

- Add `ApiNameRetrieveModel` and `PathOpenAIRetrieveModel`.
- Add OpenAI default capability mapping for the model resource path.
- Add regex-based route detection for `/v1/models/<model_id>`.
- Add `{model_id}` placeholder substitution in `MapRequestPathByCapability`.
- Allow the new capability in provider JSON configuration.
- Add regression tests for API detection, path remapping, default capabilities, and config parsing.

The internal placeholder is named `{model_id}` to avoid colliding with Azure deployment paths that already use `{model}` as a deployment placeholder.

Reference: OpenAI Models API reference documents list models, retrieve model, and delete fine-tuned model endpoints.

## Tests

```bash
GOCACHE=/private/tmp/higress-go-cache go test ./... -run 'Test_getApiName|TestProviderConfig_FromJsonModelCapabilities|TestOpenAIProviderInitializer_DefaultCapabilitiesModels|TestUtil' -count=1
GOCACHE=/private/tmp/higress-go-cache go test ./provider -run 'TestAzureDefaultOpenAIV1Capabilities|TestOpenAIProviderInitializer_DefaultCapabilitiesModels|TestProviderConfig_FromJsonModelCapabilities' -count=1
GOCACHE=/private/tmp/higress-go-cache go test . -run 'Test_getApiName|TestUtil' -count=1
GOCACHE=/private/tmp/higress-go-cache go test ./...
```
