### PR TITLE
test(e2e): add cohere conformance cases for ai-proxy

### DIFF
--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,51 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "cohere case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.cohere.com",
+						Path:        "/v1/chat",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"chat_history":[{"message":"你好，你是谁？","role":"USER"},{"message":"你好，你是谁？","role":"CHATBOT"}],"finish_reason":"COMPLETE","generation_id":"chatcmpl-llm-mock","meta":{"api_version":{"version":"1"},"billed_units":{"input_tokens":9,"output_tokens":1},"tokens":{"input_tokens":9,"output_tokens":1}},"response_id":"chatcmpl-llm-mock","text":"你好，你是谁？"}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "cohere case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.cohere.com",
+						Path:        "/v1/chat",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+					},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,25 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-cohere
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "api.cohere.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +626,14 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": command-r
+            "*": command-r
+          type: cohere
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-cohere
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add e2e conformance cases for the `cohere` provider of the ai-proxy WASM plugin, following the same pattern as the existing provider cases (e.g. hunyuan / openai). Two cases are added to `go-wasm-ai-proxy`:

- **cohere case 1 (non-streaming)**: sends an OpenAI-format chat request through the cohere provider and asserts the response. Because the cohere provider only implements `TransformRequestBody` (mapping the first message's content to the Cohere top-level `message` field) and does **not** implement `TransformResponseBody`, the native Cohere v1 `/v1/chat` response is passed through unchanged. The expected body is therefore the mock's Cohere-native JSON (`response_id`, `text`, `generation_id`, `chat_history`, `finish_reason`, `meta`) matched field-by-field.
- **cohere case 2 (streaming)**: sends a streaming request (`stream:true`) and asserts a `200` status with `Content-Type: text/event-stream`, matching the SSE framing emitted by the Cohere mock.

The corresponding `Ingress` (host `api.cohere.com`) and `WasmPlugin` matchRule (`type: cohere`, `apiTokens: [fake_token]`, `modelMapping: {"gpt-3": command-r, "*": command-r}`) are added to `go-wasm-ai-proxy.yaml`.

## Ⅱ. Does this pull request fix one issue?
fixes #1738

## Ⅲ. Why don't you add test cases (unit test/integration test)?
This PR itself adds e2e conformance test cases for the cohere provider.

## Ⅳ. Describe how to verify it
Run the e2e conformance suite:
```
go test ./test/e2e/conformance/... -run WasmPluginAiProxy
```
The cohere mock is provided by the `llm-mock` image (mock-server), so the request body `{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":<bool>}` reaches `api.cohere.com/v1/chat` after ai-proxy's request transform, and the Cohere-native response is returned to the client.

## Ⅴ. Special notes for reviews
The expected non-streaming response is the Cohere v1 native format (not converted to OpenAI shape), which is the correct behavior: the cohere provider does not implement `TransformResponseBody`, so the response from the upstream mock is transparently forwarded to the client.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

