### PR TITLE
bugfix: map Claude adaptive effort to Bedrock output config

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
@@ -963,10 +963,12 @@ func (b *bedrockProvider) buildBedrockTextGenerationRequest(origRequest *chatCom
 
 	thinking := bedrockThinkingFromClaudeConfig(origRequest.ClaudeThinking)
 	if thinking != nil {
-		if origRequest.ClaudeThinking.Type == "adaptive" && origRequest.ClaudeOutputConfig != nil && bedrockSupportsAdaptiveEffort(origRequest.ClaudeOutputConfig.Effort) {
-			thinking["effort"] = origRequest.ClaudeOutputConfig.Effort
-		}
 		request.AdditionalModelRequestFields["thinking"] = thinking
+		if origRequest.ClaudeThinking.Type == "adaptive" && origRequest.ClaudeOutputConfig != nil && bedrockSupportsAdaptiveEffort(origRequest.ClaudeOutputConfig.Effort) {
+			request.AdditionalModelRequestFields["output_config"] = map[string]interface{}{
+				"effort": origRequest.ClaudeOutputConfig.Effort,
+			}
+		}
 	} else if origRequest.ReasoningEffort != "" {
 		thinkingBudget := 1024 // default
 		switch origRequest.ReasoningEffort {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock_thinking_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock_thinking_test.go
@@ -389,7 +389,7 @@ func TestBedrockRequestPreservesClaudeNativeThinkingBudget(t *testing.T) {
 	assert.Equal(t, float64(8192), request.AdditionalModelRequestFields["thinking"].(map[string]interface{})["budget_tokens"])
 }
 
-func TestBedrockRequestMapsAdaptiveOutputEffortIntoThinking(t *testing.T) {
+func TestBedrockRequestMapsAdaptiveEffortIntoOutputConfig(t *testing.T) {
 	provider := &bedrockProvider{}
 	openaiBody, err := (&ClaudeToOpenAIConverter{}).ConvertClaudeRequestToOpenAI([]byte(`{
 		"model":"claude",
@@ -408,8 +408,10 @@ func TestBedrockRequestMapsAdaptiveOutputEffortIntoThinking(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &request))
 	thinking := request.AdditionalModelRequestFields["thinking"].(map[string]interface{})
 	assert.Equal(t, "adaptive", thinking["type"])
-	assert.Equal(t, "high", thinking["effort"])
-	assert.NotContains(t, request.AdditionalModelRequestFields, "output_config")
+	assert.NotContains(t, thinking, "effort")
+	require.Contains(t, request.AdditionalModelRequestFields, "output_config")
+	outputConfig := request.AdditionalModelRequestFields["output_config"].(map[string]interface{})
+	assert.Equal(t, "high", outputConfig["effort"])
 	assert.NotContains(t, request.AdditionalModelRequestFields, "anthropic_beta")
 }
 


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

This PR fixes the Bedrock Converse request mapping for Claude adaptive thinking.

Previously, the Anthropic-compatible request:

```json
{
  "thinking": {
    "type": "adaptive"
  },
  "output_config": {
    "effort": "high"
  }
}
```

was converted to:

```json
{
  "additionalModelRequestFields": {
    "thinking": {
      "type": "adaptive",
      "effort": "high"
    }
  }
}
```

Bedrock expects `thinking` and `output_config` to be sibling fields. This PR now generates:

```json
{
  "additionalModelRequestFields": {
    "thinking": {
      "type": "adaptive"
    },
    "output_config": {
      "effort": "high"
    }
  }
}
```

This keeps the original adaptive thinking configuration while placing `effort` in the Bedrock-compatible location.

## Ⅱ. Does this pull request fix one issue?

Closes #4170

## Ⅲ. Why don't you add test cases (unit test/integration test)?

A regression test is included.

The test verifies that:

- `thinking.type` remains `adaptive`
- `effort` is not added to the `thinking` object
- `output_config.effort` is emitted as a sibling model request field
- unsupported effort values and effort without adaptive thinking remain omitted

## Ⅳ. Describe how to verify it

Run the provider unit tests:

```shell
cd plugins/wasm-go/extensions/ai-proxy
go test ./provider -count=1
```

Run the Bedrock plugin test:

```shell
cd plugins/wasm-go/extensions/ai-proxy
go test . -run '^TestBedrock$'
```

Both commands should pass.

## Ⅴ. Special notes for reviews

- The existing supported effort values remain unchanged: `low`, `medium`, and `high`.
- Unsupported effort values are still omitted.
- Manual extended thinking with `budget_tokens` is unaffected.
- Bedrock structured output configuration is unaffected.
- No fallback behavior is introduced.