### PR TITLE
test(e2e): add claude conformance cases for ai-proxy

### DIFF
--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,52 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "claude case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.anthropic.com",
+						Path:        "/v1/messages",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:           200,
+						ContentType:          http.ContentTypeApplicationJson,
+						JsonBodyIgnoreFields: []string{"id", "created", "usage"},
+						Body:                 []byte(`{"id":"x","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":0,"model":"claude-3-5-sonnet","object":"chat.completion","usage":{}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "claude case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.anthropic.com",
+						Path:        "/v1/messages",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+					},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,25 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-claude
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "api.anthropic.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +626,14 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": claude-3-5-sonnet
+            "*": claude-3-haiku
+          type: claude
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-claude
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add e2e conformance cases for the **claude** provider of the `ai-proxy` wasm plugin, covering both the non-streaming and streaming request paths.

- **claude case 1 (non-streaming)**: sends an OpenAI-shaped chat completion request (`stream:false`) to host `api.anthropic.com`, and asserts the OpenAI-shaped response that `responseClaude2OpenAI` produces. The mock echoes the last user message text (`你好，你是谁？`) inside an Anthropic `content:[{type:text,text:...}]` block with `stop_reason:"end_turn"`. The plugin converts it to `choices[0].message.content` and maps `end_turn` to `finish_reason:"stop"`; the `model` field is the mapped model `claude-3-5-sonnet` (from `ctxKeyFinalRequestModel`). `id`/`created`/`usage` are ignored via `JsonBodyIgnoreFields`.
- **claude case 2 (streaming)**: sends the same request with `stream:true` and only asserts `StatusCode: 200` plus `Content-Type: text/event-stream`, because the mock's SSE sequence carries dynamic timestamps/usage that cannot be matched byte-for-byte.

Provider config: `type: claude`, `apiTokens: [fake_token]`, `modelMapping: {"gpt-3": claude-3-5-sonnet, "*": claude-3-haiku}`. A new Ingress routes `api.anthropic.com` to the shared `llm-mock-service`.

## Ⅱ. Does this pull request fix one issue?

fixes #1719

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR itself adds the e2e conformance tests for the claude provider. The mock server side that these cases depend on lives in the `higress-group/mock-server` repo (claude mock, already published in the latest `llm-mock` image).

## Ⅳ. Describe how to verify it

Run the conformance suite:

```
go vet -C test/e2e/conformance ./tests/...
```

The only `go vet` finding is the pre-existing non-constant format string warning in `httproute-limit.go` (unrelated to this change). The claude cases compile cleanly and follow the same pattern as the existing openai/grok/dify cases.

## Ⅴ. Special notes for reviews

- The expected non-streaming body was derived directly from `responseClaude2OpenAI` + `stopReasonClaude2OpenAI` in `plugins/wasm-go/extensions/ai-proxy/provider/claude.go`: `end_turn` -> `finishReasonStop` (`"stop"`), and `Model` is `ctx.GetStringContext(ctxKeyFinalRequestModel, "")` which holds the mapped model (`claude-3-5-sonnet` for a `gpt-3` request).
- The streaming case intentionally only checks status + content-type, matching the approach used by other streaming cases whose mock SSE contains dynamic fields.
- `go vet` was run with the `external/` submodule links populated; only the known `httproute-limit.go` warnings remain.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)


