### PR TITLE
fix: fix rand.init(0) panic in failover.go

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/failover.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/failover.go
@@ -649,6 +649,10 @@ func (c *ProviderConfig) GetGlobalRandomToken() string {
 	count := len(apiTokens)
 	switch count {
 	case 0:
+		if len(unavailableApiTokens) == 0 {
+			log.Warn("all tokens are unavailable and no unavailable tokens recorded")
+			return ""
+		}
 		log.Warn("all tokens are unavailable, will use random one of the unavailable tokens")
 		return unavailableApiTokens[rand.Intn(len(unavailableApiTokens))]
 	case 1:


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did
在 GetGlobalRandomToken 的 case 0 兜底分支加 len(unavailableApiTokens)  == 0 守卫，返回空字符串，避免 rand.Intn(0) 触发 invalid argument to Intn panic。

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->


## Ⅲ. Why don't you add test cases (unit test/integration test)? 


## Ⅳ. Describe how to verify it


## Ⅴ. Special notes for reviews


## Ⅵ. AI Coding Tool Usage Checklist (if applicable)
<!-- 
**IMPORTANT**: If you used AI Coding tools (e.g., Cursor, GitHub Copilot, etc.) to generate this PR, please check the following items.
PRs that don't meet these requirements will have **LOWER REVIEW PRIORITY** and we **CANNOT GUARANTEE** timely reviews.

If you did NOT use AI Coding tools, you can skip this section entirely.
-->

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [ ] **For regular updates/changes** (not new plugins):
  - [ ] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [ ] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)
<!-- Paste the prompts/instructions you provided to the AI Coding tool -->


### AI Coding Summary
<!-- 
AI Coding tool should provide a summary after completing the work, including:
- Key decisions made
- Major changes implemented  
- Important considerations or limitations
-->



