### PR TITLE
fix(mcpserver): honor remoteServerConfig.exportPath when generating rewrite rules

### DIFF
--- a/registry/nacos/mcpserver/watcher.go
+++ b/registry/nacos/mcpserver/watcher.go
@@ -507,6 +507,20 @@ func (w *watcher) processToolConfig(dataId, data string, credentials map[string]
 	return nil
 }
 
+// getExportPath returns the normalized upstream export path configured in
+// remoteServerConfig.exportPath, or "" if the export path is absent or root.
+// The result always has a leading "/" and never has a trailing "/".
+func getExportPath(server *provider.McpServer) string {
+	if server == nil || server.RemoteServerConfig == nil {
+		return ""
+	}
+	exportPath := strings.Trim(server.RemoteServerConfig.ExportPath, "/")
+	if exportPath == "" {
+		return ""
+	}
+	return "/" + exportPath
+}
+
 func (w *watcher) buildVirtualServiceForMcpServer(server *provider.McpServer, dataId, serviceName string, se *v1alpha3.ServiceEntry) *config.Config {
 	if server == nil {
 		return nil
@@ -532,6 +546,28 @@ func (w *watcher) buildVirtualServiceForMcpServer(server *provider.McpServer, da
 		mergePath = strings.TrimSuffix(w.McpServerBaseUrl, "/") + mergePath
 	}
 
+	exactMatch := &v1alpha3.HTTPMatchRequest{
+		Uri: &v1alpha3.StringMatch{
+			MatchType: &v1alpha3.StringMatch_Exact{
+				Exact: mergePath,
+			},
+		},
+	}
+	prefixMatch := &v1alpha3.HTTPMatchRequest{
+		Uri: &v1alpha3.StringMatch{
+			MatchType: &v1alpha3.StringMatch_Prefix{
+				Prefix: mergePath + "/",
+			},
+		},
+	}
+	newDestination := func() []*v1alpha3.HTTPRouteDestination {
+		return []*v1alpha3.HTTPRouteDestination{{
+			Destination: &v1alpha3.Destination{
+				Host: serviceName,
+			},
+		}}
+	}
+
 	vs := &v1alpha3.VirtualService{
 		Hosts:    hosts,
 		Gateways: gateways,
@@ -542,44 +578,55 @@ func (w *watcher) buildVirtualServiceForMcpServer(server *provider.McpServer, da
 			// Example:
 			// Assume mergePath=/mcp/test prefixRewrite=/ requestPath=/mcp/test/abc
 			// If we only use prefix match, the rewritten path will be //abc.
-			Match: []*v1alpha3.HTTPMatchRequest{
-				{
-					Uri: &v1alpha3.StringMatch{
-						MatchType: &v1alpha3.StringMatch_Exact{
-							Exact: mergePath,
-						},
-					},
-				},
-				{
-					Uri: &v1alpha3.StringMatch{
-						MatchType: &v1alpha3.StringMatch_Prefix{
-							Prefix: mergePath + "/",
-						},
-					},
-				},
-			},
-			Route: []*v1alpha3.HTTPRouteDestination{{
-				Destination: &v1alpha3.Destination{
-					Host: serviceName,
-				},
-			}},
+			Match: []*v1alpha3.HTTPMatchRequest{exactMatch, prefixMatch},
+			Route: newDestination(),
 		}},
 	}
 
 	// we should rewrite path for sse and streamble
 	if routeRewriteProtocols[server.Protocol] {
-		vs.Http[0].Rewrite = &v1alpha3.HTTPRewrite{
-			Uri: "/",
+		exportPath := getExportPath(server)
+		if exportPath == "" {
+			// "/" is the only rewrite URI that works for both the exact match
+			// (mergePath -> /) and the prefix match (mergePath + "/" + rest -> / + rest).
+			vs.Http[0].Rewrite = &v1alpha3.HTTPRewrite{
+				Uri: "/",
+			}
+		} else {
+			// With a non-root export path a single rewrite URI can no longer serve
+			// both matches: the prefix match strips mergePath + "/", so its rewrite
+			// needs a trailing "/" while the exact match must not have one.
+			// Split them into two routes, each with its own rewrite.
+			vs.Http = []*v1alpha3.HTTPRoute{
+				{
+					Name:  routeName,
+					Match: []*v1alpha3.HTTPMatchRequest{exactMatch},
+					Route: newDestination(),
+					Rewrite: &v1alpha3.HTTPRewrite{
+						Uri: exportPath,
+					},
+				},
+				{
+					Name:  routeName + "-prefix",
+					Match: []*v1alpha3.HTTPMatchRequest{prefixMatch},
+					Route: newDestination(),
+					Rewrite: &v1alpha3.HTTPRewrite{
+						Uri: exportPath + "/",
+					},
+				},
+			}
 		}
 	}
 	// we should rewrite host for dns service
 	if se != nil && se.Resolution == v1alpha3.ServiceEntry_DNS && len(se.Endpoints) > 0 {
-		if vs.Http[0].Rewrite == nil {
-			vs.Http[0].Rewrite = &v1alpha3.HTTPRewrite{
-				Authority: se.Endpoints[0].Address,
+		for _, httpRoute := range vs.Http {
+			if httpRoute.Rewrite == nil {
+				httpRoute.Rewrite = &v1alpha3.HTTPRewrite{
+					Authority: se.Endpoints[0].Address,
+				}
+			} else {
+				httpRoute.Rewrite.Authority = se.Endpoints[0].Address
 			}
-		} else {
-			vs.Http[0].Rewrite.Authority = se.Endpoints[0].Address
 		}
 	}
 
@@ -623,7 +670,11 @@ func (w *watcher) buildMcpServerForMcpServer(vs *v1alpha3.VirtualService, dataId
 	}
 	if mcpServerRewriteProtocols[protocol] {
 		mcpServer.EnablePathRewrite = true
-		mcpServer.PathRewritePrefix = "/"
+		if exportPath := getExportPath(server); exportPath != "" {
+			mcpServer.PathRewritePrefix = exportPath
+		} else {
+			mcpServer.PathRewritePrefix = "/"
+		}
 	}
 
 	mcpServerLog.Debugf("construct mcpserver %v", mcpServer)

--- a/registry/nacos/mcpserver/watcher_test.go
+++ b/registry/nacos/mcpserver/watcher_test.go
@@ -23,6 +23,7 @@ import (
 
 	apiv1 "github.com/alibaba/higress/v2/api/networking/v1"
 	common2 "github.com/alibaba/higress/v2/pkg/ingress/kube/common"
+	"github.com/alibaba/higress/v2/pkg/ingress/kube/mcpserver"
 	provider "github.com/alibaba/higress/v2/registry"
 	"github.com/alibaba/higress/v2/registry/memory"
 	"github.com/nacos-group/nacos-sdk-go/v2/model"
@@ -590,5 +591,127 @@ func Test_Watcher(t *testing.T) {
 				t.Errorf("dr is not equal, want %v\n, got %v", wantDr, dr)
 			}
 		})
+	}
+}
+
+func Test_GetExportPath(t *testing.T) {
+	testCases := []struct {
+		name   string
+		server *provider.McpServer
+		want   string
+	}{
+		{"nil server", nil, ""},
+		{"nil remote server config", &provider.McpServer{}, ""},
+		{"empty export path", &provider.McpServer{RemoteServerConfig: &provider.RemoteServerConfig{ExportPath: ""}}, ""},
+		{"root export path", &provider.McpServer{RemoteServerConfig: &provider.RemoteServerConfig{ExportPath: "/"}}, ""},
+		{"normal export path", &provider.McpServer{RemoteServerConfig: &provider.RemoteServerConfig{ExportPath: "/a/b/mcp"}}, "/a/b/mcp"},
+		{"no leading slash", &provider.McpServer{RemoteServerConfig: &provider.RemoteServerConfig{ExportPath: "a/b/mcp"}}, "/a/b/mcp"},
+		{"trailing slash", &provider.McpServer{RemoteServerConfig: &provider.RemoteServerConfig{ExportPath: "/a/b/mcp/"}}, "/a/b/mcp"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getExportPath(tc.server); got != tc.want {
+				t.Errorf("getExportPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func Test_BuildVirtualServiceForMcpServer_ExportPath(t *testing.T) {
+	tw := newTestWatcher(memory.NewCache(),
+		WithMcpExportDomains([]string{"mcp.com"}),
+		WithMcpBaseUrl("/mcp-servers/"))
+	w := &tw.watcher
+
+	exportPath := "/9/260bd0ed-10d8-4a8f-9b65-332cd1331fa1/mcp"
+	server := &provider.McpServer{
+		Name:     "moji222",
+		Protocol: provider.McpStreamableProtocol,
+		RemoteServerConfig: &provider.RemoteServerConfig{
+			ExportPath: exportPath,
+		},
+	}
+
+	cfg := w.buildVirtualServiceForMcpServer(server, "mock-data-id", "svc.public.nacos", nil)
+	vs := cfg.Spec.(*v1alpha3.VirtualService)
+
+	if len(vs.Http) != 2 {
+		t.Fatalf("expect 2 http routes (exact + prefix), got %d", len(vs.Http))
+	}
+
+	exactRoute, prefixRoute := vs.Http[0], vs.Http[1]
+	if got := exactRoute.Match[0].Uri.GetExact(); got != "/mcp-servers/moji222" {
+		t.Errorf("exact match = %q, want %q", got, "/mcp-servers/moji222")
+	}
+	if exactRoute.Rewrite == nil || exactRoute.Rewrite.Uri != exportPath {
+		t.Errorf("exact route rewrite = %v, want uri %q", exactRoute.Rewrite, exportPath)
+	}
+	if got := prefixRoute.Match[0].Uri.GetPrefix(); got != "/mcp-servers/moji222/" {
+		t.Errorf("prefix match = %q, want %q", got, "/mcp-servers/moji222/")
+	}
+	if prefixRoute.Rewrite == nil || prefixRoute.Rewrite.Uri != exportPath+"/" {
+		t.Errorf("prefix route rewrite = %v, want uri %q", prefixRoute.Rewrite, exportPath+"/")
+	}
+
+	// dns service should get the authority rewrite on every route
+	se := &v1alpha3.ServiceEntry{
+		Resolution: v1alpha3.ServiceEntry_DNS,
+		Endpoints:  []*v1alpha3.WorkloadEntry{{Address: "example.com"}},
+	}
+	cfg = w.buildVirtualServiceForMcpServer(server, "mock-data-id", "svc.public.nacos", se)
+	vs = cfg.Spec.(*v1alpha3.VirtualService)
+	for i, route := range vs.Http {
+		if route.Rewrite == nil || route.Rewrite.Authority != "example.com" {
+			t.Errorf("route[%d] authority rewrite = %v, want %q", i, route.Rewrite, "example.com")
+		}
+	}
+
+	// without export path the original single-route "/" rewrite is preserved
+	server.RemoteServerConfig.ExportPath = ""
+	cfg = w.buildVirtualServiceForMcpServer(server, "mock-data-id", "svc.public.nacos", nil)
+	vs = cfg.Spec.(*v1alpha3.VirtualService)
+	if len(vs.Http) != 1 {
+		t.Fatalf("expect 1 http route without export path, got %d", len(vs.Http))
+	}
+	if vs.Http[0].Rewrite == nil || vs.Http[0].Rewrite.Uri != "/" {
+		t.Errorf("rewrite = %v, want uri %q", vs.Http[0].Rewrite, "/")
+	}
+	if len(vs.Http[0].Match) != 2 {
+		t.Errorf("expect 2 matches on single route, got %d", len(vs.Http[0].Match))
+	}
+}
+
+func Test_BuildMcpServerForMcpServer_ExportPath(t *testing.T) {
+	tw := newTestWatcher(memory.NewCache(),
+		WithMcpExportDomains([]string{"mcp.com"}),
+		WithMcpBaseUrl("/mcp-servers/"))
+	w := &tw.watcher
+
+	server := &provider.McpServer{
+		Name:     "moji222",
+		Protocol: provider.McpSSEProtocol,
+		RemoteServerConfig: &provider.RemoteServerConfig{
+			ExportPath: "/a/b/mcp",
+		},
+	}
+
+	vsCfg := w.buildVirtualServiceForMcpServer(server, "mock-data-id", "svc.public.nacos", nil)
+	vs := vsCfg.Spec.(*v1alpha3.VirtualService)
+	cfg := w.buildMcpServerForMcpServer(vs, "mock-data-id", server)
+	mcpSrv := cfg.Spec.(*mcpserver.McpServer)
+	if !mcpSrv.EnablePathRewrite {
+		t.Error("EnablePathRewrite should be true for sse protocol")
+	}
+	if mcpSrv.PathRewritePrefix != "/a/b/mcp" {
+		t.Errorf("PathRewritePrefix = %q, want %q", mcpSrv.PathRewritePrefix, "/a/b/mcp")
+	}
+
+	server.RemoteServerConfig.ExportPath = ""
+	vsCfg = w.buildVirtualServiceForMcpServer(server, "mock-data-id", "svc.public.nacos", nil)
+	vs = vsCfg.Spec.(*v1alpha3.VirtualService)
+	cfg = w.buildMcpServerForMcpServer(vs, "mock-data-id", server)
+	mcpSrv = cfg.Spec.(*mcpserver.McpServer)
+	if mcpSrv.PathRewritePrefix != "/" {
+		t.Errorf("PathRewritePrefix = %q, want %q", mcpSrv.PathRewritePrefix, "/")
 	}
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

When a Nacos MCP server of protocol `mcp-sse` / `mcp-streamable` is configured with a non-root `remoteServerConfig.exportPath` (e.g. `/9/260bd0ed-.../mcp`), the controller-generated VirtualService always rewrote the URI to `/`:

```yaml
rewrite: {uri: "/", authority: "xxx"}
```

so the proxied request lost the upstream path prefix (`POST /mcp/moji222` was forwarded to `https://upstream:443/` instead of `https://upstream:443/9/260bd0ed-.../mcp`), and upstreams without a root route returned 503 (`upstream_reset_before_response_started{connection_termination}`).

This PR derives the rewrite from `remoteServerConfig.exportPath`:

- **`buildVirtualServiceForMcpServer`**: when a non-root export path is configured, the previously shared exact + prefix matches are split into two HTTP routes, each with its own rewrite:
  - exact match `mergePath` → rewrite `exportPath`
  - prefix match `mergePath + "/"` → rewrite `exportPath + "/"`

  The split is necessary because `/` was the only rewrite URI that worked for both matches in a single route (Envoy swaps the matched prefix with the rewrite string; with a non-root path the prefix-match rewrite needs a trailing `/` while the exact-match one must not have it). Without an export path the original single-route `/` rewrite is preserved unchanged.
- **`buildMcpServerForMcpServer`**: the SSE `PathRewritePrefix` also honors `exportPath` (previously hardcoded `/`).
- The DNS authority rewrite is now applied to every generated route.
- `getExportPath` normalizes the configured value (guarantees a leading `/`, strips trailing `/`, returns `""` for absent/root paths).

## Ⅱ. Does this pull request fix one issue?

fixes #4006

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Unit tests are added in `registry/nacos/mcpserver/watcher_test.go`:

- `Test_GetExportPath` — normalization table test (nil configs, empty, root, missing leading slash, trailing slash).
- `Test_BuildVirtualServiceForMcpServer_ExportPath` — verifies the two-route split with the exact/prefix rewrites (using the reproduction values from #4006), the DNS authority rewrite applied to both routes, and that the original single-route `/` rewrite shape is preserved when no export path is set.
- `Test_BuildMcpServerForMcpServer_ExportPath` — verifies SSE `PathRewritePrefix` uses the export path, and falls back to `/` without one.

The existing end-to-end `Test_Watcher` cases (empty `exportPath`) pass unchanged, confirming no behavior change for the common case.

## Ⅳ. Describe how to verify it

```bash
make prebuild   # or: git submodule update --init && ./tools/hack/prebuild.sh
go test ./registry/nacos/mcpserver/...
```

All tests pass locally (Go 1.24.4). Functional verification: configure a Nacos MCP server with `protocol: mcp-streamable` and `remoteServerConfig.exportPath: /9/xxx/mcp`, then check the generated VirtualService — the exact-match route rewrites to `/9/xxx/mcp` and the prefix-match route to `/9/xxx/mcp/`, so `POST /mcp/<name>` reaches the upstream's real endpoint.

## Ⅴ. Special notes for reviews

- `buildMcpServerForMcpServer` keeps reading the exact match from `vs.Http[0]`, which holds the exact match in both the single-route and split shapes.
- The prefix-match route gets a distinct route name (`<routeName>-prefix`) to keep Envoy route names unique.
- A pre-existing `go vet` warning in `newTestWatcher` (lock copy, `watcher_test.go`) is untouched — it predates this change.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Tool: Claude Code (Anthropic)
>
> Prompt (translated from Chinese): "Review recent open issues of higress-group/higress, pick worthwhile bugs to fix, fix them following the project's contribution requirements, verify locally thoroughly, and submit PRs."
>
> The tool selected issue #4006, located the hardcoded `/` rewrite in `registry/nacos/mcpserver/watcher.go` (`buildVirtualServiceForMcpServer` / `buildMcpServerForMcpServer`), implemented the export-path-aware rewrite with the exact/prefix route split, added unit tests, and ran the package test suite locally after `prebuild`.

### AI Coding Summary

- **Key decisions**:
  - Split into two routes when a non-root export path is set, because Envoy's prefix rewrite semantics make a single rewrite URI incorrect for either the exact or the prefix match (only `/` works for both). The no-export-path shape is preserved byte-for-byte for compatibility.
  - Normalize `exportPath` (leading `/` added, trailing `/` trimmed) so `a/b/`, `/a/b`, `/a/b/` all behave identically.
  - Apply the DNS authority rewrite across all generated routes instead of only the first.
- **Major changes**: `getExportPath` helper; route-split logic in `buildVirtualServiceForMcpServer`; export-path-aware `PathRewritePrefix` in `buildMcpServerForMcpServer`; 3 new unit tests.
- **Considerations/limitations**: only the Nacos MCP-server watcher is touched; the same exportPath semantics for other registries (if added later) would need the same treatment.
