### PR TITLE
test(e2e): add spark conformance cases for ai-proxy

### DIFF
--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.go
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.go
@@ -1207,6 +1207,52 @@ data: [DONE]
 					},
 				},
 			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "spark case 1: non-streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "spark-api-open.xf-yun.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"Hello, who are you?"}],"stream":false}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode:           200,
+						ContentType:          http.ContentTypeApplicationJson,
+						JsonBodyIgnoreFields: []string{"id", "created", "usage"},
+						Body:                 []byte(`{"id":"x","choices":[{"index":0,"message":{"role":"assistant","content":"Hello, who are you?"},"finish_reason":null,"logprobs":null}],"created":0,"model":"4.0Ultra","object":"chat.completion","usage":{}}`),
+					},
+				},
+			},
+			{
+				Meta: http.AssertionMeta{
+					TestCaseName:  "spark case 2: streaming request",
+					CompareTarget: http.CompareTargetResponse,
+				},
+				Request: http.AssertionRequest{
+					ActualRequest: http.Request{
+						Host:        "spark-api-open.xf-yun.com",
+						Path:        "/v1/chat/completions",
+						Method:      "POST",
+						ContentType: http.ContentTypeApplicationJson,
+						Body:        []byte(`{"model":"gpt-3","messages":[{"role":"user","content":"Hello, who are you?"}],"stream":true}`),
+					},
+				},
+				Response: http.AssertionResponse{
+					ExpectedResponse: http.Response{
+						StatusCode: 200,
+						Headers: map[string]string{
+							"Content-Type": "text/event-stream",
+						},
+					},
+				},
+			},
 		}
 		t.Run("WasmPlugins ai-proxy", func(t *testing.T) {
 			for _, testcase := range testcases {

--- a/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
+++ b/test/e2e/conformance/tests/go-wasm-ai-proxy.yaml
@@ -391,6 +391,25 @@ spec:
                 port:
                   number: 3000
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wasmplugin-ai-proxy-spark
+  namespace: higress-conformance-ai-backend
+spec:
+  ingressClassName: higress
+  rules:
+    - host: "spark-api-open.xf-yun.com"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: llm-mock-service
+                port:
+                  number: 3000
+---
 apiVersion: extensions.higress.io/v1alpha1
 kind: WasmPlugin
 metadata:
@@ -607,4 +626,14 @@ spec:
           type: openai
       ingress:
         - higress-conformance-ai-backend/wasmplugin-ai-proxy-openai
+    - config:
+        provider:
+          apiTokens:
+            - fake_token
+          modelMapping:
+            "gpt-3": "4.0Ultra"
+            "*": "general"
+          type: spark
+      ingress:
+        - higress-conformance-ai-backend/wasmplugin-ai-proxy-spark
   url: file:///opt/plugins/wasm-go/extensions/ai-proxy/plugin.wasm


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Add non-streaming and streaming e2e conformance cases for the `spark` (Xunfei) ai-proxy provider in `test/e2e/conformance/tests/go-wasm-ai-proxy.{go,yaml}`. These exercise spark's native response shape (a `code`/`message`/`sid` envelope wrapping OpenAI-style `choices`/`usage`) and the `responseSpark2OpenAI` transform path.

## Ⅱ. Does this pull request fix one issue?

Fixes #1721.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR itself adds the e2e conformance test cases for the spark provider.

## Ⅳ. Describe how to verify it

Run the ai-proxy conformance suite against a gateway backed by the llm-mock-server. The spark mock handler ships in the `:latest` `llm-mock-server` image via higress-group/mock-server#19 (pending) — the e2e cases will pass once that merges and the image is republished.

## Ⅴ. Special notes for reviews

The ai-proxy `provider/spark.go` already implements the Spark<->OpenAI transform; this PR only adds e2e coverage, no provider changes. The non-streaming case asserts the converted OpenAI body (ignoring `id`/`created`/`usage`); the streaming case asserts the `text/event-stream` content type, consistent with the other providers whose mock emits a fresh `created` per chunk.