### PR TITLE
fix(transformer): skip replace/add/append when host_pattern/path_pattern does not match

### DIFF
--- a/plugins/wasm-go/extensions/transformer/README.md
+++ b/plugins/wasm-go/extensions/transformer/README.md
@@ -61,6 +61,7 @@ description: 请求响应转换插件配置参考
 * 当转换对象为 headers 时，` key` 不区分大小写；当为 headers 且为 `rename`, `map` 操作时，`value` 也不区分大小写（因为此时该字段具有 key 含义）；而 querys 和 body 的 `key`, `value` 字段均区分大小写
 * `value_type` 仅对 content-type 为 application/json 的请求/响应体有效
 * `host_pattern` 和 `path_pathern` 支持 [RE2 语法](https://pkg.go.dev/regexp/syntax)，仅对 `replace`, `add`, `append` 操作有效，且在一项转换规则中两者只能选填其一，若均填写，则 `host_pattern` 生效，而 `path_pattern` 失效
+* 当配置了 `host_pattern` 或 `path_pattern`，但当前请求的主机名或路径不匹配该正则时，对应的转换项将被跳过（不执行）。借助这一点，可以为同一个 `key` 配置多条带有不同匹配规则的转换项，使其在不同的主机名/路径下生效不同的值
 
 
 

--- a/plugins/wasm-go/extensions/transformer/README_EN.md
+++ b/plugins/wasm-go/extensions/transformer/README_EN.md
@@ -56,6 +56,7 @@ Note:
 * When the transformation object is headers, `key` is case-insensitive. When headers are operated and are `rename` or `map`, `value` is also case-insensitive (as this field has a key meaning). However, `key` and `value` fields in querys and body are case-sensitive.
 * `value_type` is only effective for content type application/json for request/response bodies.
 * `host_pattern` and `path_pattern` support [RE2 syntax](https://pkg.go.dev/regexp/syntax), valid only for `replace`, `add`, `append` operations. In a transformation rule, only one of the two can be optionally filled. If both are filled, then `host_pattern` takes effect while `path_pattern` becomes ineffective.
+* When `host_pattern` or `path_pattern` is configured but the current request's hostname or path does not match the regular expression, the corresponding transformation item is skipped (not executed). This makes it possible to configure multiple transformation items for the same `key` with different matching patterns, so that different values take effect for different hostnames/paths.
 
 ## Transformation Operation Types
 | Operation Type | Key Field Meaning | Value Field Meaning | Description |

--- a/plugins/wasm-go/extensions/transformer/main.go
+++ b/plugins/wasm-go/extensions/transformer/main.go
@@ -931,21 +931,29 @@ func (h kvHandler) handle(host, path string, kvs map[string][]string, mapSourceD
 			}
 		case ReplaceK:
 			// replace: 若指定 key 不存在，相当于添加操作；否则替换 value 为 newValue
+			// 若配置了 host_pattern/path_pattern 但当前请求不匹配，则跳过该转换项
 			for _, replace := range kvtOp.replaceKvtGroup {
 				key, newValue := replace.key, replace.newValue
 				if replace.reg != nil {
+					if !replace.reg.matches(host, path) {
+						continue
+					}
 					newValue = replace.reg.matchAndReplace(newValue, host, path)
 				}
 				kvs[key] = []string{newValue}
 			}
 		case AddK:
 			// add: 若指定 key 存在则无操作；否则添加 key:value
+			// 若配置了 host_pattern/path_pattern 但当前请求不匹配，则跳过该转换项
 			for _, add := range kvtOp.addKvtGroup {
 				key, value := add.key, add.value
 				if _, ok := kvs[key]; ok {
 					continue
 				}
 				if add.reg != nil {
+					if !add.reg.matches(host, path) {
+						continue
+					}
 					value = add.reg.matchAndReplace(value, host, path)
 				}
 				kvs[key] = []string{value}
@@ -953,9 +961,13 @@ func (h kvHandler) handle(host, path string, kvs map[string][]string, mapSourceD
 
 		case AppendK:
 			// append: 若指定 key 存在，则追加同名 kv；否则相当于添加操作
+			// 若配置了 host_pattern/path_pattern 但当前请求不匹配，则跳过该转换项
 			for _, append_ := range kvtOp.appendKvtGroup {
 				key, appendValue := append_.key, append_.appendValue
 				if append_.reg != nil {
+					if !append_.reg.matches(host, path) {
+						continue
+					}
 					appendValue = append_.reg.matchAndReplace(appendValue, host, path)
 				}
 				kvs[key] = append(kvs[key], appendValue)
@@ -1068,8 +1080,12 @@ func (h jsonHandler) handle(host, path string, oriData []byte, mapSourceData map
 			}
 		case ReplaceK:
 			// replace: 若指定 key 不存在，则相当于添加操作；否则替换 value 为 newValue
+			// 若配置了 host_pattern/path_pattern 但当前请求不匹配，则跳过该转换项
 			for _, replace := range kvtOp.replaceKvtGroup {
 				key, newValue, valueType := replace.key, replace.newValue, replace.typ
+				if replace.reg != nil && !replace.reg.matches(host, path) {
+					continue
+				}
 				if valueType == "string" && replace.reg != nil {
 					newValue = replace.reg.matchAndReplace(newValue, host, path)
 				}
@@ -1083,8 +1099,12 @@ func (h jsonHandler) handle(host, path string, oriData []byte, mapSourceData map
 			}
 		case AddK:
 			// add: 若指定 key 存在则无操作；否则添加 key:value
+			// 若配置了 host_pattern/path_pattern 但当前请求不匹配，则跳过该转换项
 			for _, add := range kvtOp.addKvtGroup {
 				key, value, valueType := add.key, add.value, add.typ
+				if add.reg != nil && !add.reg.matches(host, path) {
+					continue
+				}
 				if gjson.GetBytes(data, key).Exists() {
 					continue
 				}
@@ -1102,8 +1122,12 @@ func (h jsonHandler) handle(host, path string, oriData []byte, mapSourceData map
 		case AppendK:
 			// append: 若指定 key 存在，则追加同名 kv；否则相当于添加操作
 			// 当原本的 value 为数组时，追加；当原本的 value 不为数组时，将原本的 value 和 appendValue 组成数组
+			// 若配置了 host_pattern/path_pattern 但当前请求不匹配，则跳过该转换项
 			for _, append_ := range kvtOp.appendKvtGroup {
 				key, appendValue, valueType := append_.key, append_.appendValue, append_.typ
+				if append_.reg != nil && !append_.reg.matches(host, path) {
+					continue
+				}
 				if valueType == "string" && append_.reg != nil {
 					appendValue = append_.reg.matchAndReplace(appendValue, host, path)
 				}
@@ -1474,6 +1498,18 @@ func newReg(hostPatten, pathPatten string) (r *reg, err error) {
 		return
 	}
 	return
+}
+
+// matches reports whether the configured pattern matches the current request.
+// newReg guarantees at most one of hostReg/pathReg is set.
+func (r reg) matches(host, path string) bool {
+	if r.hostReg != nil {
+		return r.hostReg.MatchString(host)
+	}
+	if r.pathReg != nil {
+		return r.pathReg.MatchString(path)
+	}
+	return true
 }
 
 func (r reg) matchAndReplace(value, host, path string) string {

--- a/plugins/wasm-go/extensions/transformer/main_test.go
+++ b/plugins/wasm-go/extensions/transformer/main_test.go
@@ -199,12 +199,12 @@ func TestRequest_Headers_DedupeStrategies(t *testing.T) {
 		// for SPLIT_*, input has a single value containing commas.
 		want []string
 	}{
-		{"", []string{"a", "b", "a", "c"}, []string{"a"}},                                // default = RETAIN_FIRST
-		{"RETAIN_FIRST", []string{"a", "b", "a", "c"}, []string{"a"}},                    // explicit
-		{"RETAIN_LAST", []string{"a", "b", "a", "c"}, []string{"c"}},                     // last only
-		{"RETAIN_UNIQUE", []string{"a", "b", "a", "c"}, []string{"a", "b", "c"}},         // dedup preserving order
-		{"SPLIT_AND_RETAIN_FIRST", []string{"x,y,z"}, []string{"x"}},                     // split first value, keep first part
-		{"SPLIT_AND_RETAIN_LAST", []string{"x,y,z"}, []string{"z"}},                      // split first value, keep last part
+		{"", []string{"a", "b", "a", "c"}, []string{"a"}},                        // default = RETAIN_FIRST
+		{"RETAIN_FIRST", []string{"a", "b", "a", "c"}, []string{"a"}},            // explicit
+		{"RETAIN_LAST", []string{"a", "b", "a", "c"}, []string{"c"}},             // last only
+		{"RETAIN_UNIQUE", []string{"a", "b", "a", "c"}, []string{"a", "b", "c"}}, // dedup preserving order
+		{"SPLIT_AND_RETAIN_FIRST", []string{"x,y,z"}, []string{"x"}},             // split first value, keep first part
+		{"SPLIT_AND_RETAIN_LAST", []string{"x,y,z"}, []string{"z"}},              // split first value, keep last part
 	}
 	for _, tc := range tests {
 		t.Run(tc.strategy, func(t *testing.T) {
@@ -486,7 +486,7 @@ func TestRequest_Headers_AddWithHostPattern(t *testing.T) {
 	})
 }
 
-func TestRequest_Headers_AddWithPathPattern_NoMatchKeepsValue(t *testing.T) {
+func TestRequest_Headers_AddWithPathPattern_NoMatchSkipsAdd(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
 		host, status := test.NewTestHost(configJSON(map[string]any{
 			"reqRules": []map[string]any{
@@ -498,14 +498,110 @@ func TestRequest_Headers_AddWithPathPattern_NoMatchKeepsValue(t *testing.T) {
 		defer host.Reset()
 		require.Equal(t, types.OnPluginStartStatusOK, status)
 
-		// path does NOT match the pattern → value is the literal "literal"
+		// path does NOT match the pattern → the add operation is skipped
 		require.Equal(t, types.ActionContinue, host.CallOnHttpRequestHeaders([][2]string{
 			{":authority", "test.com"},
 			{":path", "/static/css"},
 		}))
 
 		got := headersToMap(host.GetRequestHeaders())
-		require.Equal(t, []string{"literal"}, got["x-v"])
+		require.NotContains(t, got, "x-v")
+		host.CompleteHttp()
+	})
+}
+
+// Regression test for https://github.com/higress-group/higress/issues/4132:
+// two add entries for the SAME header key guarded by different path patterns
+// should each take effect only on requests matching their own pattern.
+func TestRequest_Headers_AddSameKeyDifferentPathPatterns(t *testing.T) {
+	cfg := configJSON(map[string]any{
+		"reqRules": []map[string]any{
+			{"operate": "add", "headers": []map[string]any{
+				{"key": "access-appId", "value": "ij2b6Nfg", "path_pattern": `^/test/.*`},
+				{"key": "access-appId", "value": "Y6JK5J7T", "path_pattern": `^/prod/.*`},
+			}},
+		},
+	})
+
+	cases := []struct {
+		name string
+		path string
+		want []string
+	}{
+		{"test path gets first value", "/test/api", []string{"ij2b6Nfg"}},
+		{"prod path gets second value", "/prod/api", []string{"Y6JK5J7T"}},
+		{"other path gets no header", "/other/api", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			test.RunTest(t, func(t *testing.T) {
+				host, status := test.NewTestHost(cfg)
+				defer host.Reset()
+				require.Equal(t, types.OnPluginStartStatusOK, status)
+
+				require.Equal(t, types.ActionContinue, host.CallOnHttpRequestHeaders([][2]string{
+					{":authority", "test.com"},
+					{":path", c.path},
+				}))
+
+				got := headersToMap(host.GetRequestHeaders())
+				if c.want == nil {
+					require.NotContains(t, got, "access-appid")
+				} else {
+					require.Equal(t, c.want, got["access-appid"])
+				}
+				host.CompleteHttp()
+			})
+		})
+	}
+}
+
+func TestRequest_Headers_ReplaceWithPathPattern_NoMatchSkipsReplace(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(configJSON(map[string]any{
+			"reqRules": []map[string]any{
+				{"operate": "replace", "headers": []map[string]any{
+					{"key": "X-Env", "newValue": "prod", "path_pattern": `^/prod/.*`},
+				}},
+			},
+		}))
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		// path does NOT match the pattern → the original value is preserved
+		require.Equal(t, types.ActionContinue, host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "test.com"},
+			{":path", "/test/api"},
+			{"x-env", "test"},
+		}))
+
+		got := headersToMap(host.GetRequestHeaders())
+		require.Equal(t, []string{"test"}, got["x-env"])
+		host.CompleteHttp()
+	})
+}
+
+func TestRequest_BodyJson_AddWithPathPattern_NoMatchSkipsAdd(t *testing.T) {
+	test.RunTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost(configJSON(map[string]any{
+			"reqRules": []map[string]any{
+				{"operate": "add", "body": []map[string]any{
+					{"key": "appId", "value": "ij2b6Nfg", "path_pattern": `^/test/.*`},
+				}},
+			},
+		}))
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		require.Equal(t, types.ActionContinue, host.CallOnHttpRequestHeaders([][2]string{
+			{":authority", "test.com"},
+			{":path", "/prod/api"},
+			{"content-type", "application/json"},
+		}))
+		require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{"a":1}`)))
+
+		// path does NOT match the pattern → body stays unchanged
+		require.JSONEq(t, `{"a":1}`, string(host.GetRequestBody()))
 		host.CompleteHttp()
 	})
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

In the `transformer` plugin, `host_pattern` / `path_pattern` were only used for regex capture-group substitution of the value: when the pattern did **not** match the current request, the `replace` / `add` / `append` operation was still executed with the literal value.

Because of this, configuring two `add` entries for the same header key guarded by different path patterns could never work: the first entry always added its literal value (even on non-matching paths), and the second entry was then skipped because the key already existed.

This PR makes a configured but non-matching pattern skip that transformation item entirely, for `replace` / `add` / `append` on headers, query params, and body (both kv and JSON handlers). This matches the documented semantics of the fields (“指定请求主机名/路径**匹配规则**” / “matching rule”) and enables per-host/per-path conditional transformations:

```yaml
reqRules:
- operate: add
  headers:
  - key: access-appId
    value: "ij2b6Nfg"
    path_pattern: "^/test/.*"   # now only takes effect on /test/**
  - key: access-appId
    value: "Y6JK5J7T"
    path_pattern: "^/prod/.*"   # now only takes effect on /prod/**
```

When the pattern matches, the original capture-group substitution behavior (`value: host-$1` etc.) is unchanged.

Docs (README.md / README_EN.md) are updated to state the new skip-on-no-match semantics.

**Behavior change note**: previously, an entry whose pattern did not match still executed with the raw literal value (e.g. a header would get the literal string `host-$1`). That value was almost never what users intended, and `TestRequest_Headers_AddWithPathPattern_NoMatchKeepsValue` (added in #3873 as characterization of existing behavior) has been updated accordingly to `..._NoMatchSkipsAdd`.

## Ⅱ. Does this pull request fix one issue?

fixes #4132

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Test cases are added:

- `TestRequest_Headers_AddSameKeyDifferentPathPatterns` — regression test for the exact scenario in #4132 (same key, different `path_pattern`s; verifies `/test/**` gets the first value, `/prod/**` gets the second, other paths get no header).
- `TestRequest_Headers_AddWithPathPattern_NoMatchSkipsAdd` — updated from `..._NoMatchKeepsValue` to pin the new skip semantics.
- `TestRequest_Headers_ReplaceWithPathPattern_NoMatchSkipsReplace` — non-matching `replace` preserves the original header value.
- `TestRequest_BodyJson_AddWithPathPattern_NoMatchSkipsAdd` — non-matching body `add` leaves the JSON body unchanged.
- `TestRequest_Headers_AddWithHostPattern` (existing) still passes — capture-group substitution on match is unchanged.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/transformer
go test ./...   # all tests pass, in both go and wasm (wazero) modes
GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o /tmp/transformer.wasm .   # builds cleanly
```

Locally verified with Go 1.24.4: full test suite passes (each test runs both as native Go and as a compiled wasm module under wazero via the `wasm-go/pkg/test` framework), and the plugin compiles to the wasip1/wasm target used by CI.

## Ⅴ. Special notes for reviews

- The gate applies whenever a pattern is configured, regardless of `value_type` — previously the regex was compiled but silently unused for non-string body values.
- `newReg` guarantees at most one of `hostReg`/`pathReg` is set, so `reg.matches` checks them in the same precedence order as `matchAndReplace`.
- `remove`/`rename`/`map`/`dedupe` are unaffected (patterns were never valid for them, consistent with the README).

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Tool: Claude Code (Anthropic)
>
> Prompt (translated from Chinese): "Review recent open issues of higress-group/higress, pick a worthwhile bug to fix, fix it following the project's contribution requirements, verify locally thoroughly, and submit a PR."
>
> The tool then selected issue #4132, located the root cause in `plugins/wasm-go/extensions/transformer/main.go` (`kvHandler.handle` / `jsonHandler.handle` treating `host_pattern`/`path_pattern` as value-substitution-only), implemented the skip-on-no-match gate, updated/added tests and docs, and ran the full test suite plus a wasip1/wasm build locally.

### AI Coding Summary

- **Key decisions**:
  - Treat a configured non-matching pattern as a condition that skips the transformation item, applied consistently to `replace`/`add`/`append` across headers/querys/body — this follows the README wording ("匹配规则"/"matching rule") and user expectation in #4132.
  - Apply the gate regardless of `value_type` in the JSON body handler (previously the compiled regex was silently ignored for non-string values).
  - Updated the characterization test `..._NoMatchKeepsValue` (from #3873) to the new semantics rather than keeping the old literal-value fallback, since the literal fallback (e.g. header value `host-$1`) was effectively a misconfiguration trap.
- **Major changes**: `reg.matches` helper in `main.go`; skip-gates in 6 operation branches (3 kv + 3 JSON); 3 new tests + 1 updated test; README/README_EN notes.
- **Considerations/limitations**: this is a deliberate behavior change for the non-matching-pattern case; users relying on the literal-value fallback (if any) would need to remove the pattern to keep unconditional execution.
