### PR TITLE
fix(jwt-auth): harden cookie token parsing

### DIFF
--- a/plugins/wasm-go/extensions/jwt-auth/handler/extractor.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/extractor.go
@@ -129,8 +129,8 @@ func findCookie(cookie string, key string) string {
 
 	for _, pair := range pairs {
 		pair = strings.TrimSpace(pair)
-		kv := strings.Split(pair, "=")
-		if kv[0] == key {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) == 2 && kv[0] == key {
 			value = kv[1]
 			break
 		}

--- a/plugins/wasm-go/extensions/jwt-auth/handler/extractor_test.go
+++ b/plugins/wasm-go/extensions/jwt-auth/handler/extractor_test.go
@@ -1,0 +1,51 @@
+package handler
+
+import "testing"
+
+func TestFindCookie(t *testing.T) {
+	tests := []struct {
+		name   string
+		cookie string
+		key    string
+		want   string
+	}{
+		{
+			name:   "extracts matching cookie value",
+			cookie: "user=alice; other=value",
+			key:    "user",
+			want:   "alice",
+		},
+		{
+			name:   "skips segment without equals sign",
+			cookie: "user; other=value",
+			key:    "user",
+			want:   "",
+		},
+		{
+			name:   "keeps equals signs in cookie value",
+			cookie: "user=alice=admin; other=value",
+			key:    "user",
+			want:   "alice=admin",
+		},
+		{
+			name:   "empty cookie returns empty",
+			cookie: "",
+			key:    "user",
+			want:   "",
+		},
+		{
+			name:   "key not present returns empty",
+			cookie: "user=alice; other=value",
+			key:    "missing",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findCookie(tt.cookie, tt.key); got != tt.want {
+				t.Fatalf("findCookie() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Harden `jwt-auth` cookie token parsing by skipping malformed cookie segments that do not contain `=`.

This mirrors the cookie parsing robustness fix previously applied to `cluster-key-rate-limit`:

- use `strings.SplitN(pair, "=", 2)` so cookie values containing `=` are preserved
- check `len(kv) == 2` before reading the cookie value
- add regression coverage for malformed cookie segments, empty cookies, missing keys, and values containing `=`

## Ⅱ. Does this pull request fix one issue?

No public issue.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Added unit tests for `findCookie`.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/jwt-auth
go test ./handler
```

## Ⅴ. Special notes for reviews

This is a robustness bugfix for malformed Cookie headers in `jwt-auth` when `from_cookies` is configured.

