### PR TITLE
test(e2e): add hunyuan conformance cases for ai-proxy

### DIFF
--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,52 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "hunyuan case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "hunyuan.tencentcloudapi.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:           200,
+						ContentType:          http.ContentTypeApplicationJson,
+						JsonBodyIgnoreFields: []string{"id", "created", "usage"},
+						Body:                 []byte(`{"id":"x","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":0,"model":"hunyuan-pro","object":"chat.completion","usage":{}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "hunyuan case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "hunyuan.tencentcloudapi.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+					},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,25 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-hunyuan
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "hunyuan.tencentcloudapi.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +626,16 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          hunyuanAuthId: "12345678-1234-1234-1234-123456789012"
+          hunyuanAuthKey: "1234567890abcdef1234567890abcdef"
+          modelMapping:
+            "gpt-3": hunyuan-pro
+            "*": hunyuan-lite
+          type: hunyuan
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-hunyuan
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add non-streaming and streaming e2e conformance cases for the `hunyuan` ai-proxy provider in `test/e2e/conformance/tests/go-wasm-ai-proxy.{go,yaml}`. These cases exercise hunyuan's native TC3 transform path (OpenAI ↔ Tencent Cloud ChatCompletions).

## Ⅱ. Does this pull request fix one issue?

fixes #1720

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR itself adds the e2e conformance test cases for the hunyuan provider.

## Ⅳ. Describe how to verify it

Run the ai-proxy conformance suite against a gateway backed by the llm-mock-server. The hunyuan mock is shipped in the `:latest` `llm-mock-server` image (mock-server #17, already republished).

## Ⅴ. Special notes for reviews

The hunyuan provider has two modes: native TC3 (when `hunyuanAuthId`/`hunyuanAuthKey` are configured) and OpenAI-compatible pass-through (otherwise). The e2e config uses native TC3 mode so the full request/response transform is exercised — the mock-server hunyuan handler only matches the native TC3 host (`hunyuan.tencentcloudapi.com`) and path (`/`). The streaming case asserts only the `text/event-stream` content type because the mock emits a dynamic `Created` timestamp per chunk.
