### PR TITLE
test(ai-proxy): add e2e cases for azure and ollama

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/ollama_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/ollama_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ollama routes to the configured server: CreateProvider derives the upstream host:port that
+// TransformRequestHeaders sets as the request authority. The mock is host-agnostic so the e2e
+// can't check this; lock the derivation here.
+func TestOllamaProvider_CreateProviderDerivesUpstreamHostPort(t *testing.T) {
+	p, err := (&ollamaProviderInitializer{}).CreateProvider(ProviderConfig{
+		ollamaServerHost: "ollama-backend.internal",
+		ollamaServerPort: 11434,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ollama-backend.internal:11434", p.(*ollamaProvider).serviceDomain)
+}
+
+func TestOllamaProvider_ValidateConfig(t *testing.T) {
+	init := &ollamaProviderInitializer{}
+	require.Error(t, init.ValidateConfig(&ProviderConfig{ollamaServerPort: 11434})) // missing host
+	require.Error(t, init.ValidateConfig(&ProviderConfig{ollamaServerHost: "x"}))   // missing port
+	require.NoError(t, init.ValidateConfig(&ProviderConfig{ollamaServerHost: "x", ollamaServerPort: 11434}))
+}

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,186 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "azure case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "fake-azure.openai.azure.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"id":"chatcmpl-llm-mock","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"gpt-4o","object":"chat.completion","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "azure case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "fake-azure.openai.azure.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeTextEventStream,
+						Body: []byte(`data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"gpt-4o","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"好"},"finish_reason":null,"logprobs":null}],"created":10,"model":"gpt-4o","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"，"},"finish_reason":null,"logprobs":null}],"created":10,"model":"gpt-4o","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"gpt-4o","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"是"},"finish_reason":null,"logprobs":null}],"created":10,"model":"gpt-4o","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"谁"},"finish_reason":null,"logprobs":null}],"created":10,"model":"gpt-4o","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"gpt-4o","object":"chat.completion.chunk","usage":null}
+
+data: [DONE]
+
+`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "ollama case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "ollama.local",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"id":"chatcmpl-llm-mock","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"llama3.2","object":"chat.completion","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "ollama case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "ollama.local",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeTextEventStream,
+						Body: []byte(`data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"llama3.2","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"好"},"finish_reason":null,"logprobs":null}],"created":10,"model":"llama3.2","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"，"},"finish_reason":null,"logprobs":null}],"created":10,"model":"llama3.2","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"llama3.2","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"是"},"finish_reason":null,"logprobs":null}],"created":10,"model":"llama3.2","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"谁"},"finish_reason":null,"logprobs":null}],"created":10,"model":"llama3.2","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"llama3.2","object":"chat.completion.chunk","usage":null}
+
+data: [DONE]
+
+`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "azure request rewrite: path -> /openai/v1 and api-key injected",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+					CompareTarget:   http.CompareTargetRequest,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "fake-azure-req.openai.azure.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"hi"}],"stream":false}`),
+					},
+					// Assert what the upstream actually received: azure rewrites the path to the v1 surface,
+					// overwrites the host to the service URL host, and injects the api-key header.
+					ExpectedRequest: &http.ExpectedRequest{
+						Request: http.Request{
+							Method: "POST",
+							Host:   "fake-azure.openai.azure.com",
+							Path:   "/openai/v1/chat/completions",
+							Headers: map[string]string{
+								"api-key": "fake_token",
+							},
+						},
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{StatusCode: 200},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:    "ollama request rewrite: upstream host -> configured ollamaServerHost:port",
+					TargetBackend:   "infra-backend-v1",
+					TargetNamespace: "higress-conformance-infra",
+					CompareTarget:   http.CompareTargetRequest,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "ollama-req.local",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"hi"}],"stream":false}`),
+					},
+					// Assert the upstream host was rewritten to the configured Ollama server host:port.
+					ExpectedRequest: &http.ExpectedRequest{
+						Request: http.Request{
+							Method: "POST",
+							Host:   "ollama-upstream.internal:11434",
+							Path:   "/v1/chat/completions",
+						},
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{StatusCode: 200},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,82 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-azure
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "fake-azure.openai.azure.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-ollama
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "ollama.local"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-azure-req
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "fake-azure-req.openai.azure.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-ollama-req
+  namespace: higress-conformance-infra
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "ollama-req.local"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: infra-backend-v1
+                port:
+                  number: 8080
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +683,46 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": gpt-4o
+            "*": gpt-4o-mini
+          type: azure
+          azureServiceUrl: "https://fake-azure.openai.azure.com/openai/v1"
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-azure
+    - config:
+        provider:
+          type: ollama
+          ollamaServerHost: llm-mock-service.higress-conformance-ai-backend.svc.cluster.local
+          ollamaServerPort: 3000
+          modelMapping:
+            "gpt-3": llama3.2
+            "*": llama3.1
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-ollama
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": gpt-4o
+            "*": gpt-4o-mini
+          type: azure
+          azureServiceUrl: "https://fake-azure.openai.azure.com/openai/v1"
+      ingress:
+        - higress-conformance-infra/wasmplugin-ai-proxy-azure-req
+    - config:
+        provider:
+          type: ollama
+          ollamaServerHost: ollama-upstream.internal
+          ollamaServerPort: 11434
+          modelMapping:
+            "gpt-3": llama3.2
+            "*": llama3.1
+      ingress:
+        - higress-conformance-infra/wasmplugin-ai-proxy-ollama-req
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Adds conformance e2e for the OpenAI-compatible **azure** and **ollama** providers. Both are passthrough providers backed by the existing OpenAI mock, so **no mock-server change is needed**.

- Response cases: assert the OpenAI-shaped non-stream/stream response (config, routing, modelMapping).
- Request-rewrite cases (echo backend): assert azure's path rewrite to `/openai/v1/chat/completions` + `api-key` injection, and ollama's upstream host rewrite.
- Unit test for the ollama `host:port` derivation.

### Ⅱ. Does this pull request fix one issue?

Fixes #1725
Fixes #1734

### Ⅲ. Why don't you add test cases (unit test)?

Includes a unit test for the ollama host:port derivation.

### Ⅳ. Describe how to verify it

`make higress-conformance-test-wasmplugin PLUGIN_TYPE=GO PLUGIN_NAME=ai-proxy TEST_SHORTNAME=WasmPluginAiProxy`

### Ⅴ. Special notes for reviews

No mock-server dependency.