### PR TITLE
test(e2e): add deepl conformance cases for ai-proxy

### DIFF
--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,29 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "deepl case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api-free.deepl.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"Free","messages":[{"role":"user","content":"你好，你是谁？"}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:           200,
+						ContentType:          http.ContentTypeApplicationJson,
+						JsonBodyIgnoreFields: []string{"created", "usage"},
+						Body:                 []byte(`{"choices":[{"index":0,"logprobs":null,"message":{"content":"你好，你是谁？","name":"EN","role":"assistant"}},"finish_reason":null}],"model":"Free","object":"chat.completion"}`),
+					},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,25 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-deepl
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "api-free.deepl.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +626,12 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          targetLang: EN
+          type: deepl
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-deepl
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

Add a non-streaming e2e conformance case for the `deepl` provider of the ai-proxy wasm plugin. The case sends an OpenAI-format chat completion request (model `Free`) and verifies that ai-proxy transforms it to the DeepL `/v2/translate` request shape (text array + `target_lang`), routes to the Free host `api-free.deepl.com`, and converts the DeepL translation response back into an OpenAI `chat.completion` (with `detected_source_language` mapped to `message.name`).

It reuses the same conformance scaffolding as the existing openai/hunyuan/etc. cases:

- New `Ingress` `wasmplugin-ai-proxy-deepl` (host `api-free.deepl.com`) pointing at `llm-mock-service`.
- New `matchRule` with `type: deepl`, `apiTokens: [fake_token]`, `targetLang: EN` (required by `deeplProviderInitializer.ValidateConfig`).
- A single non-streaming test case asserting the OpenAI-format response, ignoring the volatile `created` and `usage` fields.

## Ⅱ. Does this pull request fix one issue?
<!-- If that, add "fixes #xxx" below in the next line, for example, fixes #97. -->
fixes #1723

## Ⅲ. Why don't you add test cases (unit test/integration test)?
This PR itself adds the e2e conformance test case for the deepl provider.

## Ⅳ. Describe how to verify it
Run the conformance suite against a cluster with the `llm-mock` (latest image, which ships the deepl mock) service and the `ai-proxy` wasm plugin built:

```
go test ./test/e2e/conformance/tests/... -run TestGoWasmAiProxy
```

The `deepl case 1: non-streaming request` case should pass.

## Ⅴ. Special notes for reviews
- Only a non-streaming case is added; DeepL's `/v2/translate` is non-streaming, so the deepl provider has no streaming path.
- The request body uses `model: "Free"` (the deepl provider requires `Free` or `Pro`; `Free` selects the `api-free.deepl.com` host).
- `targetLang: EN` is mandatory in the provider config and is therefore set in the `matchRule`.
- `JsonBodyIgnoreFields: ["created", "usage"]` excludes the timestamp (`time.Now()`) and the always-null `usage` (deepl does not populate token usage) from the comparison.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)
<!-- 
**IMPORTANT**: If you used AI Coding tools (e.g., Cursor, GitHub Copilot, etc.) to generate this PR, please check the following items.
PRs that don't meet these requirements will have **LOWER REVIEW PRIORITY** and we **CANNOT GUARANTEE** timely reviews.

If you did NOT use AI Coding tools, you can skip this section entirely.
-->

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [ ] **For regular updates/changes** (not new plugins):
  - [ ] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [ ] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)
<!-- Paste the prompts/instructions you provided to the AI Coding tool -->


### AI Coding Summary
<!-- 
AI Coding tool should provide a summary after completing the work, including:
- Key decisions made
- Major changes implemented  
- Important considerations or limitations
-->
