### PR TITLE
fix(golang-filter): align Envoy Go bindings with the envoy/envoy submodule

### DIFF
--- a/.github/workflows/check-golang-filter-envoy-sync.yaml
+++ b/.github/workflows/check-golang-filter-envoy-sync.yaml
@@ -1,0 +1,32 @@
+name: "Check golang-filter Envoy Sync"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "plugins/golang-filter/go.mod"
+      - "envoy/envoy"
+      - ".gitmodules"
+      - "tools/hack/check-golang-filter-envoy-sync.sh"
+      - ".github/workflows/check-golang-filter-envoy-sync.yaml"
+  pull_request:
+    branches: ["*"]
+    paths:
+      - "plugins/golang-filter/go.mod"
+      - "envoy/envoy"
+      - ".gitmodules"
+      - "tools/hack/check-golang-filter-envoy-sync.sh"
+      - ".github/workflows/check-golang-filter-envoy-sync.yaml"
+  workflow_dispatch: ~
+
+jobs:
+  check-envoy-sync:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The check reads the submodule commit from the tree, so submodules
+          # do not need to be fetched.
+          submodules: false
+      - name: "Verify golang-filter Envoy pin matches the envoy/envoy submodule"
+        run: bash tools/hack/check-golang-filter-envoy-sync.sh

--- a/plugins/golang-filter/go.mod
+++ b/plugins/golang-filter/go.mod
@@ -1,8 +1,8 @@
 module github.com/alibaba/higress/plugins/golang-filter
 
-go 1.22
+go 1.23
 
-replace github.com/envoyproxy/envoy => github.com/higress-group/envoy v0.0.0-20250430151331-2c556780b65c
+replace github.com/envoyproxy/envoy => github.com/higress-group/envoy v0.0.0-20260707144248-4491e6783b3d
 
 replace github.com/mark3labs/mcp-go => github.com/higress-group/mcp-go v0.0.0-20250428145706-792ce64b4b30
 
@@ -17,7 +17,7 @@ require (
 	github.com/openai/openai-go/v2 v2.7.0
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/stretchr/testify v1.9.0
-	google.golang.org/protobuf v1.36.5
+	google.golang.org/protobuf v1.36.10
 	gorm.io/driver/clickhouse v0.6.1
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/driver/postgres v1.5.11
@@ -53,6 +53,7 @@ require (
 	github.com/cockroachdb/errors v1.9.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f // indirect
 	github.com/cockroachdb/redact v1.1.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/getsentry/sentry-go v0.12.0 // indirect

--- a/plugins/golang-filter/go.sum
+++ b/plugins/golang-filter/go.sum
@@ -185,7 +185,10 @@ github.com/getsentry/sentry-go v0.12.0/go.mod h1:NSap0JBYWzHND8oMbyi0+XZhUalc1TB
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
+github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-faker/faker/v4 v4.1.0 h1:ffuWmpDrducIUOO0QSKSF5Q2dxAht+dhsT9FvVHhPEI=
+github.com/go-faker/faker/v4 v4.1.0/go.mod h1:uuNc0PSRxF8nMgjGrrrU4Nw5cF30Jc6Kd0/FUTTYbhg=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=
@@ -264,8 +267,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -294,8 +297,8 @@ github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/higress-group/envoy v0.0.0-20250430151331-2c556780b65c h1:chAOZk/qEXFhLILWoNucj3X6r9xYnRR+SWFvhsOa2oo=
-github.com/higress-group/envoy v0.0.0-20250430151331-2c556780b65c/go.mod h1:SU+IJUAfh1kkZtH+u0E1dnwho8AhbGeYMgp5vvjU+Gc=
+github.com/higress-group/envoy v0.0.0-20260707144248-4491e6783b3d h1:JHeCakX2pS4OxpAdBNqvkUfLSrSVCNNtPkSjKe8lkfk=
+github.com/higress-group/envoy v0.0.0-20260707144248-4491e6783b3d/go.mod h1:mgMEye9tOlNiUTG+iYhQYgCzQcX46MMS0Jo6bVwRt1U=
 github.com/higress-group/mcp-go v0.0.0-20250428145706-792ce64b4b30 h1:N4NMq8M1nZyyChPyzn+EUUdHi5asig2uLR5hOyRmsXI=
 github.com/higress-group/mcp-go v0.0.0-20250428145706-792ce64b4b30/go.mod h1:O9gri9UOzthw728vusc2oNu99lVh8cKCajpxNfC90gE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -426,6 +429,7 @@ github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKf
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -934,8 +938,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
-google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
+google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/tools/hack/check-golang-filter-envoy-sync.sh
+++ b/tools/hack/check-golang-filter-envoy-sync.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022 Alibaba Group Holding Ltd.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The golang-filter shared object is built against the Go bindings published by
+# the envoy/envoy submodule, while the Envoy binary that loads it is built from
+# that same submodule. The two must be produced from the same commit, otherwise
+# the cgo boundary between the Go filter and the host Envoy can diverge.
+#
+# This script asserts that the github.com/higress-group/envoy commit pinned by
+# plugins/golang-filter/go.mod matches the commit checked out for the
+# envoy/envoy git submodule. Run it from the repository root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+GO_MOD="plugins/golang-filter/go.mod"
+SUBMODULE_PATH="envoy/envoy"
+
+# Commit recorded for the envoy/envoy submodule in the current tree. Reading it
+# from the tree (rather than the checked-out submodule) means the check works
+# even when submodules have not been initialized.
+submodule_commit="$(git rev-parse "HEAD:${SUBMODULE_PATH}")"
+
+# The replace directive pins github.com/higress-group/envoy to a pseudo-version
+# of the form v0.0.0-<UTC timestamp>-<12-char commit prefix>.
+pin_line="$(grep -E 'replace[[:space:]]+github.com/envoyproxy/envoy[[:space:]]+=>[[:space:]]+github.com/higress-group/envoy' "${GO_MOD}" || true)"
+if [[ -z "${pin_line}" ]]; then
+  echo "ERROR: could not find the github.com/higress-group/envoy replace directive in ${GO_MOD}" >&2
+  exit 1
+fi
+
+pin_prefix="$(echo "${pin_line}" | grep -oE '[0-9a-f]{12}$' || true)"
+if [[ -z "${pin_prefix}" ]]; then
+  echo "ERROR: could not parse the commit prefix from the envoy pseudo-version in ${GO_MOD}" >&2
+  echo "       line: ${pin_line}" >&2
+  exit 1
+fi
+
+if [[ "${submodule_commit:0:12}" != "${pin_prefix}" ]]; then
+  cat >&2 <<EOF
+ERROR: golang-filter Envoy dependency is out of sync with the envoy/envoy submodule.
+
+  envoy/envoy submodule commit : ${submodule_commit}
+  ${GO_MOD} pin prefix         : ${pin_prefix}
+
+The Go bindings used to build golang-filter must come from the same Envoy commit
+as the host Envoy binary. When you bump the envoy/envoy submodule, update the
+github.com/higress-group/envoy replace directive in ${GO_MOD} to the matching
+pseudo-version and run 'go mod tidy'. You can obtain the pseudo-version with:
+
+  GOPROXY=direct go list -m -json github.com/higress-group/envoy@${submodule_commit}
+EOF
+  exit 1
+fi
+
+echo "OK: ${GO_MOD} envoy pin (${pin_prefix}) matches envoy/envoy submodule (${submodule_commit})."


### PR DESCRIPTION
## Summary

- The `golang-filter` shared object links against the Go bindings published by `github.com/higress-group/envoy`, while the host Envoy binary that loads it is built from the `envoy/envoy` git submodule. The cgo boundary between the Go filter and the host Envoy is only stable when both are produced from the **same** Envoy commit.
- The `go.mod` `replace` pin had drifted behind the `envoy/envoy` submodule. This PR updates it to the pseudo-version matching the current submodule commit (`4491e6783b3d`) and runs `go mod tidy`.
- Adds a CI guard (`tools/hack/check-golang-filter-envoy-sync.sh` + a workflow) that fails when the `go.mod` envoy pin no longer matches the `envoy/envoy` submodule commit, so future submodule bumps keep the `golang-filter` build dependency in sync.

## Details

The check reads the submodule commit directly from the tree (`git rev-parse HEAD:envoy/envoy`), so it does not require initializing submodules in CI. It parses the 12-char commit prefix from the `higress-group/envoy` pseudo-version and compares the two.

When bumping the `envoy/envoy` submodule going forward, update the replace directive with:

```
GOPROXY=direct go list -m -json github.com/higress-group/envoy@<submodule-commit>
```

then run `go mod tidy`.

## Test plan

- [x] `go mod tidy` succeeds; `golang-filter` packages compile against the updated bindings
- [x] `tools/hack/check-golang-filter-envoy-sync.sh` passes on the synced state and fails on a mismatched pin
- [ ] CI green