### PR TITLE
feat: enable AOF persistence for Redis when persistence is enabled

### DIFF
--- a/helm/core/charts/redis/templates/configmap.yaml
+++ b/helm/core/charts/redis/templates/configmap.yaml
@@ -8,3 +8,13 @@ data:
     {{- if .Values.redis.password }}
     requirepass {{ .Values.redis.password }}
     {{- end }}
+    {{- if .Values.redis.persistence.enabled }}
+    dir /data
+    appendonly yes
+    appendfsync everysec
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 64mb
+    {{- end }}
+    {{- if .Values.redis.extraConfig -}}
+    {{- .Values.redis.extraConfig | nindent 4 }}
+    {{- end }}

--- a/helm/core/charts/redis/values.yaml
+++ b/helm/core/charts/redis/values.yaml
@@ -37,7 +37,8 @@ redis:
   # -- Affinity for Redis
   affinity: {}
   persistence:
-    # -- Enable persistence on Redis
+    # -- Enable persistence on Redis. When enabled, AOF persistence is turned on
+    # by default (appendonly yes, appendfsync everysec) and data is written to a PVC.
     enabled: false
     # -- If defined, storageClassName: <storageClass>
     # -- If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
@@ -47,3 +48,10 @@ redis:
       - ReadWriteOnce
     # -- Persistent Volume size
     size: 1Gi
+  # -- Extra redis-stack.conf directives appended after the generated config
+  # (requirepass, and AOF defaults when persistence is enabled).
+  # Directives here take precedence over generated defaults (Redis applies the last value).
+  # Example:
+  #   maxmemory 512mb
+  #   maxmemory-policy allkeys-lru
+  extraConfig: ""

--- a/helm/core/values.yaml
+++ b/helm/core/values.yaml
@@ -783,7 +783,8 @@ redis:
     # -- Affinity for Redis
     affinity: {}
     persistence:
-      # -- Enable persistence on Redis, default is false
+      # -- Enable persistence on Redis. When enabled, AOF persistence is turned on
+      # by default (appendonly yes, appendfsync everysec) and data is written to a PVC.
       enabled: false
       # -- If defined, storageClassName: <storageClass>
       # -- If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
@@ -793,6 +794,13 @@ redis:
         - ReadWriteOnce
       # -- Persistent Volume size
       size: 1Gi
+    # -- Extra redis-stack.conf directives appended after the generated config
+    # (requirepass, and AOF defaults when persistence is enabled).
+    # Directives here take precedence over generated defaults (Redis applies the last value).
+    # Example:
+    #   maxmemory 512mb
+    #   maxmemory-policy allkeys-lru
+    extraConfig: ""
 
 pluginServer:
   name: "higress-plugin-server"

--- a/helm/higress/README.md
+++ b/helm/higress/README.md
@@ -303,6 +303,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | redis.redis.service.type | string | `"ClusterIP"` | Exporter service type |
 | redis.redis.tag | string | `"7.4.0-v3"` | Specify the tag |
 | redis.redis.tolerations | list | `[]` | Tolerations for Redis |
+| redis.redis.extraConfig | string | `""` | Extra redis-stack.conf directives appended after the generated config |
 | revision | string | `""` |  |
 | tracing.enable | bool | `false` |  |
 | tracing.sampling | int | `100` |  |


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Makes Redis AOF persistence turn on automatically when `redis.persistence.enabled=true`, and wires up the previously-unused `extraConfig` value.

Behavior of the generated `redis-stack.conf`:

| `persistence.enabled` | result |
|---|---|
| `false` (default) | only `requirepass` (if a password is set); **no AOF**; ephemeral |
| `true` | `requirepass` + `dir /data` + AOF (`appendonly yes`, `appendfsync everysec`, `auto-aof-rewrite-*`); data on PVC |

Changes:
- `helm/core/charts/redis/templates/configmap.yaml`: emit `dir /data` + AOF directives under `{{- if .Values.redis.persistence.enabled }}`; render `redis.extraConfig` (it was referenced by **no** template before, so adding it to values alone had no effect).
- `helm/core/charts/redis/values.yaml` & `helm/core/values.yaml`: document that persistence enables AOF by default; add `extraConfig` as an escape hatch (empty default). Directives in `extraConfig` are emitted last, so they override the generated defaults (Redis applies the last value).

`dir /data` matches the existing PVC `mountPath: /data` (mounted only when persistence is enabled), so AOF files land on the persistent volume and survive pod restarts.

## Ⅱ. Does this pull request fix one issue?

No specific issue. Motivated by the gap that enabling `persistence.enabled` previously only mounted a PVC without configuring any Redis durability, and that `extraConfig` was not wired into the template.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This is a Helm template (YAML) change with no Go code, so there is no Go unit-test surface. Verified by rendering the chart with `helm template` across all relevant value combinations (persistence off/on, with/without password, with `extraConfig` overrides) — the generated `redis-stack.conf` is correct in every case. Helm chart template rendering is the standard verification method here.

## Ⅳ. Describe how to verify it

```bash
# persistence off (default) → no AOF
helm template r ./helm/core/charts/redis --show-only templates/configmap.yaml

# persistence on → AOF auto-enabled
helm template r ./helm/core/charts/redis --set redis.persistence.enabled=true \
     --show-only templates/configmap.yaml

# via the parent chart
helm template h ./helm/core --set global.enableRedis=true \
     --set redis.redis.persistence.enabled=true
```

## Ⅴ. Special notes for reviews

- AOF is intentionally tied to `persistence.enabled` rather than enabled unconditionally: without a PVC, AOF files are written to the container's ephemeral filesystem and lost on restart, so enabling AOF only when there is a persistent volume avoids a misleading "persisted" config that isn't actually durable.
- `appendfsync everysec` is the standard durability/performance trade-off (≤1s potential data loss).
- Users who prefer RDB-only can override via `extraConfig: appendonly no` (emitted last → wins).
- No change to default behavior: `persistence.enabled` stays `false`.

## Ⅵ. AI Coding Tool Usage Checklist

This PR was produced with the assistance of **Claude Code** (Anthropic).

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

1. Add the following Redis AOF persistence config to `helm/core/values.yaml` and `helm/core/charts/redis/values.yaml`; is defaulting Redis persistence to AOF more reasonable?
   ```yaml
   extraConfig: |
     appendonly yes
     appendfsync everysec
     auto-aof-rewrite-percentage 100
     auto-aof-rewrite-min-size 64mb
   ```
2. "默认 persistence.enabled: false，当 persistence.enabled: true 时，默认为 AOF 这样是不是就合理了？" — Keep `persistence.enabled: false` as the default; when `persistence.enabled: true`, default to AOF — is this reasonable?
3. "帮忙提交一个 PR" — Help submit a PR.

### AI Coding Summary

- **Key decisions**: (a) Tie AOF to `persistence.enabled` rather than enabling it unconditionally, because AOF without a PVC is not actually durable. (b) Wire `extraConfig` into the ConfigMap template — it was referenced nowhere, so adding it to values alone had no effect. (c) Set `dir /data` explicitly so AOF files land on the PVC mount path (the existing chart never set `dir`). (d) Keep `extraConfig` as an empty-default escape hatch, emitted last so user directives can override defaults.
- **Major changes**: `configmap.yaml` emits the AOF block under `persistence.enabled` and renders `extraConfig`; both `values.yaml` files document the behavior and expose `extraConfig`.
- **Limitations / considerations**: `persistence.enabled` still defaults to `false` (no cluster behavior change); enabling it requires a StorageClass/PV provisioner. Verified via `helm template` only — no Go code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
