### PR TITLE
test(e2e): add bedrock conformance cases for ai-proxy

### DIFF
--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,52 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "bedrock case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "bedrock-runtime.us-east-1.amazonaws.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:           200,
+						ContentType:          http.ContentTypeApplicationJson,
+						JsonBodyIgnoreFields: []string{"id", "created", "usage"},
+						Body:                 []byte(`{"id":"x","choices":[{"index":0,"message":{"role":"assistant","content":"This is a mock response from Bedrock provider. You said: 你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":0,"model":"amazon.nova-lite-v1:0","object":"chat.completion","usage":{}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "bedrock case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "bedrock-runtime.us-east-1.amazonaws.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+					},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,25 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-bedrock
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "bedrock-runtime.us-east-1.amazonaws.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +626,15 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          awsRegion: us-east-1
+          modelMapping:
+            "gpt-3": "amazon.nova-lite-v1:0"
+            "*": "amazon.nova-lite-v1:0"
+          type: bedrock
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-bedrock
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add e2e conformance testcases for the **Bedrock** provider of the ai-proxy plugin (part of #2717), mirroring the vertex cases in #4092:

- **bedrock case 1 (non-streaming)**: JSON body assertion (ignoring `id`/`created`/`usage`). The provider runs in **apiTokens mode** (no SigV4 / real AWS credentials); Bedrock yields `finish_reason: "stop"` (`end_turn` → `stop`).
- **bedrock case 2 (streaming)**: asserts status code 200 and `text/event-stream` content type.

ai-proxy rewrites the request to `bedrock-runtime.us-east-1.amazonaws.com` on `/model/{model}/converse(-stream)`, which the llm-mock-server Bedrock simulation answers.

## Ⅱ. Does this pull request fix one issue?
fixed #2717

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR *adds* the e2e conformance test cases themselves, following the existing declarative ai-proxy pattern.

## Ⅳ. Describe how to verify it

Run the Higress conformance suite with the `go-wasm-ai-proxy` test enabled, against a `llm-mock-server` image that includes the Bedrock simulation (higress-group/mock-server#16).

## Ⅴ. Special notes for reviews

- Depends on **higress-group/mock-server#16** (the Bedrock mock simulation). The mock-server side is the harder half — streaming uses Amazon Event Stream binary frames (a stdlib encoder mirroring ai-proxy's decoder), verified locally frame-by-frame with valid CRCs.
- The higress e2e CI will stay red until #16 merges AND the mock-server `:latest` image is rebuilt — note the mock-server image build workflow has been failing, which also blocks the already-merged vertex support.
- As a fork/external contributor the in-repo Actions CI doesn't auto-run on this PR; the DCO/CLA/FOSSA bot checks pass.
