### PR TITLE
test(ai-proxy): add e2e cases for claude, cohere, hunyuan, deepl

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -411,11 +411,11 @@ func (c *claudeProvider) TransformResponseBody(ctx wrapper.HttpContext, apiName 
 }
 
 func (c *claudeProvider) OnStreamingResponseBody(ctx wrapper.HttpContext, name ApiName, chunk []byte, isLastChunk bool) ([]byte, error) {
-	if isLastChunk || len(chunk) == 0 {
-		return nil, nil
-	}
 	// only process the response from chat completion, skip other responses
 	if name != ApiNameChatCompletion {
+		if isLastChunk {
+			return nil, nil
+		}
 		return chunk, nil
 	}
 
@@ -441,6 +441,10 @@ func (c *claudeProvider) OnStreamingResponseBody(ctx wrapper.HttpContext, name A
 				c.appendResponse(responseBuilder, string(responseBody))
 			}
 		}
+	}
+	// Emit the OpenAI `data: [DONE]` terminator on the final chunk (Claude native has none).
+	if isLastChunk {
+		responseBuilder.WriteString(ssePrefix + streamEndDataValue + "\n\n")
 	}
 	modifiedResponseChunk := responseBuilder.String()
 	log.Debugf("modified response chunk: %s", modifiedResponseChunk)
@@ -971,7 +975,8 @@ func (c *claudeProvider) streamResponseClaude2OpenAI(ctx wrapper.HttpContext, or
 
 	case "message_delta":
 		if origResponse.Usage != nil {
-			c.usage.CompletionTokens += origResponse.Usage.OutputTokens
+			// message_delta usage.output_tokens is cumulative, so overwrite (not accumulate).
+			c.usage.CompletionTokens = origResponse.Usage.OutputTokens
 			c.usage.TotalTokens = c.usage.PromptTokens + c.usage.CompletionTokens
 		}
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
@@ -465,6 +465,64 @@ func TestClaudeProvider_StreamToolCallArgumentDeltaIncludesFunctionType(t *testi
 	assert.Equal(t, `{"path":"/tmp/example"}`, response.Choices[0].Delta.ToolCalls[0].Function.Arguments)
 }
 
+// Claude native ends at message_stop with no [DONE]; the plugin appends the OpenAI terminator.
+func TestClaudeProvider_StreamingAppendsDoneOnLastChunk(t *testing.T) {
+	provider := &claudeProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	// A non-final chunk carries no terminator.
+	delta := "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n\n"
+	out, err := provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(delta), false)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "[DONE]")
+
+	// The final chunk appends the OpenAI stream terminator.
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(""), true)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "data: [DONE]")
+}
+
+func TestClaudeProvider_StreamingEdgeCases(t *testing.T) {
+	provider := &claudeProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	// A non-chat-completion response passes through untouched; its final chunk returns nil.
+	out, err := provider.OnStreamingResponseBody(ctx, ApiNameEmbeddings, []byte("raw"), false)
+	require.NoError(t, err)
+	assert.Equal(t, "raw", string(out))
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameEmbeddings, []byte("raw"), true)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	// A malformed data line is skipped (no panic), producing no output rather than failing the stream.
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte("data: {not json"), false)
+	require.NoError(t, err)
+	assert.Empty(t, string(out))
+}
+
+func TestClaudeProvider_StreamUsageIsCumulativeNotSummed(t *testing.T) {
+	provider := &claudeProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	// message_start reports a small initial output_tokens.
+	provider.streamResponseClaude2OpenAI(ctx, &claudeTextGenStreamResponse{
+		Type:    "message_start",
+		Message: &claudeTextGenResponse{Usage: claudeTextGenUsage{InputTokens: 10, OutputTokens: 2}},
+	})
+	// message_delta reports the CUMULATIVE final output_tokens, not an increment.
+	stopReason := "end_turn"
+	provider.streamResponseClaude2OpenAI(ctx, &claudeTextGenStreamResponse{
+		Type:  "message_delta",
+		Delta: &claudeTextGenDelta{StopReason: &stopReason},
+		Usage: &claudeTextGenUsage{OutputTokens: 20},
+	})
+
+	assert.Equal(t, 10, provider.usage.PromptTokens)
+	// Must be the cumulative 20, not 2 (message_start) + 20 (message_delta) = 22.
+	assert.Equal(t, 20, provider.usage.CompletionTokens)
+	assert.Equal(t, 30, provider.usage.TotalTokens)
+}
+
 func TestClaudeProvider_BuildClaudeTextGenRequest_ClaudeCodeMode(t *testing.T) {
 	provider := &claudeProvider{
 		config: ProviderConfig{

--- a/plugins/wasm-go/extensions/ai-proxy/provider/cohere.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/cohere.go
@@ -1,14 +1,18 @@
 package provider
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
-	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/log"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
 const (
@@ -16,6 +20,8 @@ const (
 	// TODO: support more capabilities, upgrade to v2, docs: https://docs.cohere.com/v2/reference/chat
 	cohereChatCompletionPath = "/v1/chat"
 	cohereRerankPath         = "/v1/rerank"
+	// ctxKeyCohereStreamId carries the Cohere generation id across chunks for the OpenAI chunk id.
+	ctxKeyCohereStreamId = "cohereStreamId"
 )
 
 type cohereProviderInitializer struct{}
@@ -121,4 +127,183 @@ func (m *cohereProvider) GetApiName(path string) ApiName {
 		return ApiNameChatCompletion
 	}
 	return ""
+}
+
+// Cohere v1 /chat non-streaming response, only the fields ai-proxy maps (tools are never
+// forwarded to Cohere, so tool_calls responses can't occur).
+type cohereChatResponse struct {
+	ResponseId   string `json:"response_id"`
+	Text         string `json:"text"`
+	FinishReason string `json:"finish_reason"`
+	Meta         struct {
+		Tokens struct {
+			InputTokens  int `json:"input_tokens"`
+			OutputTokens int `json:"output_tokens"`
+		} `json:"tokens"`
+	} `json:"meta"`
+}
+
+// One Cohere v1 /chat streaming event (JSONL or SSE frame).
+type cohereStreamEvent struct {
+	EventType    string `json:"event_type"`
+	GenerationId string `json:"generation_id"` // from stream-start; reused as the chunk id
+	Text         string `json:"text"`
+	Response     *struct {
+		ResponseId   string `json:"response_id"`
+		FinishReason string `json:"finish_reason"`
+		Meta         struct {
+			Tokens struct {
+				InputTokens  int `json:"input_tokens"`
+				OutputTokens int `json:"output_tokens"`
+			} `json:"tokens"`
+		} `json:"meta"`
+	} `json:"response"`
+}
+
+func cohereFinishReason2OpenAI(reason string) string {
+	if reason == "MAX_TOKENS" {
+		return finishReasonLength
+	}
+	return finishReasonStop
+}
+
+func (m *cohereProvider) TransformResponseHeaders(ctx wrapper.HttpContext, apiName ApiName, headers http.Header) {
+	// Original-protocol and non-chat (e.g. rerank) responses pass through untouched.
+	if m.config.IsOriginal() || apiName != ApiNameChatCompletion {
+		ctx.DontReadResponseBody()
+		return
+	}
+	headers.Del("Content-Length")
+	// Cohere streams newline-delimited JSON; the converted output is OpenAI SSE.
+	if strings.Contains(headers.Get("Content-Type"), "stream") {
+		headers.Set("Content-Type", "text/event-stream; charset=utf-8")
+	}
+}
+
+func (m *cohereProvider) TransformResponseBody(ctx wrapper.HttpContext, apiName ApiName, body []byte) ([]byte, error) {
+	if m.config.IsOriginal() || apiName != ApiNameChatCompletion {
+		return body, nil
+	}
+	cohereResponse := &cohereChatResponse{}
+	if err := json.Unmarshal(body, cohereResponse); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal cohere response: %v", err)
+	}
+	openAIResponse := &chatCompletionResponse{
+		Id:      cohereResponse.ResponseId,
+		Created: time.Now().Unix(),
+		Model:   ctx.GetStringContext(ctxKeyFinalRequestModel, ""),
+		Object:  objectChatCompletion,
+		Choices: []chatCompletionChoice{{
+			Index:        0,
+			Message:      &chatMessage{Role: roleAssistant, Content: cohereResponse.Text},
+			FinishReason: util.Ptr(cohereFinishReason2OpenAI(cohereResponse.FinishReason)),
+		}},
+		Usage: &usage{
+			PromptTokens:     cohereResponse.Meta.Tokens.InputTokens,
+			CompletionTokens: cohereResponse.Meta.Tokens.OutputTokens,
+			TotalTokens:      cohereResponse.Meta.Tokens.InputTokens + cohereResponse.Meta.Tokens.OutputTokens,
+		},
+	}
+	return json.Marshal(openAIResponse)
+}
+
+func (m *cohereProvider) OnStreamingResponseBody(ctx wrapper.HttpContext, name ApiName, chunk []byte, isLastChunk bool) ([]byte, error) {
+	if m.config.IsOriginal() || name != ApiNameChatCompletion {
+		if isLastChunk {
+			return nil, nil
+		}
+		return chunk, nil
+	}
+
+	body := chunk
+	if buffered, has := ctx.GetContext(ctxKeyStreamingBody).([]byte); has {
+		body = append(buffered, chunk...)
+	}
+	lines := bytes.Split(body, []byte("\n"))
+	if isLastChunk {
+		// Last chunk: the un-terminated trailing line is complete too.
+		ctx.SetContext(ctxKeyStreamingBody, []byte(nil))
+	} else {
+		// Re-buffer the trailing partial line.
+		ctx.SetContext(ctxKeyStreamingBody, lines[len(lines)-1])
+		lines = lines[:len(lines)-1]
+	}
+
+	responseBuilder := &strings.Builder{}
+	model := ctx.GetStringContext(ctxKeyFinalRequestModel, "")
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		// Accept both bare JSONL and SSE frames: skip comment/event lines, strip an optional "data:".
+		if len(line) == 0 || bytes.HasPrefix(line, []byte(":")) || bytes.HasPrefix(line, []byte("event:")) {
+			continue
+		}
+		line = bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+		if len(line) == 0 {
+			continue
+		}
+		var event cohereStreamEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			log.Errorf("unable to unmarshal cohere stream event: %v", err)
+			continue
+		}
+		openAIChunk := &chatCompletionResponse{
+			Id:      ctx.GetStringContext(ctxKeyCohereStreamId, ""),
+			Created: time.Now().Unix(),
+			Model:   model,
+			Object:  objectChatCompletionChunk,
+		}
+		switch event.EventType {
+		case "stream-start":
+			ctx.SetContext(ctxKeyCohereStreamId, event.GenerationId)
+			openAIChunk.Id = event.GenerationId
+			// Role belongs in the first delta only (OpenAI convention).
+			openAIChunk.Choices = []chatCompletionChoice{{Index: 0, Delta: &chatMessage{Role: roleAssistant}}}
+		case "text-generation":
+			openAIChunk.Choices = []chatCompletionChoice{{Index: 0, Delta: &chatMessage{Content: event.Text}}}
+		case "stream-end":
+			finishReason := finishReasonStop
+			if event.Response != nil {
+				finishReason = cohereFinishReason2OpenAI(event.Response.FinishReason)
+			}
+			// Finish chunk (usage:null), then a separate choices:[] usage chunk (OpenAI convention).
+			openAIChunk.Choices = []chatCompletionChoice{{Index: 0, Delta: &chatMessage{}, FinishReason: util.Ptr(finishReason)}}
+			finishBytes, err := json.Marshal(openAIChunk)
+			if err != nil {
+				return nil, err
+			}
+			responseBuilder.WriteString(ssePrefix + string(finishBytes) + "\n\n")
+			if event.Response != nil {
+				usageChunk := &chatCompletionResponse{
+					Id:      ctx.GetStringContext(ctxKeyCohereStreamId, ""),
+					Created: time.Now().Unix(),
+					Model:   model,
+					Object:  objectChatCompletionChunk,
+					Choices: []chatCompletionChoice{},
+					Usage: &usage{
+						PromptTokens:     event.Response.Meta.Tokens.InputTokens,
+						CompletionTokens: event.Response.Meta.Tokens.OutputTokens,
+						TotalTokens:      event.Response.Meta.Tokens.InputTokens + event.Response.Meta.Tokens.OutputTokens,
+					},
+				}
+				usageBytes, err := json.Marshal(usageChunk)
+				if err != nil {
+					return nil, err
+				}
+				responseBuilder.WriteString(ssePrefix + string(usageBytes) + "\n\n")
+			}
+			continue
+		default:
+			continue // other events carry no OpenAI-visible content
+		}
+		chunkBytes, err := json.Marshal(openAIChunk)
+		if err != nil {
+			return nil, err
+		}
+		responseBuilder.WriteString(ssePrefix + string(chunkBytes) + "\n\n")
+	}
+	// Emit the OpenAI `data: [DONE]` terminator on the final chunk (Cohere native has none).
+	if isLastChunk {
+		responseBuilder.WriteString(ssePrefix + streamEndDataValue + "\n\n")
+	}
+	return []byte(responseBuilder.String()), nil
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/cohere_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/cohere_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCohereProvider_TransformResponseBody(t *testing.T) {
+	provider := &cohereProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	cohereBody := `{"response_id":"resp-1","text":"你好","generation_id":"g-1","finish_reason":"COMPLETE","meta":{"tokens":{"input_tokens":9,"output_tokens":1}}}`
+	out, err := provider.TransformResponseBody(ctx, ApiNameChatCompletion, []byte(cohereBody))
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, `"id":"resp-1"`)
+	assert.Contains(t, s, `"object":"chat.completion"`)
+	assert.Contains(t, s, `"content":"你好"`)
+	assert.Contains(t, s, `"finish_reason":"stop"`)
+	assert.Contains(t, s, `"prompt_tokens":9`)
+	assert.Contains(t, s, `"completion_tokens":1`)
+	assert.Contains(t, s, `"total_tokens":10`)
+}
+
+// JSONL -> OpenAI SSE: content deltas, finish chunk, usage chunk, [DONE].
+func TestCohereProvider_OnStreamingResponseBody(t *testing.T) {
+	provider := &cohereProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	stream := `{"event_type":"stream-start","generation_id":"g-1"}` + "\n" +
+		`{"event_type":"text-generation","text":"你"}` + "\n" +
+		`{"event_type":"stream-end","response":{"finish_reason":"COMPLETE","meta":{"tokens":{"input_tokens":9,"output_tokens":1}}}}` + "\n"
+	out, err := provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(stream), true)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, `"delta":{"role":"assistant"}`) // stream-start -> role-only first delta
+	assert.Contains(t, s, `"content":"你"`)                // text-generation -> content delta
+	assert.Contains(t, s, `"usage":null`)                 // the content delta chunk
+	assert.Contains(t, s, `"finish_reason":"stop"`)       // the stream-end chunk
+	assert.Contains(t, s, `"total_tokens":10`)            // usage populated on the final chunk
+	assert.Contains(t, s, ssePrefix+streamEndDataValue)   // terminates with data: [DONE]
+}
+
+// A last-chunk line without a trailing newline must still be processed.
+func TestCohereProvider_OnStreamingResponseBody_LastFrameNoNewline(t *testing.T) {
+	provider := &cohereProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	stream := `{"event_type":"text-generation","text":"你"}` + "\n" +
+		`{"event_type":"stream-end","response":{"finish_reason":"COMPLETE","meta":{"tokens":{"input_tokens":9,"output_tokens":1}}}}` // no trailing newline
+	out, err := provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(stream), true)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, `"finish_reason":"stop"`) // stream-end must NOT be dropped
+	assert.Contains(t, s, `"total_tokens":10`)
+	assert.Contains(t, s, ssePrefix+streamEndDataValue)
+}
+
+func TestCohereProvider_OriginalProtocolPassthrough(t *testing.T) {
+	provider := &cohereProvider{config: ProviderConfig{protocol: protocolOriginal}}
+	ctx := newMockMultipartHttpContext()
+
+	out, err := provider.TransformResponseBody(ctx, ApiNameChatCompletion, []byte("raw-cohere-body"))
+	require.NoError(t, err)
+	assert.Equal(t, "raw-cohere-body", string(out))
+
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte("raw-chunk"), false)
+	require.NoError(t, err)
+	assert.Equal(t, "raw-chunk", string(out))
+}
+
+func TestCohereProvider_OnStreamingResponseBody_BuffersPartialLine(t *testing.T) {
+	provider := &cohereProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	// First chunk ends mid-line; nothing complete yet, so no content is emitted.
+	out, err := provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(`{"event_type":"text-gene`), false)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), `"content"`)
+
+	// The rest of the line arrives; the completed event is now converted.
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(`ration","text":"好"}`+"\n"), false)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"content":"好"`)
+}
+
+func TestCohereFinishReason2OpenAI(t *testing.T) {
+	assert.Equal(t, finishReasonStop, cohereFinishReason2OpenAI("COMPLETE"))
+	assert.Equal(t, finishReasonLength, cohereFinishReason2OpenAI("MAX_TOKENS"))
+	assert.Equal(t, finishReasonStop, cohereFinishReason2OpenAI("SOMETHING_ELSE"))
+}
+
+func TestCohereProvider_ResponseEdgeCases(t *testing.T) {
+	provider := &cohereProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	// Non-chat-completion responses (e.g. rerank) pass through untouched.
+	out, err := provider.TransformResponseBody(ctx, ApiNameCohereV1Rerank, []byte("raw"))
+	require.NoError(t, err)
+	assert.Equal(t, "raw", string(out))
+
+	// A malformed non-stream body is an error.
+	_, err = provider.TransformResponseBody(ctx, ApiNameChatCompletion, []byte("{not json"))
+	require.Error(t, err)
+
+	// Non-chat streaming passes through; its final chunk returns nil.
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameCohereV1Rerank, []byte("raw"), false)
+	require.NoError(t, err)
+	assert.Equal(t, "raw", string(out))
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameCohereV1Rerank, []byte("raw"), true)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+
+	// A malformed stream line is skipped; the last chunk still terminates with [DONE].
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte("{not json\n"), true)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), ssePrefix+streamEndDataValue)
+}
+
+// SSE frames (event:/data:) must convert like JSONL, and stream-start's generation_id becomes the chunk id.
+func TestCohereProvider_OnStreamingResponseBody_SSEModeAndId(t *testing.T) {
+	provider := &cohereProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	sse := "event: stream-start\n" +
+		`data: {"event_type":"stream-start","generation_id":"gen-1"}` + "\n\n" +
+		"event: text-generation\n" +
+		`data: {"event_type":"text-generation","text":"hi"}` + "\n\n"
+	out, err := provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(sse), false)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, `"content":"hi"`)     // data: frame parsed despite the event: lines
+	assert.Contains(t, s, `"id":"gen-1"`)       // generation_id reused as the chunk id
+	assert.Contains(t, s, `"role":"assistant"`) // stream-start -> role delta
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/deepl.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/deepl.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
-	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
 // deeplProvider is the provider for DeepL service.
@@ -120,7 +120,8 @@ func (d *deeplProvider) TransformRequestBodyHeaders(ctx wrapper.HttpContext, api
 }
 
 func (d *deeplProvider) TransformResponseBody(ctx wrapper.HttpContext, apiName ApiName, body []byte) ([]byte, error) {
-	if apiName != ApiNameChatCompletion {
+	// Original-protocol responses pass through untouched.
+	if d.config.IsOriginal() || apiName != ApiNameChatCompletion {
 		return body, nil
 	}
 	deeplResponse := &deeplResponse{}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/deepl_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/deepl_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeeplProvider_TransformResponseBody(t *testing.T) {
+	provider := &deeplProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	body := `{"translations":[{"detected_source_language":"EN","text":"你好"}]}`
+	out, err := provider.TransformResponseBody(ctx, ApiNameChatCompletion, []byte(body))
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, `"content":"你好"`)
+	assert.Contains(t, s, `"name":"EN"`) // detected_source_language -> message.name
+	assert.Contains(t, s, `"object":"chat.completion"`)
+}
+
+func TestDeeplProvider_OriginalProtocolPassthrough(t *testing.T) {
+	provider := &deeplProvider{config: ProviderConfig{protocol: protocolOriginal}}
+	ctx := newMockMultipartHttpContext()
+
+	out, err := provider.TransformResponseBody(ctx, ApiNameChatCompletion, []byte(`{"translations":[{"text":"x"}]}`))
+	require.NoError(t, err)
+	assert.Equal(t, `{"translations":[{"text":"x"}]}`, string(out))
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
-	"github.com/higress-group/wasm-go/pkg/log"
-	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/log"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
 // hunyuanProvider is the provider for hunyuan AI service.
@@ -370,6 +370,11 @@ func (m *hunyuanProvider) OnStreamingResponseBody(ctx wrapper.HttpContext, name 
 	// 刷新剩余的不完整事件回到上下文缓冲区以便下次继续处理
 	ctx.SetContext(ctxKeyStreamingBody, newBufferedBody)
 
+	// Emit the OpenAI `data: [DONE]` terminator on the final chunk (Hunyuan native has none).
+	if isLastChunk {
+		outputBuffer = append(outputBuffer, []byte(ssePrefix+streamEndDataValue+"\n\n")...)
+	}
+
 	log.Debugf("=== modified response chunk: %s", string(outputBuffer))
 	return outputBuffer, nil
 }
@@ -380,6 +385,10 @@ func (m *hunyuanProvider) convertChunkFromHunyuanToOpenAI(ctx wrapper.HttpContex
 	if err := json.Unmarshal(hunyuanChunk, hunyuanFormattedChunk); err != nil {
 		return []byte(""), nil
 	}
+	// Guard the Choices[0] access below against choice-less frames (e.g. keep-alive).
+	if len(hunyuanFormattedChunk.Choices) == 0 {
+		return []byte(""), nil
+	}
 
 	openAIFormattedChunk := &chatCompletionResponse{
 		Id:                hunyuanFormattedChunk.Id,
@@ -387,18 +396,13 @@ func (m *hunyuanProvider) convertChunkFromHunyuanToOpenAI(ctx wrapper.HttpContex
 		Model:             ctx.GetStringContext(ctxKeyFinalRequestModel, ""),
 		SystemFingerprint: "",
 		Object:            objectChatCompletionChunk,
-		Usage: &usage{
-			PromptTokens:     hunyuanFormattedChunk.Usage.PromptTokens,
-			CompletionTokens: hunyuanFormattedChunk.Usage.CompletionTokens,
-			TotalTokens:      hunyuanFormattedChunk.Usage.TotalTokens,
-		},
 	}
 	// tmpStr3, _ := json.Marshal(hunyuanFormattedChunk)
 	// log.Debugf("@@@ --- 源数据是：: %s", tmpStr3)
 
 	// 是否为最后一个chunk？
-	if hunyuanFormattedChunk.Choices[0].FinishReason == hunyuanStreamEndMark {
-		// log.Debugf("@@@ --- 最后chunk: ")
+	isFinal := hunyuanFormattedChunk.Choices[0].FinishReason == hunyuanStreamEndMark
+	if isFinal {
 		openAIFormattedChunk.Choices = append(openAIFormattedChunk.Choices, chatCompletionChoice{
 			FinishReason: util.Ptr(hunyuanFormattedChunk.Choices[0].FinishReason),
 		})
@@ -409,24 +413,33 @@ func (m *hunyuanProvider) convertChunkFromHunyuanToOpenAI(ctx wrapper.HttpContex
 			Content:   hunyuanFormattedChunk.Choices[0].Delta.Content,
 			ToolCalls: []toolCall{},
 		}
-
-		// tmpStr2, _ := json.Marshal(deltaMsg)
-		// log.Debugf("@@@ --- 中间chunk: choices.chatMsg 是: %s", tmpStr2)
-
 		openAIFormattedChunk.Choices = append(
 			openAIFormattedChunk.Choices,
 			chatCompletionChoice{Delta: &deltaMsg},
 		)
-		// tmpStr, _ := json.Marshal(openAIFormattedChunk.Choices)
-		// log.Debugf("@@@ --- 中间chunk: choices 是: %s", tmpStr)
 	}
 
-	// 返回的格式
-	openAIFormattedChunkBytes, _ := json.Marshal(openAIFormattedChunk)
 	var openAIChunk strings.Builder
-	openAIChunk.WriteString(ssePrefix)
-	openAIChunk.WriteString(string(openAIFormattedChunkBytes))
-	openAIChunk.WriteString("\n\n")
+	chunkBytes, _ := json.Marshal(openAIFormattedChunk)
+	openAIChunk.WriteString(ssePrefix + string(chunkBytes) + "\n\n")
+
+	// Usage goes in a separate choices:[] chunk on the final frame (OpenAI convention).
+	if isFinal {
+		usageChunk := &chatCompletionResponse{
+			Id:      hunyuanFormattedChunk.Id,
+			Created: time.Now().UnixMilli() / 1000,
+			Model:   ctx.GetStringContext(ctxKeyFinalRequestModel, ""),
+			Object:  objectChatCompletionChunk,
+			Choices: []chatCompletionChoice{},
+			Usage: &usage{
+				PromptTokens:     hunyuanFormattedChunk.Usage.PromptTokens,
+				CompletionTokens: hunyuanFormattedChunk.Usage.CompletionTokens,
+				TotalTokens:      hunyuanFormattedChunk.Usage.TotalTokens,
+			},
+		}
+		usageBytes, _ := json.Marshal(usageChunk)
+		openAIChunk.WriteString(ssePrefix + string(usageBytes) + "\n\n")
+	}
 
 	return []byte(openAIChunk.String()), nil
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/hunyuan_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Hunyuan sends usage on every frame; OpenAI wants it only on the final chunk.
+func TestHunyuanProvider_ChunkUsageOnlyOnFinalChunk(t *testing.T) {
+	provider := &hunyuanProvider{}
+	ctx := newMockMultipartHttpContext()
+
+	// Non-final frame (FinishReason empty): usage must be null.
+	nonFinal := `{"Id":"x","Choices":[{"FinishReason":"","Delta":{"Role":"assistant","Content":"你"}}],"Usage":{"PromptTokens":9,"CompletionTokens":1,"TotalTokens":10}}`
+	out, err := provider.convertChunkFromHunyuanToOpenAI(ctx, []byte(nonFinal))
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"usage":null`)
+	assert.Contains(t, string(out), `"content":"你"`)
+
+	// Final frame: finish chunk (usage:null) + separate choices:[] usage chunk.
+	final := `{"Id":"x","Choices":[{"FinishReason":"stop","Delta":{"Role":"assistant","Content":""}}],"Usage":{"PromptTokens":9,"CompletionTokens":1,"TotalTokens":10}}`
+	out, err = provider.convertChunkFromHunyuanToOpenAI(ctx, []byte(final))
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"finish_reason":"stop"`)
+	assert.Contains(t, string(out), `"choices":[]`)      // usage-only chunk
+	assert.Contains(t, string(out), `"total_tokens":10`) // usage populated on that chunk
+	assert.True(t, strings.HasPrefix(string(out), ssePrefix))
+}
+
+// Hunyuan native has no [DONE]; the plugin appends it (auth set -> native path).
+func TestHunyuanProvider_StreamingAppendsDoneOnLastChunk(t *testing.T) {
+	provider := &hunyuanProvider{config: ProviderConfig{
+		hunyuanAuthId:  "12345678-1234-1234-1234-123456789012",
+		hunyuanAuthKey: "abcdefghijklmnopqrstuvwxyz012345",
+	}}
+	ctx := newMockMultipartHttpContext()
+
+	// A non-final frame converts to a chunk without any terminator.
+	frame := "data: {\"Id\":\"x\",\"Choices\":[{\"FinishReason\":\"\",\"Delta\":{\"Role\":\"assistant\",\"Content\":\"你\"}}],\"Usage\":{\"PromptTokens\":9,\"CompletionTokens\":1,\"TotalTokens\":10}}\n\n"
+	out, err := provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(frame), false)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "[DONE]")
+	assert.Contains(t, string(out), `"content":"你"`)
+
+	// The final chunk appends the OpenAI stream terminator.
+	out, err = provider.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte(""), true)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), "data: [DONE]")
+}
+
+func TestHunyuanProvider_StreamingEdgeCases(t *testing.T) {
+	ctx := newMockMultipartHttpContext()
+
+	// OpenAI-compatible mode (no auth id/key) passes the chunk through unchanged.
+	compat := &hunyuanProvider{}
+	out, err := compat.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte("raw"), false)
+	require.NoError(t, err)
+	assert.Equal(t, "raw", string(out))
+
+	native := &hunyuanProvider{config: ProviderConfig{
+		hunyuanAuthId:  "12345678-1234-1234-1234-123456789012",
+		hunyuanAuthKey: "abcdefghijklmnopqrstuvwxyz012345",
+	}}
+	// An incomplete (unterminated) event on a non-final chunk is buffered, producing no output yet.
+	out, err = native.OnStreamingResponseBody(ctx, ApiNameChatCompletion, []byte("data: {\"Id\":\"x\""), false)
+	require.NoError(t, err)
+	assert.Empty(t, string(out))
+
+	// A malformed frame converts to an empty payload rather than erroring.
+	out, err = native.convertChunkFromHunyuanToOpenAI(ctx, []byte("{not json"))
+	require.NoError(t, err)
+	assert.Empty(t, string(out))
+}
+
+// A choice-less frame (e.g. keep-alive) converts to empty output without panicking.
+func TestHunyuanProvider_ChunkWithoutChoices(t *testing.T) {
+	provider := &hunyuanProvider{}
+	ctx := newMockMultipartHttpContext()
+	out, err := provider.convertChunkFromHunyuanToOpenAI(ctx, []byte(`{"Id":"x","Choices":[],"Usage":{"PromptTokens":9,"CompletionTokens":1,"TotalTokens":10}}`))
+	require.NoError(t, err)
+	assert.Empty(t, string(out))
+}

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,321 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "claude case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.anthropic.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:           200,
+						ContentType:          http.ContentTypeApplicationJson,
+						JsonBodyIgnoreFields: []string{"created"},
+						Body:                 []byte(`{"id":"msg_llm-mock","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "claude case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.anthropic.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true,"stream_options":{"include_usage":true}}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeTextEventStream,
+						// Per-chunk "created" is regenerated, so it is ignored.
+						JsonBodyIgnoreFields: []string{"created"},
+						Body: []byte(`data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"content":"好"},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"content":"，"},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"content":"是"},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"content":"谁"},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"content":"？"},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{},"finish_reason":"stop","logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}
+
+data: [DONE]
+
+`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "claude case 3: streaming tool call",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.anthropic.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"weather in Beijing?"}],"stream":true,"stream_options":{"include_usage":true},"tools":[{"type":"function","function":{"name":"get_weather","description":"get weather","parameters":{"type":"object","properties":{"location":{"type":"string"}}}}}]}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeTextEventStream,
+						// ai-proxy converts Claude tool_use stream events to OpenAI tool_calls deltas; created ignored.
+						JsonBodyIgnoreFields: []string{"created"},
+						Body: []byte(`data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"toolu_llm-mock","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"arguments":"{\"location\": "}}]},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"arguments":"\"Beijing\"}"}}]},"finish_reason":null,"logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls","logprobs":null}],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_llm-mock","choices":[],"created":10,"model":"claude-3-5-sonnet-20241022","object":"chat.completion.chunk","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}
+
+data: [DONE]
+
+`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "claude case 4: upstream auth failure is surfaced",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.anthropic.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						// Sentinel prompt: the mock replies with an upstream 401.
+						Body: []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"__force_auth_error__"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  401,
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"type":"error","request_id":"req_llm-mock","error":{"type":"authentication_error","message":"invalid x-api-key"}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "cohere case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.cohere.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						// ai-proxy converts the Cohere v1 response to OpenAI chat.completion shape (created regenerated).
+						JsonBodyIgnoreFields: []string{"created"},
+						Body:                 []byte(`{"id":"chatcmpl-llm-mock","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"command-r","object":"chat.completion","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "cohere case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.cohere.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true,"stream_options":{"include_usage":true}}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeTextEventStream,
+						// ai-proxy converts the Cohere JSONL stream to OpenAI SSE; per-chunk "created" is ignored.
+						JsonBodyIgnoreFields: []string{"created"},
+						Body: []byte(`data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null,"logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"好"},"finish_reason":null,"logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"，"},"finish_reason":null,"logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"是"},"finish_reason":null,"logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"谁"},"finish_reason":null,"logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"content":"？"},"finish_reason":null,"logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{},"finish_reason":"stop","logprobs":null}],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[],"created":10,"model":"command-r","object":"chat.completion.chunk","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}
+
+data: [DONE]
+
+`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "hunyuan case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "hunyuan.tencentcloudapi.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:           200,
+						ContentType:          http.ContentTypeApplicationJson,
+						JsonBodyIgnoreFields: []string{"created"},
+						Body:                 []byte(`{"id":"chatcmpl-llm-mock","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "hunyuan case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "hunyuan.tencentcloudapi.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":true,"stream_options":{"include_usage":true}}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeTextEventStream,
+						// Per-chunk "created" is regenerated, so it is ignored.
+						JsonBodyIgnoreFields: []string{"created"},
+						Body: []byte(`data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":"好"},"finish_reason":null,"logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":"，"},"finish_reason":null,"logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":"你"},"finish_reason":null,"logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":"是"},"finish_reason":null,"logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":"谁"},"finish_reason":null,"logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"delta":{"role":"assistant","content":"？"},"finish_reason":null,"logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[{"index":0,"finish_reason":"stop","logprobs":null}],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":null}
+
+data: {"id":"chatcmpl-llm-mock","choices":[],"created":10,"model":"hunyuan-standard","object":"chat.completion.chunk","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}
+
+data: [DONE]
+
+`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "hunyuan case 3: OpenAI-compatible endpoint (no auth id/key)",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api.hunyuan.cloud.tencent.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						// OpenAI-compatible passthrough: response unchanged (created=10, modelMapping not applied).
+						Body: []byte(`{"id":"chatcmpl-llm-mock","choices":[{"index":0,"message":{"role":"assistant","content":"你好，你是谁？"},"finish_reason":"stop","logprobs":null}],"created":10,"model":"gpt-3","object":"chat.completion","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "deepl case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "api-free.deepl.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						// deepl's "model" is the tier ("Free"/"Pro") picking the host; modelMapping is not run for deepl, so send "Free" directly.
+						Body: []byte(`{"model":"Free","messages":[{"role":"user","content":"你好，你是谁？"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:  200,
+						ContentType: http.ContentTypeApplicationJson,
+						// DeepL response converted to OpenAI shape: detected_source_language -> message.name, no id/usage, fresh "created".
+						JsonBodyIgnoreFields: []string{"created"},
+						Body:                 []byte(`{"choices":[{"index":0,"message":{"name":"EN","role":"assistant","content":"你好，你是谁？"},"finish_reason":null,"logprobs":null}],"created":10,"model":"Free","object":"chat.completion","usage":null}`),
+					},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,101 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-claude
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "api.anthropic.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-cohere
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "api.cohere.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-hunyuan
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "hunyuan.tencentcloudapi.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-deepl
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "api-free.deepl.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-hunyuan-openai
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "api.hunyuan.cloud.tencent.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +702,50 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          type: claude
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": claude-3-5-sonnet-20241022
+            "*": claude-3-5-haiku-20241022
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-claude
+    - config:
+        provider:
+          type: cohere
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": command-r
+            "*": command-r
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-cohere
+    - config:
+        provider:
+          type: hunyuan
+          hunyuanAuthId: "12345678-1234-1234-1234-123456789012"
+          hunyuanAuthKey: "abcdefghijklmnopqrstuvwxyz012345"
+          modelMapping:
+            "gpt-3": hunyuan-standard
+            "*": hunyuan-pro
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-hunyuan
+    - config:
+        provider:
+          type: deepl
+          apiTokens:
+            - fake_token
+          targetLang: "ZH"
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-deepl
+    - config:
+        provider:
+          # No hunyuanAuthId/Key -> the OpenAI-compatible endpoint (passthrough; modelMapping not applied).
+          type: hunyuan
+          apiTokens:
+            - fake_token
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-hunyuan-openai
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm

--- a/test/e2e/conformance/utils/http/http.go
+++ b/test/e2e/conformance/utils/http/http.go
@@ -612,8 +612,15 @@ func CompareResponse(cRes *roundtripper.CapturedResponse, expected Assertion) er
 
 			switch cTyp {
 			case ContentTypeTextPlain:
-			case ContentTypeTextEventStream:
 				if !bytes.Equal(expected.Response.ExpectedResponse.Body, cRes.Body) {
+					return fmt.Errorf("expected %s body to be %s, got %s", cTyp, string(expected.Response.ExpectedResponse.Body), string(cRes.Body))
+				}
+			case ContentTypeTextEventStream:
+				if len(expected.Response.ExpectedResponse.JsonBodyIgnoreFields) > 0 {
+					if err := CompareSSEEventsWithIgnoreFields(expected.Response.ExpectedResponse.Body, cRes.Body, expected.Response.ExpectedResponse.JsonBodyIgnoreFields); err != nil {
+						return err
+					}
+				} else if !bytes.Equal(expected.Response.ExpectedResponse.Body, cRes.Body) {
 					return fmt.Errorf("expected %s body to be %s, got %s", cTyp, string(expected.Response.ExpectedResponse.Body), string(cRes.Body))
 				}
 			case ContentTypeApplicationJson:
@@ -671,6 +678,57 @@ func CompareResponse(cRes *roundtripper.CapturedResponse, expected Assertion) er
 					return fmt.Errorf("expected %s header to not be set, got %s", name, val)
 				}
 			}
+		}
+	}
+	return nil
+}
+
+// CompareSSEEventsWithIgnoreFields compares two SSE bodies event-by-event: `data: [DONE]` matches
+// literally, other frames compare as JSON with the given top-level fields ignored.
+func CompareSSEEventsWithIgnoreFields(expected, actual []byte, ignoreFields []string) error {
+	// parse returns each event's joined `data:` payload (CRLF normalized, comment/other lines skipped).
+	parse := func(b []byte) []string {
+		normalized := strings.ReplaceAll(strings.ReplaceAll(string(b), "\r\n", "\n"), "\r", "\n")
+		var events []string
+		for _, block := range strings.Split(normalized, "\n\n") {
+			var data []string
+			for _, line := range strings.Split(block, "\n") {
+				if line == "" || strings.HasPrefix(line, ":") {
+					continue
+				}
+				if strings.HasPrefix(line, "data:") {
+					data = append(data, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+				}
+			}
+			if len(data) > 0 {
+				events = append(events, strings.Join(data, "\n"))
+			}
+		}
+		return events
+	}
+	eEvents := parse(expected)
+	cEvents := parse(actual)
+	if len(eEvents) != len(cEvents) {
+		return fmt.Errorf("expected %d SSE events, got %d (expected body: %s, actual body: %s)",
+			len(eEvents), len(cEvents), string(expected), string(actual))
+	}
+	for i := range eEvents {
+		if eEvents[i] == "[DONE]" || cEvents[i] == "[DONE]" {
+			if eEvents[i] != cEvents[i] {
+				return fmt.Errorf("SSE event %d mismatch: expected %q, got %q", i, eEvents[i], cEvents[i])
+			}
+			continue
+		}
+		eObj := make(map[string]interface{})
+		cObj := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(eEvents[i]), &eObj); err != nil {
+			return fmt.Errorf("failed to unmarshal expected SSE event %d %q: %s", i, eEvents[i], err.Error())
+		}
+		if err := json.Unmarshal([]byte(cEvents[i]), &cObj); err != nil {
+			return fmt.Errorf("failed to unmarshal captured SSE event %d %q: %s", i, cEvents[i], err.Error())
+		}
+		if err := CompareJSONWithIgnoreFields(eObj, cObj, ignoreFields); err != nil {
+			return fmt.Errorf("SSE event %d mismatch: %s (expected %q, got %q)", i, err.Error(), eEvents[i], cEvents[i])
 		}
 	}
 	return nil

--- a/test/e2e/conformance/utils/http/http_test.go
+++ b/test/e2e/conformance/utils/http/http_test.go
@@ -1101,3 +1101,64 @@ func TestCompareResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareSSEEventsWithIgnoreFields(t *testing.T) {
+	cases := []struct {
+		name         string
+		expected     string
+		actual       string
+		ignoreFields []string
+		wantErr      bool
+	}{
+		{
+			name:         "created differs but ignored, ends with DONE",
+			expected:     "data: {\"id\":\"x\",\"created\":10,\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n",
+			actual:       "data: {\"id\":\"x\",\"created\":9999,\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n",
+			ignoreFields: []string{"created"},
+			wantErr:      false,
+		},
+		{
+			name:         "content mismatch is caught",
+			expected:     "data: {\"created\":10,\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+			actual:       "data: {\"created\":11,\"choices\":[{\"delta\":{\"content\":\"bye\"}}]}\n\n",
+			ignoreFields: []string{"created"},
+			wantErr:      true,
+		},
+		{
+			name:         "event count mismatch is caught",
+			expected:     "data: {\"created\":10}\n\ndata: [DONE]\n\n",
+			actual:       "data: {\"created\":10}\n\n",
+			ignoreFields: []string{"created"},
+			wantErr:      true,
+		},
+		{
+			name:         "DONE vs non-DONE mismatch is caught",
+			expected:     "data: [DONE]\n\n",
+			actual:       "data: {\"created\":10}\n\n",
+			ignoreFields: []string{"created"},
+			wantErr:      true,
+		},
+		{
+			name:     "malformed expected event errors",
+			expected: "data: {not json\n\n",
+			actual:   "data: {\"a\":1}\n\n",
+			wantErr:  true,
+		},
+		{
+			name:     "malformed actual event errors",
+			expected: "data: {\"a\":1}\n\n",
+			actual:   "data: {not json\n\n",
+			wantErr:  true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := CompareSSEEventsWithIgnoreFields([]byte(c.expected), []byte(c.actual), c.ignoreFields)
+			if c.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Adds conformance e2e for **claude, cohere, hunyuan, deepl** (non-stream + streaming; claude also covers tool-call streaming and upstream-401 propagation). Mock handlers are in higress-group/mock-server#17 (merged, image rebuilt).

Plugin fixes surfaced by the tests:

- **claude**: `message_delta` usage is cumulative — overwrite, don't accumulate; emit `data: [DONE]` on the final chunk.
- **hunyuan**: emit usage once as a separate `choices:[]` chunk; guard against choice-less frames.
- **cohere**: add the missing OpenAI response conversion (raw Cohere body used to leak to the client).
- **deepl / cohere**: pass responses through untouched in original-protocol mode.

**http.go**: SSE bodies were compared with exact `bytes.Equal`, but these providers stamp a fresh `created` per chunk — exact match can never pass, so streams couldn't be asserted at all. Added an event-by-event JSON comparator with ignorable fields (opt-in via `JsonBodyIgnoreFields`; existing cases unaffected). Also fixed the empty `text/plain` branch.

## Ⅱ. Does this pull request fix one issue?

Fixes #1719, Fixes #1738, Fixes #1720, Fixes #1723. Part of #1629.

## Ⅲ. Why don't you add test cases (unit test)?

Unit tests included for all changed plugin logic and the comparator.

## Ⅳ. Describe how to verify it

`make higress-conformance-test-wasmplugin PLUGIN_TYPE=GO PLUGIN_NAME=ai-proxy TEST_SHORTNAME=WasmPluginAiProxy` — verified locally on kind against the rebuilt image: 49 cases, 0 failures.

## Ⅴ. Special notes for reviews

#4116 touches the same test files; whichever merges second needs a trivial rebase.