### PR TITLE
ci: pin go-choppy/ossutil-github-action to a SHA in the OSS-deploy workflows

### DIFF
--- a/.github/workflows/deploy-standalone-to-oss.yaml
+++ b/.github/workflows/deploy-standalone-to-oss.yaml
@@ -29,7 +29,7 @@ jobs:
           echo "Version=$VERSION"
       # Step 3
       - name: Upload to OSS
-        uses: go-choppy/ossutil-github-action@master
+        uses: go-choppy/ossutil-github-action@7fe73c7342e740bdfb6954f8ca3486dd714fde94 # master (2022-05-26)
         with:
           ossArgs: 'cp -r -u ./artifact/ oss://higress-ai/standalone/'
           accessKey: ${{ secrets.ACCESS_KEYID }}

--- a/.github/workflows/deploy-to-oss.yaml
+++ b/.github/workflows/deploy-to-oss.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
       # Step 2
       - name: Download Helm Charts Index
-        uses: go-choppy/ossutil-github-action@master
+        uses: go-choppy/ossutil-github-action@7fe73c7342e740bdfb6954f8ca3486dd714fde94 # master (2022-05-26)
         with:
           ossArgs: 'cp oss://higress-ai/helm-charts/index.yaml ./artifact/'
           accessKey: ${{ secrets.ACCESS_KEYID }}
@@ -46,7 +46,7 @@ jobs:
             sed -i 's/higress\.io/higress\.cn/g' ./artifact/cn-index.yaml
       # Step 5
       - name: Upload to OSS
-        uses: go-choppy/ossutil-github-action@master
+        uses: go-choppy/ossutil-github-action@7fe73c7342e740bdfb6954f8ca3486dd714fde94 # master (2022-05-26)
         with:
           ossArgs: 'cp -r -u ./artifact/ oss://higress-ai/helm-charts/'
           accessKey: ${{ secrets.ACCESS_KEYID }}

--- a/.github/workflows/sync-skills-to-oss.yaml
+++ b/.github/workflows/sync-skills-to-oss.yaml
@@ -34,7 +34,7 @@ jobs:
           done
 
       - name: Sync Skills to OSS
-        uses: go-choppy/ossutil-github-action@master
+        uses: go-choppy/ossutil-github-action@7fe73c7342e740bdfb6954f8ca3486dd714fde94 # master (2022-05-26)
         with:
           ossArgs: 'cp -r -u packaged-skills/ oss://higress-ai/skills/'
           accessKey: ${{ secrets.ACCESS_KEYID }}
@@ -42,7 +42,7 @@ jobs:
           endpoint: oss-cn-hongkong.aliyuncs.com
 
       - name: Sync Install Script to OSS
-        uses: go-choppy/ossutil-github-action@master
+        uses: go-choppy/ossutil-github-action@7fe73c7342e740bdfb6954f8ca3486dd714fde94 # master (2022-05-26)
         with:
           ossArgs: 'cp -u install.sh oss://higress-ai/ai-gateway/install.sh'
           accessKey: ${{ secrets.ACCESS_KEYID }}


### PR DESCRIPTION
## What this does

The OSS-deploy workflows run `go-choppy/ossutil-github-action@master` — a third-party action pinned to a mutable branch — and pass it the Aliyun OSS credentials directly as inputs (`accessKey: ${{ secrets.ACCESS_KEYID }}`, `accessSecret: ${{ secrets.ACCESS_KEYSECRET }}`). This pins it to the current commit SHA across all three workflows.

## Why

`@master` resolves to whatever that branch's HEAD is at run time. The action redirects to `yjcyxky/ossutil-github-action`, a personal repo whose last commit was **2022-05-26** — so it's dormant and a natural target. If that branch were force-moved or the account compromised (the class of thing that happened with `tj-actions/changed-files`), the injected code would run in a job holding the OSS access key + secret for `oss://higress-ai/` (which serves the public helm charts, tarballs, and `install.sh`). Because the secrets are passed as direct inputs, they'd be trivially exfiltratable.

Pinning to a full commit SHA (`7fe73c7`, the current `master`) keeps behavior identical while removing the moving-target window. Changed in `deploy-to-oss.yaml`, `deploy-standalone-to-oss.yaml`, and `sync-skills-to-oss.yaml`.

Since the action is dormant, you may also want to vendor or replace it long-term — happy to help if useful.

DCO signed-off.

---

*Disclosure: I used an AI tool to help spot this and prepare the change; I verified the action's repo and the pinned SHA myself and take responsibility for it.*
