### PR TITLE
feat(registry): add Custom Discoverer interface (#767)

### DIFF
--- a/registry/custom/watcher.go
+++ b/registry/custom/watcher.go
@@ -1,0 +1,301 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package custom adapts a registry.Discoverer to the registry.Watcher
+// interface so that custom service-discovery implementations (e.g. xDS or HTTP
+// watch based) can feed services into Higress through the standard Reconciler
+// pipeline, exactly like the built-in nacos/consul/eureka/zookeeper registries.
+package custom
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/istio/pkg/log"
+
+	apiv1 "github.com/alibaba/higress/v2/api/networking/v1"
+	"github.com/alibaba/higress/v2/pkg/common"
+	ingress "github.com/alibaba/higress/v2/pkg/ingress/kube/common"
+	"github.com/alibaba/higress/v2/registry"
+	"github.com/alibaba/higress/v2/registry/memory"
+)
+
+// watcher adapts a registry.Discoverer to the registry.Watcher interface.
+type watcher struct {
+	registry.BaseWatcher
+	apiv1.RegistryConfig
+
+	cache      memory.Cache
+	discoverer registry.Discoverer
+
+	mutex  sync.Mutex
+	cancel context.CancelFunc
+	hosts  map[string]struct{}
+}
+
+// NewWatcher builds a registry.Watcher backed by the Discoverer registered for
+// cfg.Type via registry.RegisterDiscoverer. The returned watcher converts every
+// discovery update into ingress.ServiceWrapper entries stored in cache.
+func NewWatcher(cache memory.Cache, cfg *apiv1.RegistryConfig, auth registry.AuthOption) (registry.Watcher, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("custom watcher: nil registry config")
+	}
+	factory := registry.LookupDiscovererFactory(cfg.Type)
+	if factory == nil {
+		return nil, fmt.Errorf("custom watcher: no discoverer registered for type %q", cfg.Type)
+	}
+	discoverer, err := factory(cfg, auth)
+	if err != nil {
+		return nil, fmt.Errorf("custom watcher: build discoverer for type %q: %w", cfg.Type, err)
+	}
+	return &watcher{
+		cache:      cache,
+		discoverer: discoverer,
+		hosts:      make(map[string]struct{}),
+	}, nil
+}
+
+// Run starts the underlying discoverer and keeps the cache in sync with the
+// reported target groups until Stop is called.
+func (w *watcher) Run() {
+	ctx, cancel := context.WithCancel(context.Background())
+	w.mutex.Lock()
+	w.cancel = cancel
+	w.mutex.Unlock()
+
+	up := make(chan []*registry.TargetGroup, 1)
+	go w.discoverer.Run(ctx, up)
+
+	w.Ready(true)
+	for {
+		select {
+		case groups, ok := <-up:
+			if !ok {
+				return
+			}
+			if w.apply(groups) {
+				w.UpdateService()
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Stop cancels the discoverer and removes every service owned by this watcher
+// from the cache.
+func (w *watcher) Stop() {
+	w.mutex.Lock()
+	cancel := w.cancel
+	w.cancel = nil
+	hosts := w.hosts
+	w.hosts = make(map[string]struct{})
+	w.mutex.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+
+	for host := range hosts {
+		w.cache.DeleteServiceWrapper(host)
+	}
+	w.UpdateService()
+	w.Ready(false)
+}
+
+func (w *watcher) GetRegistryType() string {
+	return w.Type
+}
+
+// apply reconciles the full snapshot of target groups with the cache. It returns
+// true when any service was added, updated or removed.
+func (w *watcher) apply(groups []*registry.TargetGroup) bool {
+	type update struct {
+		host string
+		sew  *ingress.ServiceWrapper
+	}
+
+	updates := make([]update, 0, len(groups))
+	newHosts := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		sew, host := toServiceWrapper(group, w.Name, w.Type)
+		if sew == nil {
+			continue
+		}
+		updates = append(updates, update{host: host, sew: sew})
+		newHosts[host] = struct{}{}
+	}
+
+	w.mutex.Lock()
+	var deleted []string
+	for host := range w.hosts {
+		if _, ok := newHosts[host]; !ok {
+			deleted = append(deleted, host)
+		}
+	}
+	w.hosts = newHosts
+	w.mutex.Unlock()
+
+	for _, u := range updates {
+		w.cache.UpdateServiceWrapper(u.host, u.sew)
+	}
+	for _, host := range deleted {
+		w.cache.DeleteServiceWrapper(host)
+	}
+
+	return len(updates) > 0 || len(deleted) > 0
+}
+
+// toServiceWrapper converts a single registry.TargetGroup into an
+// ingress.ServiceWrapper together with the cache host key. It returns a nil
+// wrapper when the group cannot be converted (no service name or no valid
+// target).
+func toServiceWrapper(group *registry.TargetGroup, registryName, registryType string) (*ingress.ServiceWrapper, string) {
+	host := groupHost(group)
+	if host == "" {
+		log.Warnf("custom discoverer: target group has no service name (job/__service__ label or source), skipping")
+		return nil, ""
+	}
+
+	endpoints := make([]*v1alpha3.WorkloadEntry, 0, len(group.Targets))
+	servicePorts := make(map[string]uint32)
+	portOrder := make([]string, 0)
+
+	for _, target := range group.Targets {
+		instance := target[registry.InstanceLabel]
+		address, portStr, ok := splitHostPort(instance)
+		if !ok {
+			log.Warnf("custom discoverer: invalid __instance__ %q, skipping target", instance)
+			continue
+		}
+		port, err := strconv.ParseUint(portStr, 10, 32)
+		if err != nil || port == 0 || port > 65535 {
+			log.Warnf("custom discoverer: invalid port %q in __instance__ %q, skipping target", portStr, instance)
+			continue
+		}
+
+		protocol := common.ParseProtocol(firstNonEmpty(target[registry.ProtocolLabel], group.Labels[registry.ProtocolLabel]))
+		if protocol.IsUnsupported() {
+			protocol = common.HTTP
+		}
+
+		labels := make(map[string]string, len(group.Labels)+len(target))
+		mergeLabels(labels, group.Labels)
+		mergeLabels(labels, target)
+		delete(labels, registry.InstanceLabel)
+
+		endpoints = append(endpoints, &v1alpha3.WorkloadEntry{
+			Address: address,
+			Ports:   map[string]uint32{protocol.String(): uint32(port)},
+			Labels:  labels,
+		})
+
+		if _, exists := servicePorts[protocol.String()]; !exists {
+			servicePorts[protocol.String()] = uint32(port)
+			portOrder = append(portOrder, protocol.String())
+		}
+	}
+
+	if len(endpoints) == 0 {
+		return nil, ""
+	}
+
+	ports := make([]*v1alpha3.ServicePort, 0, len(portOrder))
+	for _, proto := range portOrder {
+		ports = append(ports, &v1alpha3.ServicePort{
+			Number:   servicePorts[proto],
+			Name:     proto,
+			Protocol: proto,
+		})
+	}
+
+	serviceEntry := &v1alpha3.ServiceEntry{
+		Hosts:      []string{host},
+		Ports:      ports,
+		Location:   v1alpha3.ServiceEntry_MESH_INTERNAL,
+		Resolution: v1alpha3.ServiceEntry_STATIC,
+		Endpoints:  endpoints,
+	}
+
+	return &ingress.ServiceWrapper{
+		ServiceName:  host,
+		ServiceEntry: serviceEntry,
+		Suffix:       registryType,
+		RegistryType: registryType,
+		RegistryName: registryName,
+	}, host
+}
+
+// groupHost resolves the service name (and cache key) for a target group.
+func groupHost(group *registry.TargetGroup) string {
+	if group == nil {
+		return ""
+	}
+	if name := group.Labels[registry.ServiceLabelAlias]; name != "" {
+		return name
+	}
+	if name := group.Labels[registry.ServiceLabel]; name != "" {
+		return name
+	}
+	return group.Source
+}
+
+// splitHostPort splits an "__instance__" value into host and port. It supports
+// both IPv4 ("1.2.3.4:80") and IPv6 ("[2001:db8::1]:80") forms.
+func splitHostPort(instance string) (host, port string, ok bool) {
+	if instance == "" {
+		return "", "", false
+	}
+	if strings.HasPrefix(instance, "[") {
+		last := strings.LastIndex(instance, "]")
+		if last < 0 {
+			return "", "", false
+		}
+		host = instance[1:last]
+		rest := instance[last+1:]
+		if !strings.HasPrefix(rest, ":") || len(rest) <= 1 {
+			return "", "", false
+		}
+		return host, rest[1:], true
+	}
+	// IPv4 host:port.
+	idx := strings.LastIndex(instance, ":")
+	if idx <= 0 || idx == len(instance)-1 {
+		return "", "", false
+	}
+	if strings.Count(instance, ":") != 1 {
+		// Bare IPv6 address without brackets/port is not a usable target.
+		return "", "", false
+	}
+	return instance[:idx], instance[idx+1:], true
+}
+
+func mergeLabels(dst, src map[string]string) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/registry/custom/watcher_test.go
+++ b/registry/custom/watcher_test.go
@@ -1,0 +1,329 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package custom
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	apiv1 "github.com/alibaba/higress/v2/api/networking/v1"
+	"github.com/alibaba/higress/v2/pkg/common"
+	"github.com/alibaba/higress/v2/registry"
+	"github.com/alibaba/higress/v2/registry/memory"
+
+	"istio.io/api/networking/v1alpha3"
+)
+
+// fakeDiscoverer is a controllable Discoverer used by the adapter tests.
+type fakeDiscoverer struct {
+	mu     sync.Mutex
+	ch     chan []*registry.TargetGroup
+	ctx    context.Context
+	sent   int
+	closed bool
+}
+
+func newFakeDiscoverer() *fakeDiscoverer {
+	return &fakeDiscoverer{ch: make(chan []*registry.TargetGroup, 16)}
+}
+
+func (f *fakeDiscoverer) Run(ctx context.Context, up chan<- []*registry.TargetGroup) {
+	f.mu.Lock()
+	f.ctx = ctx
+	f.mu.Unlock()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case groups, ok := <-f.ch:
+			if !ok {
+				return
+			}
+			up <- groups
+			f.mu.Lock()
+			f.sent++
+			f.mu.Unlock()
+		}
+	}
+}
+
+func (f *fakeDiscoverer) send(groups []*registry.TargetGroup) { f.ch <- groups }
+
+func (f *fakeDiscoverer) sentCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.sent
+}
+
+func TestToServiceWrapper_BasicConversion(t *testing.T) {
+	group := &registry.TargetGroup{
+		Targets: []registry.LabelSet{
+			{
+				registry.InstanceLabel: "10.11.150.1:7870",
+				"hostname":             "demo-target-1",
+				registry.ProtocolLabel: "grpc",
+			},
+			{
+				registry.InstanceLabel: "10.11.150.4:7870",
+				"hostname":             "demo-target-2",
+			},
+		},
+		Labels: registry.LabelSet{
+			registry.ServiceLabel: "mysql",
+		},
+		Source: "src-1",
+	}
+
+	sew, host := toServiceWrapper(group, "myreg", "custom")
+	if sew == nil {
+		t.Fatal("expected a non-nil ServiceWrapper")
+	}
+	if host != "mysql" {
+		t.Fatalf("expected host mysql, got %s", host)
+	}
+	if sew.ServiceName != "mysql" {
+		t.Fatalf("expected ServiceName mysql, got %s", sew.ServiceName)
+	}
+	if sew.RegistryName != "myreg" || sew.RegistryType != "custom" {
+		t.Fatalf("unexpected registry name/type: %s/%s", sew.RegistryName, sew.RegistryType)
+	}
+
+	se := sew.ServiceEntry
+	if len(se.Hosts) != 1 || se.Hosts[0] != "mysql" {
+		t.Fatalf("unexpected hosts: %v", se.Hosts)
+	}
+	if len(se.Endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(se.Endpoints))
+	}
+
+	ep0 := se.Endpoints[0]
+	if ep0.Address != "10.11.150.1" {
+		t.Fatalf("expected endpoint address 10.11.150.1, got %s", ep0.Address)
+	}
+	if port, ok := ep0.Ports[common.GRPC.String()]; !ok || port != 7870 {
+		t.Fatalf("expected GRPC port 7870, got %v", ep0.Ports)
+	}
+	if ep0.Labels["hostname"] != "demo-target-1" {
+		t.Fatalf("expected hostname label carried over, got %v", ep0.Labels)
+	}
+	if _, present := ep0.Labels[registry.InstanceLabel]; present {
+		t.Fatalf("the __instance__ label must not leak into endpoint labels")
+	}
+
+	// Second endpoint falls back to the default HTTP protocol.
+	ep1 := se.Endpoints[1]
+	if port, ok := ep1.Ports[common.HTTP.String()]; !ok || port != 7870 {
+		t.Fatalf("expected default HTTP port 7870, got %v", ep1.Ports)
+	}
+
+	// The service port list is derived from the distinct protocols seen.
+	if len(se.Ports) != 2 {
+		t.Fatalf("expected 2 service ports, got %d", len(se.Ports))
+	}
+}
+
+func TestToServiceWrapper_ServiceNameResolution(t *testing.T) {
+	cases := []struct {
+		name  string
+		group *registry.TargetGroup
+		host  string
+		isNil bool
+	}{
+		{
+			name:  "alias label wins",
+			group: &registry.TargetGroup{Labels: registry.LabelSet{registry.ServiceLabel: "a", registry.ServiceLabelAlias: "b"}},
+			host:  "b",
+		},
+		{
+			name:  "job label used",
+			group: &registry.TargetGroup{Labels: registry.LabelSet{registry.ServiceLabel: "a"}},
+			host:  "a",
+		},
+		{
+			name:  "source fallback",
+			group: &registry.TargetGroup{Source: "from-source"},
+			host:  "from-source",
+		},
+		{
+			name:  "no name returns nil",
+			group: &registry.TargetGroup{Targets: []registry.LabelSet{{registry.InstanceLabel: "1.2.3.4:80"}}},
+			isNil: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Ensure the group always has at least one usable target so that the
+			// nil result is solely due to the missing service name.
+			if tc.group.Targets == nil && !tc.isNil {
+				tc.group.Targets = []registry.LabelSet{{registry.InstanceLabel: "1.2.3.4:80"}}
+			}
+			sew, host := toServiceWrapper(tc.group, "reg", "custom")
+			if tc.isNil {
+				if sew != nil {
+					t.Fatalf("expected nil wrapper, got host %s", host)
+				}
+				return
+			}
+			if sew == nil {
+				t.Fatalf("expected non-nil wrapper")
+			}
+			if host != tc.host {
+				t.Fatalf("expected host %s, got %s", tc.host, host)
+			}
+		})
+	}
+}
+
+func TestToServiceWrapper_InvalidInstances(t *testing.T) {
+	group := &registry.TargetGroup{
+		Labels: registry.LabelSet{registry.ServiceLabel: "svc"},
+		Targets: []registry.LabelSet{
+			{registry.InstanceLabel: ""},                 // missing
+			{registry.InstanceLabel: "no-port"},          // no port
+			{registry.InstanceLabel: "1.2.3.4:0"},        // zero port
+			{registry.InstanceLabel: "1.2.3.4:70000"},    // out of range
+			{registry.InstanceLabel: "fe80::1"},          // bare ipv6
+			{registry.InstanceLabel: "1.2.3.4:80"},       // valid
+			{registry.InstanceLabel: "[2001:db8::1]:80"}, // valid ipv6
+			{registry.InstanceLabel: "[2001:db8::1]"},    // ipv6 missing port
+		},
+	}
+
+	sew, _ := toServiceWrapper(group, "reg", "custom")
+	if sew == nil {
+		t.Fatal("expected a wrapper with only the valid targets")
+	}
+	if len(sew.ServiceEntry.Endpoints) != 2 {
+		t.Fatalf("expected 2 valid endpoints, got %d", len(sew.ServiceEntry.Endpoints))
+	}
+}
+
+func TestWatcher_LifecycleAppliesUpdates(t *testing.T) {
+	cache := memory.NewCache()
+	fd := newFakeDiscoverer()
+	w := &watcher{
+		cache:      cache,
+		discoverer: fd,
+		hosts:      make(map[string]struct{}),
+	}
+
+	updates := make(chan struct{}, 16)
+	ready := make(chan bool, 16)
+	w.AppendServiceUpdateHandler(func() {
+		select {
+		case updates <- struct{}{}:
+		default:
+		}
+	})
+	w.ReadyHandler(func(isReady bool) {
+		select {
+		case ready <- isReady:
+		default:
+		}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		w.Run()
+		close(done)
+	}()
+
+	// Wait until the watcher reports readiness.
+	select {
+	case r := <-ready:
+		if !r {
+			t.Fatal("expected the watcher to become ready")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not become ready in time")
+	}
+
+	// First snapshot: add two services.
+	fd.send([]*registry.TargetGroup{
+		{Labels: registry.LabelSet{registry.ServiceLabel: "a"}, Targets: []registry.LabelSet{{registry.InstanceLabel: "10.0.0.1:80"}}},
+		{Labels: registry.LabelSet{registry.ServiceLabel: "b"}, Targets: []registry.LabelSet{{registry.InstanceLabel: "10.0.0.2:80"}}},
+	})
+	waitForUpdate(t, updates)
+	cache.PurgeStaleItems()
+
+	if got := countServiceWrappers(cache); got != 2 {
+		t.Fatalf("expected 2 cached services, got %d", got)
+	}
+
+	// Second snapshot: remove "a", keep "b", add "c".
+	fd.send([]*registry.TargetGroup{
+		{Labels: registry.LabelSet{registry.ServiceLabel: "b"}, Targets: []registry.LabelSet{{registry.InstanceLabel: "10.0.0.2:80"}}},
+		{Labels: registry.LabelSet{registry.ServiceLabel: "c"}, Targets: []registry.LabelSet{{registry.InstanceLabel: "10.0.0.3:90"}}},
+	})
+	waitForUpdate(t, updates)
+	cache.PurgeStaleItems()
+
+	hosts := serviceHosts(cache.GetAllServiceEntry())
+	for _, want := range []string{"b", "c"} {
+		if _, ok := hosts[want]; !ok {
+			t.Fatalf("expected service %s to remain, got hosts %v", want, hosts)
+		}
+	}
+	if _, ok := hosts["a"]; ok {
+		t.Fatalf("stale service a should have been removed")
+	}
+
+	// Stop should clean the cache and exit Run.
+	w.Stop()
+	cache.PurgeStaleItems()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit after Stop")
+	}
+
+	if got := countServiceWrappers(cache); got != 0 {
+		t.Fatalf("expected cache to be empty after Stop, got %d", got)
+	}
+}
+
+func TestNewWatcher_NoFactory(t *testing.T) {
+	cache := memory.NewCache()
+	_, err := NewWatcher(cache, &apiv1.RegistryConfig{Type: "definitely-not-registered-xyz"}, registry.AuthOption{})
+	if err == nil {
+		t.Fatal("expected an error when no discoverer factory is registered")
+	}
+}
+
+func waitForUpdate(t *testing.T, updates <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-updates:
+	case <-time.After(time.Second):
+		t.Fatal("did not receive a service update notification in time")
+	}
+}
+
+func countServiceWrappers(cache memory.Cache) int {
+	return len(cache.GetAllServiceWrapper())
+}
+
+func serviceHosts(entries []*v1alpha3.ServiceEntry) map[string]bool {
+	out := make(map[string]bool)
+	for _, se := range entries {
+		for _, h := range se.Hosts {
+			out[h] = true
+		}
+	}
+	return out
+}

--- a/registry/discoverer.go
+++ b/registry/discoverer.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"sync"
+
+	apiv1 "github.com/alibaba/higress/v2/api/networking/v1"
+)
+
+const (
+	// Custom is a generic ServiceRegistryType backed by a Discoverer registered
+	// via RegisterDiscoverer. Custom discoverers may also register under their
+	// own arbitrary type strings.
+	Custom ServiceRegistryType = "custom"
+
+	// InstanceLabel is the target label that carries the target address in the
+	// form "host:port". It mirrors Prometheus' "__address__" convention.
+	InstanceLabel = "__instance__"
+	// ProtocolLabel is the target/group label that carries the upstream protocol
+	// (e.g. http, grpc, dubbo). It defaults to HTTP when absent.
+	ProtocolLabel = "protocol"
+	// ServiceLabel is the group label that names the discovered service. It is
+	// the primary way a discoverer identifies the service host.
+	ServiceLabel = "job"
+	// ServiceLabelAlias is an alternative group label for naming the service. It
+	// takes precedence over ServiceLabel when both are present.
+	ServiceLabelAlias = "__service__"
+)
+
+// LabelSet is a set of key/value labels describing a discovered target or a
+// group of targets. It is the native equivalent of Prometheus'
+// model.LabelSet and is used so that the registry package does not need to
+// depend on the Prometheus modules directly.
+type LabelSet map[string]string
+
+// TargetGroup describes a set of discovered service targets that share common
+// labels. It mirrors the structure of Prometheus' discovery targetgroup.Group
+// so that custom discovery mechanisms (for example xDS or HTTP watch based
+// ones) can feed service information into Higress through a standard interface.
+type TargetGroup struct {
+	// Targets is the list of discovered targets. Every target LabelSet should
+	// carry the "__instance__" key with the target address in "host:port" form.
+	// Any other labels (e.g. "hostname", "protocol") are attached to the
+	// corresponding workload entry.
+	Targets []LabelSet
+	// Labels are labels shared by every target in this group (e.g. "job"). The
+	// "job" (or "__service__") label names the resulting service.
+	Labels LabelSet
+	// Source uniquely identifies the group within a single discoverer. When no
+	// "job"/"__service__" label is present it is used as the service name.
+	Source string
+}
+
+// Discoverer discovers groups of service targets and reports the full current
+// set of groups to the provided channel whenever it changes. A Discoverer must
+// block until ctx is cancelled, sending the complete target set on every
+// update (a snapshot, not a delta). This is the same contract as the
+// Prometheus discovery.Discoverer interface.
+//
+// Users can add custom registration centers (e.g. xDS or HTTP watch based) by
+// implementing this interface and registering a factory with
+// RegisterDiscoverer.
+type Discoverer interface {
+	Run(ctx context.Context, up chan<- []*TargetGroup)
+}
+
+// DiscovererFactory builds a Discoverer from a registry configuration. It
+// receives the full RegistryConfig (so custom discoverers can reuse fields such
+// as Domain, Port, Protocol and Metadata) together with the resolved
+// AuthOption.
+type DiscovererFactory func(registry *apiv1.RegistryConfig, auth AuthOption) (Discoverer, error)
+
+var (
+	discovererFactoriesMu sync.RWMutex
+	discovererFactories   = make(map[string]DiscovererFactory)
+)
+
+// RegisterDiscoverer registers a DiscovererFactory under the given registry
+// type. It is intended to be called from package init() of packages providing
+// custom discovery implementations (for example xDS or HTTP watch based).
+// Registering the same type twice or registering with an empty type or nil
+// factory panics, mirroring the standard library registration conventions
+// (e.g. database/sql.Register, image.RegisterFormat).
+func RegisterDiscoverer(registryType string, factory DiscovererFactory) {
+	if registryType == "" {
+		panic("registry: RegisterDiscoverer called with empty type")
+	}
+	if factory == nil {
+		panic("registry: RegisterDiscoverer called with nil factory for type " + registryType)
+	}
+	discovererFactoriesMu.Lock()
+	defer discovererFactoriesMu.Unlock()
+	if _, exists := discovererFactories[registryType]; exists {
+		panic("registry: RegisterDiscoverer called twice for type " + registryType)
+	}
+	discovererFactories[registryType] = factory
+}
+
+// LookupDiscovererFactory returns the DiscovererFactory registered for the
+// given registry type, or nil if none has been registered.
+func LookupDiscovererFactory(registryType string) DiscovererFactory {
+	discovererFactoriesMu.RLock()
+	defer discovererFactoriesMu.RUnlock()
+	return discovererFactories[registryType]
+}

--- a/registry/discoverer_test.go
+++ b/registry/discoverer_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2022 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"testing"
+
+	apiv1 "github.com/alibaba/higress/v2/api/networking/v1"
+)
+
+// noopDiscoverer is a Discoverer that does nothing; used only for registration tests.
+type noopDiscoverer struct{}
+
+func (noopDiscoverer) Run(ctx context.Context, up chan<- []*TargetGroup) {}
+
+// registerForTest installs a factory under a unique type name and removes it
+// when the test finishes, so tests do not leak global state into each other.
+func registerForTest(t *testing.T, registryType string) {
+	t.Helper()
+	discovererFactoriesMu.Lock()
+	if _, exists := discovererFactories[registryType]; exists {
+		discovererFactoriesMu.Unlock()
+		t.Fatalf("test fixture collision: type %q already registered", registryType)
+	}
+	discovererFactories[registryType] = func(*apiv1.RegistryConfig, AuthOption) (Discoverer, error) {
+		return noopDiscoverer{}, nil
+	}
+	discovererFactoriesMu.Unlock()
+	t.Cleanup(func() {
+		discovererFactoriesMu.Lock()
+		delete(discovererFactories, registryType)
+		discovererFactoriesMu.Unlock()
+	})
+}
+
+func TestRegisterAndLookupDiscoverer(t *testing.T) {
+	registryType := "test-lookup-only"
+	registerForTest(t, registryType)
+
+	if factory := LookupDiscovererFactory(registryType); factory == nil {
+		t.Fatal("expected the registered factory to be found")
+	}
+
+	if factory := LookupDiscovererFactory("never-registered-type"); factory != nil {
+		t.Fatal("expected nil factory for an unregistered type")
+	}
+}
+
+func TestRegisterDiscovererPanicsOnDuplicate(t *testing.T) {
+	registryType := "test-duplicate"
+	registerForTest(t, registryType)
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected RegisterDiscoverer to panic on duplicate registration")
+		}
+	}()
+	RegisterDiscoverer(registryType, func(*apiv1.RegistryConfig, AuthOption) (Discoverer, error) {
+		return noopDiscoverer{}, nil
+	})
+}
+
+func TestRegisterDiscovererPanicsOnInvalidArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		rType   string
+		factory DiscovererFactory
+	}{
+		{name: "empty type", rType: "", factory: func(*apiv1.RegistryConfig, AuthOption) (Discoverer, error) { return nil, nil }},
+		{name: "nil factory", rType: "test-nil-factory", factory: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatal("expected RegisterDiscoverer to panic")
+				}
+			}()
+			RegisterDiscoverer(tc.rType, tc.factory)
+		})
+	}
+}
+
+func TestTargetGroupZeroValueIsSafe(t *testing.T) {
+	// A nil/empty TargetGroup must not panic when converted by callers.
+	var g *TargetGroup
+	if got := groupHostFromPackage(g); got != "" {
+		t.Fatalf("expected empty host for nil group, got %s", got)
+	}
+}
+
+// groupHostFromPackage mirrors the custom.groupHost helper and exists only so
+// the registry package test can exercise nil-safety of the TargetGroup type
+// without importing the custom subpackage (which would create a cycle).
+func groupHostFromPackage(g *TargetGroup) string {
+	if g == nil {
+		return ""
+	}
+	if name := g.Labels[ServiceLabelAlias]; name != "" {
+		return name
+	}
+	if name := g.Labels[ServiceLabel]; name != "" {
+		return name
+	}
+	return g.Source
+}

--- a/registry/reconcile/reconcile.go
+++ b/registry/reconcile/reconcile.go
@@ -32,6 +32,7 @@ import (
 	"github.com/alibaba/higress/v2/pkg/kube"
 	. "github.com/alibaba/higress/v2/registry"
 	"github.com/alibaba/higress/v2/registry/consul"
+	"github.com/alibaba/higress/v2/registry/custom"
 	"github.com/alibaba/higress/v2/registry/direct"
 	"github.com/alibaba/higress/v2/registry/eureka"
 	"github.com/alibaba/higress/v2/registry/memory"
@@ -271,7 +272,13 @@ func (r *Reconciler) generateWatcherFromRegistryConfig(registry *apiv1.RegistryC
 			eureka.WithVport(registry.Vport),
 		)
 	default:
-		return nil, errors.New("unsupported registry type:" + registry.Type)
+		// Fall back to a Discoverer registered via RegisterDiscoverer so users
+		// can plug custom registration centers (e.g. xDS or HTTP watch based)
+		// into the standard reconcile pipeline.
+		if LookupDiscovererFactory(registry.Type) == nil {
+			return nil, errors.New("unsupported registry type:" + registry.Type)
+		}
+		watcher, err = custom.NewWatcher(r.Cache, registry, authOption)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## What this PR does

Resolves #767 by adding a standard **Custom Discoverer interface** so users can plug custom registration centers (e.g. xDS or HTTP watch based) into Higress through the existing service-discovery pipeline, instead of adding a dedicated watcher package for every new registry type.

The interface mirrors the Prometheus `discovery.Discoverer` contract requested in the issue:

```go
type Discoverer interface {
    Run(ctx context.Context, up chan<- []*TargetGroup)
}

type TargetGroup struct {
    Targets []LabelSet // each carries "__instance__" (host:port) + optional labels (protocol, hostname, ...)
    Labels  LabelSet   // shared labels; "job"/"__service__" names the service
    Source  string
}
```

A discoverer reports the **full current snapshot** of target groups on every update (not a delta), exactly like Prometheus discoverers.

### How it is wired

- `registry.RegisterDiscoverer(type, factory)` registers a `DiscovererFactory` under a registry type (standard Go factory pattern, like `database/sql.Register`). The factory receives the full `McpBridge` `RegistryConfig` plus the resolved `AuthOption`, so custom discoverers can reuse existing fields such as `Domain`, `Port`, `Protocol` and `Metadata`.
- `Reconciler.generateWatcherFromRegistryConfig` now falls back to a registered discoverer for any registry type that is not one of the built-in ones (`nacos`/`nacos2`/`nacos3`/`zookeeper`/`consul`/`static`/`dns`/`eureka`). An adapter watcher (`registry/custom`) runs the discoverer and converts every snapshot into `ingress.ServiceWrapper` entries in the shared memory cache, reconciling additions and removals on each update and cleaning up on `Stop()` — identical lifecycle to the built-in watchers.
- No new API/CRD fields are required: a custom discoverer is selected purely by the existing `RegistryConfig.type`.

### Why native types instead of `github.com/prometheus/prometheus`

The issue's example uses Prometheus' `targetgroup.Group` / `model.LabelSet`. Those modules are already *indirect* dependencies, but promoting the very large `prometheus/prometheus` module to a direct dependency of the core `registry` package would add significant weight and version risk for no semantic gain. The introduced `TargetGroup`/`LabelSet` types mirror the Prometheus structure and semantics exactly, keeping the registry package self-contained.

### Relationship to MCP

As discussed in the issue, MCP-based discovery remains supported and is complementary: an MCP-over-xDS discoverer can be registered through this same interface. This change reuses the existing Reconciler/Cache/push pipeline rather than introducing a new push mechanism.

## Changes

- `registry/discoverer.go` — `Discoverer` interface, `TargetGroup`/`LabelSet` types, label constants, and the `RegisterDiscoverer`/`LookupDiscovererFactory` factory registry.
- `registry/custom/watcher.go` — adapter that bridges a `Discoverer` to the `Watcher` interface, including the `TargetGroup` → `ServiceEntry`/`ServiceWrapper` conversion (host:port + protocol parsing, IPv4/IPv6, default-HTTP fallback, snapshot reconciliation).
- `registry/reconcile/reconcile.go` — dispatch unknown registry types to a registered discoverer factory.
- `registry/discoverer_test.go`, `registry/custom/watcher_test.go` — unit tests for registration (duplicate/invalid panics, lookup), conversion edge cases (invalid instances, service-name resolution, IPv6, protocol fallback) and the adapter lifecycle (add/update/remove/stop) including `-race`.

## Verification

- `go build ./registry/... ./pkg/ingress/config/... ./pkg/bootstrap/...` — passes (downstream consumers of the reconciler build cleanly).
- `go test ./registry/ ./registry/custom/` — passes, including `go test -race -count=3`.
- `go vet ./registry ./registry/custom ./registry/reconcile` — clean.
- `gofmt` — clean for all added/changed files.
- `go.mod`/`go.sum` — unchanged (no new dependencies introduced).

Pre-existing failures in `registry/nacos` and `registry/nacos/v2` (`Test_generateServiceEntry_Weight`, `Test_generateServiceEntry_WeightFieldSet`) are unrelated to this change and reproduce on the unmodified base commit.

## Notes / assumptions

- Custom discoverers register under an arbitrary type string (a conventional `custom` type constant is also exported). They are responsible for providing unique service host names via the `job`/`__service__` group label or `Source`, since the cache is keyed by host.
- No documentation files were added per repository conventions; this PR description documents the public API.