### PR TITLE
bugfix: preserve Bedrock cache read and write token details

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
@@ -207,7 +207,7 @@ func (b *bedrockProvider) convertEventFromBedrockToOpenAI(ctx wrapper.HttpContex
 			CompletionTokens:    bedrockEvent.Usage.OutputTokens,
 			PromptTokens:        bedrockEvent.Usage.InputTokens,
 			TotalTokens:         bedrockEvent.Usage.TotalTokens,
-			PromptTokensDetails: buildPromptTokensDetails(bedrockEvent.Usage.CacheReadInputTokens, bedrockEvent.Usage.CacheWriteInputTokens),
+			PromptTokensDetails: buildPromptTokensDetails(bedrockEvent.Usage.cacheReadTokens(), bedrockEvent.Usage.cacheWriteTokens()),
 		}
 	}
 	openAIFormattedChunkBytes, _ := json.Marshal(openAIFormattedChunk)
@@ -1119,7 +1119,7 @@ func (b *bedrockProvider) buildChatCompletionResponse(ctx wrapper.HttpContext, b
 			PromptTokens:        bedrockResponse.Usage.InputTokens,
 			CompletionTokens:    bedrockResponse.Usage.OutputTokens,
 			TotalTokens:         bedrockResponse.Usage.TotalTokens,
-			PromptTokensDetails: buildPromptTokensDetails(bedrockResponse.Usage.CacheReadInputTokens, bedrockResponse.Usage.CacheWriteInputTokens),
+			PromptTokensDetails: buildPromptTokensDetails(bedrockResponse.Usage.cacheReadTokens(), bedrockResponse.Usage.cacheWriteTokens()),
 		},
 	}
 }
@@ -1280,12 +1280,12 @@ func appendCachePointToBedrockMessage(request *bedrockTextGenRequest, messageInd
 }
 
 func buildPromptTokensDetails(cacheReadInputTokens int, cacheWriteInputTokens int) *promptTokensDetails {
-	totalCachedTokens := cacheReadInputTokens + cacheWriteInputTokens
-	if totalCachedTokens <= 0 {
+	if cacheReadInputTokens <= 0 && cacheWriteInputTokens <= 0 {
 		return nil
 	}
 	return &promptTokensDetails{
-		CachedTokens: totalCachedTokens,
+		CachedTokens:     cacheReadInputTokens,
+		CacheWriteTokens: cacheWriteInputTokens,
 	}
 }
 
@@ -1444,7 +1444,25 @@ type tokenUsage struct {
 
 	CacheReadInputTokens int `json:"cacheReadInputTokens,omitempty"`
 
+	CacheReadInputTokenCount int `json:"cacheReadInputTokenCount,omitempty"`
+
 	CacheWriteInputTokens int `json:"cacheWriteInputTokens,omitempty"`
+
+	CacheWriteInputTokenCount int `json:"cacheWriteInputTokenCount,omitempty"`
+}
+
+func (u tokenUsage) cacheReadTokens() int {
+	if u.CacheReadInputTokens > 0 {
+		return u.CacheReadInputTokens
+	}
+	return u.CacheReadInputTokenCount
+}
+
+func (u tokenUsage) cacheWriteTokens() int {
+	if u.CacheWriteInputTokens > 0 {
+		return u.CacheWriteInputTokens
+	}
+	return u.CacheWriteInputTokenCount
 }
 
 func chatToolMessage2BedrockToolResultContent(chatMessage chatMessage) bedrockMessageContent {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock_usage_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock_usage_test.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPromptTokensDetailsPreservesCacheUsage(t *testing.T) {
+	tests := []struct {
+		name       string
+		cacheRead  int
+		cacheWrite int
+		wantNil    bool
+	}{
+		{
+			name:    "no cache usage",
+			wantNil: true,
+		},
+		{
+			name:      "cache read only",
+			cacheRead: 7,
+		},
+		{
+			name:       "cache write only",
+			cacheWrite: 3,
+		},
+		{
+			name:       "cache read and write",
+			cacheRead:  7,
+			cacheWrite: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			details := buildPromptTokensDetails(tt.cacheRead, tt.cacheWrite)
+			if tt.wantNil {
+				assert.Nil(t, details)
+				return
+			}
+			require.NotNil(t, details)
+			assert.Equal(t, tt.cacheRead, details.CachedTokens)
+			assert.Equal(t, tt.cacheWrite, details.CacheWriteTokens)
+		})
+	}
+}
+
+func TestTokenUsageCacheTokensSupportsBedrockFieldAliases(t *testing.T) {
+	tests := []struct {
+		name      string
+		usage     tokenUsage
+		wantRead  int
+		wantWrite int
+	}{
+		{
+			name: "current fields",
+			usage: tokenUsage{
+				CacheReadInputTokens:  7,
+				CacheWriteInputTokens: 3,
+			},
+			wantRead:  7,
+			wantWrite: 3,
+		},
+		{
+			name: "legacy count fields",
+			usage: tokenUsage{
+				CacheReadInputTokenCount:  11,
+				CacheWriteInputTokenCount: 5,
+			},
+			wantRead:  11,
+			wantWrite: 5,
+		},
+		{
+			name: "current fields take precedence",
+			usage: tokenUsage{
+				CacheReadInputTokens:      7,
+				CacheReadInputTokenCount:  70,
+				CacheWriteInputTokens:     3,
+				CacheWriteInputTokenCount: 30,
+			},
+			wantRead:  7,
+			wantWrite: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantRead, tt.usage.cacheReadTokens())
+			assert.Equal(t, tt.wantWrite, tt.usage.cacheWriteTokens())
+		})
+	}
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
@@ -397,7 +397,8 @@ func (c *ClaudeToOpenAIConverter) ConvertOpenAIResponseToClaude(ctx wrapper.Http
 			OutputTokens: openaiResponse.Usage.CompletionTokens,
 		}
 		if openaiResponse.Usage.PromptTokensDetails != nil {
-			claudeResponse.Usage.CacheReadInputTokens = openaiResponse.Usage.PromptTokensDetails.CachedTokens
+			claudeResponse.Usage.CacheReadInputTokens, claudeResponse.Usage.CacheCreationInputTokens =
+				openaiResponse.Usage.PromptTokensDetails.cacheTokenUsage()
 		}
 	}
 
@@ -1009,7 +1010,8 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 			OutputTokens: openaiResponse.Usage.CompletionTokens,
 		}
 		if openaiResponse.Usage.PromptTokensDetails != nil {
-			usage.CacheReadInputTokens = openaiResponse.Usage.PromptTokensDetails.CachedTokens
+			usage.CacheReadInputTokens, usage.CacheCreationInputTokens =
+				openaiResponse.Usage.PromptTokensDetails.cacheTokenUsage()
 		}
 
 		// Send message_delta with both stop_reason and usage (Claude protocol requirement)

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
@@ -1409,6 +1409,108 @@ func TestClaudeToOpenAIConverter_ConvertReasoningResponseToClaude(t *testing.T) 
 	}
 }
 
+func TestClaudeToOpenAIConverter_ConvertOpenAIResponseToClaude_WithCacheTokenDetails(t *testing.T) {
+	tests := []struct {
+		name                  string
+		promptTokensDetails   string
+		expectedInput         int
+		expectedCacheRead     int
+		expectedCacheCreation int
+	}{
+		{
+			name:                  "cache read and write details",
+			promptTokensDetails:   `{"cached_tokens":7,"cache_write_tokens":3}`,
+			expectedInput:         93,
+			expectedCacheRead:     7,
+			expectedCacheCreation: 3,
+		},
+		{
+			name:                  "only cache write details",
+			promptTokensDetails:   `{"cache_write_tokens":3}`,
+			expectedInput:         100,
+			expectedCacheCreation: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := &ClaudeToOpenAIConverter{}
+			openAIResponse := []byte(`{
+				"id":"chatcmpl-test",
+				"model":"gpt-4o",
+				"choices":[{"index":0,"message":{"role":"assistant","content":"done"},"finish_reason":"stop"}],
+				"usage":{
+					"prompt_tokens":100,
+					"completion_tokens":20,
+					"total_tokens":120,
+					"prompt_tokens_details":` + tt.promptTokensDetails + `
+				}
+			}`)
+
+			result, err := converter.ConvertOpenAIResponseToClaude(nil, openAIResponse)
+			require.NoError(t, err)
+
+			var claudeResponse claudeTextGenResponse
+			require.NoError(t, json.Unmarshal(result, &claudeResponse))
+			assert.Equal(t, tt.expectedInput, claudeResponse.Usage.InputTokens)
+			assert.Equal(t, 20, claudeResponse.Usage.OutputTokens)
+			assert.Equal(t, tt.expectedCacheRead, claudeResponse.Usage.CacheReadInputTokens)
+			assert.Equal(t, tt.expectedCacheCreation, claudeResponse.Usage.CacheCreationInputTokens)
+		})
+	}
+}
+
+func TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_WithCacheTokenDetails(t *testing.T) {
+	tests := []struct {
+		name                  string
+		promptTokensDetails   string
+		expectedInput         string
+		expectedCacheRead     string
+		expectedCacheCreation string
+	}{
+		{
+			name:                  "cache read and write details",
+			promptTokensDetails:   `{"cached_tokens":7,"cache_write_tokens":3}`,
+			expectedInput:         `"input_tokens":93`,
+			expectedCacheRead:     `"cache_read_input_tokens":7`,
+			expectedCacheCreation: `"cache_creation_input_tokens":3`,
+		},
+		{
+			name:                  "only cache write details",
+			promptTokensDetails:   `{"cache_write_tokens":3}`,
+			expectedInput:         `"input_tokens":100`,
+			expectedCacheCreation: `"cache_creation_input_tokens":3`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter := &ClaudeToOpenAIConverter{}
+			streamChunk := "data: {\"id\":\"chatcmpl-test\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
+				"data: {\"id\":\"chatcmpl-test\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":20,\"total_tokens\":120,\"prompt_tokens_details\":" +
+				tt.promptTokensDetails + "}}\n\n"
+
+			result, err := converter.ConvertOpenAIStreamResponseToClaude(nil, []byte(streamChunk))
+			require.NoError(t, err)
+
+			resultStr := string(result)
+			assert.Contains(t, resultStr, `"type":"message_delta"`)
+			assert.Contains(t, resultStr, tt.expectedInput)
+			assert.Contains(t, resultStr, `"output_tokens":20`)
+			if tt.expectedCacheRead == "" {
+				assert.NotContains(t, resultStr, `"cache_read_input_tokens"`)
+			} else {
+				assert.Contains(t, resultStr, tt.expectedCacheRead)
+			}
+			if tt.expectedCacheCreation == "" {
+				assert.NotContains(t, resultStr, `"cache_creation_input_tokens"`)
+			} else {
+				assert.Contains(t, resultStr, tt.expectedCacheCreation)
+			}
+		})
+	}
+}
+
 func TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_WithCachedTokens(t *testing.T) {
 	converter := &ClaudeToOpenAIConverter{}
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -193,8 +193,13 @@ type usage struct {
 }
 
 type promptTokensDetails struct {
-	AudioTokens  int `json:"audio_tokens,omitempty"`
-	CachedTokens int `json:"cached_tokens,omitempty"`
+	AudioTokens      int `json:"audio_tokens,omitempty"`
+	CachedTokens     int `json:"cached_tokens,omitempty"`
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+}
+
+func (d *promptTokensDetails) cacheTokenUsage() (int, int) {
+	return d.CachedTokens, d.CacheWriteTokens
 }
 
 type completionTokensDetails struct {

--- a/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/test/bedrock.go
@@ -1813,8 +1813,8 @@ func RunBedrockOnHttpResponseBodyTests(t *testing.T) {
 					"inputTokens": 10,
 					"outputTokens": 15,
 					"totalTokens": 25,
-					"cacheReadInputTokens": 6,
-					"cacheWriteInputTokens": 12
+					"cacheReadInputTokenCount": 6,
+					"cacheWriteInputTokenCount": 12
 				}
 			}`
 
@@ -1841,9 +1841,9 @@ func RunBedrockOnHttpResponseBodyTests(t *testing.T) {
 			usageMap := usage.(map[string]interface{})
 			promptTokensDetails, hasPromptTokensDetails := usageMap["prompt_tokens_details"].(map[string]interface{})
 			require.True(t, hasPromptTokensDetails, "prompt_tokens_details should exist when cacheReadInputTokens is present")
-			require.Equal(t, float64(18), promptTokensDetails["cached_tokens"], "cached_tokens should sum cacheReadInputTokens and cacheWriteInputTokens")
-			_, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
-			require.False(t, hasCacheWriteTokens, "cache_write_tokens should not exist in OpenAI-compatible usage")
+			require.Equal(t, float64(6), promptTokensDetails["cached_tokens"], "cached_tokens should represent cache read tokens")
+			require.NotContains(t, promptTokensDetails, "cache_read_tokens", "cache_read_tokens is not part of the OpenAI usage schema")
+			require.Equal(t, float64(12), promptTokensDetails["cache_write_tokens"], "cache_write_tokens should preserve Bedrock cache write tokens")
 		})
 
 		t.Run("bedrock response body with zero cache read tokens should omit prompt_tokens_details", func(t *testing.T) {
@@ -1914,7 +1914,7 @@ func RunBedrockOnHttpResponseBodyTests(t *testing.T) {
 			require.False(t, hasPromptTokensDetails, "prompt_tokens_details should be omitted when cacheReadInputTokens is zero")
 		})
 
-		t.Run("bedrock response body with only cache write tokens should map to cached_tokens", func(t *testing.T) {
+		t.Run("bedrock response body with only cache write tokens should preserve cache write detail", func(t *testing.T) {
 			host, status := test.NewTestHost(bedrockApiTokenConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
@@ -1979,9 +1979,11 @@ func RunBedrockOnHttpResponseBodyTests(t *testing.T) {
 			usageMap := responseMap["usage"].(map[string]interface{})
 			promptTokensDetails, hasPromptTokensDetails := usageMap["prompt_tokens_details"].(map[string]interface{})
 			require.True(t, hasPromptTokensDetails, "prompt_tokens_details should exist when cacheWriteInputTokens is present")
-			require.Equal(t, float64(9), promptTokensDetails["cached_tokens"], "cached_tokens should map from cacheWriteInputTokens when cacheReadInputTokens is zero")
-			_, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
-			require.False(t, hasCacheWriteTokens, "cache_write_tokens should not exist in OpenAI-compatible usage")
+			_, hasCachedTokens := promptTokensDetails["cached_tokens"]
+			require.False(t, hasCachedTokens, "cached_tokens should not be populated by cache write tokens")
+			_, hasCacheReadTokens := promptTokensDetails["cache_read_tokens"]
+			require.False(t, hasCacheReadTokens, "cache_read_tokens should be omitted when cache read is zero")
+			require.Equal(t, float64(9), promptTokensDetails["cache_write_tokens"], "cache_write_tokens should preserve Bedrock cache write tokens")
 		})
 
 		t.Run("bedrock anthropic messages response body should pass through", func(t *testing.T) {
@@ -2203,7 +2205,7 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 			}
 		})
 
-		t.Run("bedrock streaming usage should map cached_tokens", func(t *testing.T) {
+		t.Run("bedrock streaming usage should preserve cache token details", func(t *testing.T) {
 			host, status := test.NewTestHost(bedrockApiTokenConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
@@ -2239,11 +2241,11 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 
 			streamingChunk := buildBedrockEventStreamMessage(t, map[string]interface{}{
 				"usage": map[string]interface{}{
-					"inputTokens":           10,
-					"outputTokens":          2,
-					"totalTokens":           12,
-					"cacheReadInputTokens":  7,
-					"cacheWriteInputTokens": 3,
+					"inputTokens":               10,
+					"outputTokens":              2,
+					"totalTokens":               12,
+					"cacheReadInputTokenCount":  7,
+					"cacheWriteInputTokenCount": 3,
 				},
 			})
 			action = host.CallOnHttpStreamingResponseBody(streamingChunk, true)
@@ -2266,9 +2268,9 @@ func RunBedrockOnStreamingResponseBodyTests(t *testing.T) {
 			require.NoError(t, err)
 			usageMap := responseMap["usage"].(map[string]interface{})
 			promptTokensDetails := usageMap["prompt_tokens_details"].(map[string]interface{})
-			require.Equal(t, float64(10), promptTokensDetails["cached_tokens"], "cached_tokens should sum cacheReadInputTokens and cacheWriteInputTokens in streaming usage event")
-			_, hasCacheWriteTokens := promptTokensDetails["cache_write_tokens"]
-			require.False(t, hasCacheWriteTokens, "cache_write_tokens should not exist in OpenAI-compatible streaming usage")
+			require.Equal(t, float64(7), promptTokensDetails["cached_tokens"], "cached_tokens should represent streaming cache read tokens")
+			require.NotContains(t, promptTokensDetails, "cache_read_tokens", "cache_read_tokens is not part of the OpenAI usage schema")
+			require.Equal(t, float64(3), promptTokensDetails["cache_write_tokens"], "cache_write_tokens should preserve streaming cache write tokens")
 		})
 
 		t.Run("bedrock streaming text chunk then usage chunk format is stable", func(t *testing.T) {


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

This PR preserves Bedrock prompt cache read and write token details across OpenAI-compatible and Claude response conversions.

Previously, Higress combined Bedrock cache read and cache write tokens into `prompt_tokens_details.cached_tokens`:

```json
{
  "cached_tokens": 18
}
```

for a Bedrock response containing 6 cache read tokens and 12 cache write tokens.

This incorrectly treated cache writes as cache hits. When the response was converted back to the Claude Messages format, all 18 tokens were reported as `cache_read_input_tokens`, while `cache_creation_input_tokens` was lost.

This PR keeps the two values separate:

```json
{
  "prompt_tokens_details": {
    "cached_tokens": 6,
    "cache_write_tokens": 12
  }
}
```

When converting the response to the Claude Messages format, the values are mapped to:

```json
{
  "usage": {
    "cache_read_input_tokens": 6,
    "cache_creation_input_tokens": 12
  }
}
```

The change applies to both streaming and non-streaming responses.

It also accepts both Bedrock cache usage field variants. The current `cacheReadInputTokens` and `cacheWriteInputTokens` fields take precedence, with `cacheReadInputTokenCount` and `cacheWriteInputTokenCount` retained as compatibility fallbacks.

## Ⅱ. Does this pull request fix one issue?

Closes #4169

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Regression tests are included for:

- Bedrock cache read and write field normalization
- precedence of the current Bedrock field names
- compatibility with the legacy token count field names
- cache read-only and cache write-only responses
- OpenAI-to-Claude non-streaming response conversion
- OpenAI-to-Claude streaming response conversion
- Bedrock streaming and non-streaming response handling
- omission of the non-standard `cache_read_tokens` field

## Ⅳ. Describe how to verify it

Run the provider tests:

```shell
cd plugins/wasm-go/extensions/ai-proxy
go test ./provider -count=1
```

Run the Bedrock plugin test:

```shell
cd plugins/wasm-go/extensions/ai-proxy
go test . -run '^TestBedrock$' -count=1
```

Both commands should pass.

## Ⅴ. Special notes for reviews

- `cached_tokens` represents cache reads only.
- `cache_write_tokens` preserves Bedrock cache writes.
- The non-standard `cache_read_tokens` field is not introduced.
- The existing `prompt_tokens` calculation is intentionally unchanged.
- The only fallback added is compatibility with Bedrock's legacy `*InputTokenCount` cache usage field names.