### PR TITLE
feat(helm): decouple gateway Promtail from the bundled o11y stack

### DIFF
--- a/helm/core/templates/_pod.tpl
+++ b/helm/core/templates/_pod.tpl
@@ -203,11 +203,11 @@ template:
         - mountPath: /opt/plugins
           name: local-wasmplugins-volume
         {{- end }}
-        {{- if $o11y.enabled }}
+        {{- if or $o11y.enabled (dig "promtail" "enabled" false $o11y) }}
         - mountPath: /var/log/proxy
           name: log
         {{- end }}
-      {{- if $o11y.enabled }}
+      {{- if or $o11y.enabled (dig "promtail" "enabled" false $o11y) }}
         {{- $config := $o11y.promtail }}
       - name: promtail
         image: {{ $config.image.repository | default (printf "%s/higress/promtail" .Values.global.hub) }}:{{ $config.image.tag }}
@@ -295,7 +295,7 @@ template:
       emptyDir: {}
     - name: proxy-socket
       emptyDir: {}
-    {{- if $o11y.enabled }}
+    {{- if or $o11y.enabled (dig "promtail" "enabled" false $o11y) }}
     - name: log
       emptyDir: {}
     - name: tmp

--- a/helm/core/templates/configmap.yaml
+++ b/helm/core/templates/configmap.yaml
@@ -3,7 +3,7 @@
     # Refer to https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain
     trustDomain: "cluster.local"
     accessLogEncoding: TEXT
-    {{- if .Values.global.o11y.enabled }}
+    {{- if or .Values.global.o11y.enabled (dig "promtail" "enabled" false .Values.global.o11y) }}
     accessLogFile: "/var/log/proxy/access.log"
     {{- else }}
     accessLogFile: "/dev/stdout"

--- a/helm/core/templates/promtail.yaml
+++ b/helm/core/templates/promtail.yaml
@@ -1,5 +1,5 @@
 {{- $o11y := .Values.global.o11y  }}
-{{- if $o11y.enabled }}
+{{- if or $o11y.enabled (dig "promtail" "enabled" false $o11y) }}
 {{- $config := $o11y.promtail }}
 apiVersion: v1
 kind: ConfigMap
@@ -13,7 +13,7 @@ data:
       http_listen_port: {{ $config.port }}
 
     clients:
-    - url: http://higress-console-loki.{{ .Release.Namespace }}:3100/loki/api/v1/push
+    - url: {{ $config.lokiUrl | default (printf "http://higress-console-loki.%s:3100/loki/api/v1/push" .Release.Namespace) }}
 
     positions:
       filename: /tmp/promtail-positions.yaml

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -378,6 +378,17 @@ global:
   o11y:
     enabled: false
     promtail:
+      # -- Inject the Promtail sidecar and write the gateway access log to a file,
+      # WITHOUT deploying the bundled Loki/Grafana/Prometheus. Independent of
+      # `global.o11y.enabled` (which additionally deploys the bundled o11y stack),
+      # so the gateway access log can be shipped to an externally-managed Loki.
+      enabled: false
+      # -- Promtail push target (full URL). Empty defaults to the bundled Loki
+      # service: http://higress-console-loki.<namespace>:3100/loki/api/v1/push
+      # NOTE: only the endpoint URL is configurable here — Loki authentication
+      # (basic/bearer) and multi-tenancy (X-Scope-OrgID) are not yet supported,
+      # i.e. this targets a single-tenant, unauthenticated Loki.
+      lokiUrl: ""
       image:
         repository: "" # Will use global.hub if not set
         tag: 2.9.4


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

Decouples the gateway Promtail sidecar from the bundled observability stack and makes the Loki push URL configurable, so the gateway access log can be shipped to an **externally-managed Loki** without deploying the bundled Loki/Grafana/Prometheus.

- Adds `global.o11y.promtail.enabled` — inject the Promtail sidecar + write the access-log file to `/var/log/proxy/access.log`, **independent of** `global.o11y.enabled` (which additionally deploys the bundled stack).
- Adds `global.o11y.promtail.lokiUrl` — configurable push target (full URL); empty defaults to the current `higress-console-loki` service.
- Gates use `or o11y.enabled (dig "promtail" "enabled" false o11y)` (nil-safe).

Only `helm/core` is touched; `higress-console` is untouched.

### Ⅱ. Does this pull request fix one issue?

fixes #4126

### Ⅲ. Why don't you add test cases (unit test/integration test)?

The chart has no unit-test harness and the change is values-gated template wiring. Verified with `helm template` diffs and `helm lint` (see below).

### Ⅳ. Describe how to verify it

Backward compatibility — **byte-identical** to the pre-change render:

```
helm template t ./helm/core                                 # defaults → stdout access log, no sidecar
helm template t ./helm/core --set global.o11y.enabled=true  # bundled mode → unchanged
```

New behavior:

```
helm template t ./helm/core \
  --set global.o11y.promtail.enabled=true \
  --set global.o11y.promtail.lokiUrl=http://my-loki:3100/loki/api/v1/push
```
renders the `promtail` sidecar, `accessLogFile: /var/log/proxy/access.log`, and `- url: http://my-loki:3100/loki/api/v1/push`, with no bundled backends.

nil-safe regression guard: `helm template t ./helm/core --set global.o11y.promtail=null` still renders. `helm lint` clean.

Also verified end-to-end on a live cluster: gateway JSON access log → Promtail sidecar → externally-deployed Loki → queried in Grafana.

### Ⅴ. Special notes for reviews

- Both new values default to empty/`false` → **zero behavioral change** for existing installs.
- Scope is intentionally minimal. Loki authentication (basic/bearer) and multi-tenancy (`X-Scope-OrgID`) are **out of scope** here (single-tenant, unauthenticated Loki) and can be a follow-up — documented in the `lokiUrl` values comment.
