### PR TITLE
fix(mcp): keep object-typed tool args whose schema carries a required array

### DIFF
--- a/plugins/wasm-go/pkg/mcp/server/rest_server.go
+++ b/plugins/wasm-go/pkg/mcp/server/rest_server.go
@@ -50,9 +50,43 @@ type RestToolArg struct {
 	Items interface{} `json:"items,omitempty"`
 	// For object type
 	Properties interface{} `json:"properties,omitempty"`
+	// For object type: required nested properties (the object schema's own
+	// "required" array in raw JSON Schema, renamed to avoid the conflict with
+	// the boolean "required" above)
+	ObjectRequired []string `json:"objectRequired,omitempty"`
 	// Position specifies where the argument should be placed in the request
 	// Valid values: query, path, header, cookie, body
 	Position string `json:"position,omitempty"`
+}
+
+// UnmarshalJSON accepts both meanings of the "required" key: the boolean of
+// this DSL (argument is required), and the string array of raw JSON Schema
+// object schemas (required nested properties), which lands in ObjectRequired.
+// This keeps configs that paste raw JSON Schema object parameters working
+// instead of failing the whole tool config parse.
+func (a *RestToolArg) UnmarshalJSON(data []byte) error {
+	type restToolArgAlias RestToolArg
+	tmp := &struct {
+		Required json.RawMessage `json:"required,omitempty"`
+		*restToolArgAlias
+	}{restToolArgAlias: (*restToolArgAlias)(a)}
+	if err := json.Unmarshal(data, tmp); err != nil {
+		return err
+	}
+	if len(tmp.Required) == 0 {
+		return nil
+	}
+	var requiredBool bool
+	if err := json.Unmarshal(tmp.Required, &requiredBool); err == nil {
+		a.Required = requiredBool
+		return nil
+	}
+	var requiredList []string
+	if err := json.Unmarshal(tmp.Required, &requiredList); err == nil {
+		a.ObjectRequired = requiredList
+		return nil
+	}
+	return fmt.Errorf("invalid \"required\" value %s: expect boolean or string array", string(tmp.Required))
 }
 
 // RestToolHeader represents an HTTP header
@@ -986,6 +1020,11 @@ func (t *RestMCPTool) InputSchema() map[string]any {
 		// Add properties for object type
 		if argType == "object" && arg.Properties != nil {
 			argSchema["properties"] = arg.Properties
+		}
+
+		// Add required nested properties for object type
+		if argType == "object" && len(arg.ObjectRequired) > 0 {
+			argSchema["required"] = arg.ObjectRequired
 		}
 
 		properties[arg.Name] = argSchema

--- a/plugins/wasm-go/pkg/mcp/server/rest_server_test.go
+++ b/plugins/wasm-go/pkg/mcp/server/rest_server_test.go
@@ -1295,3 +1295,63 @@ func TestHasContentType_CaseAndCharsetSuffix(t *testing.T) {
 var _ = url.Parse
 var _ = sjson.Set
 var _ = strings.TrimSpace
+
+// Regression test for https://github.com/higress-group/higress/issues/4004:
+// an object-typed argument carrying a raw JSON Schema "required" array must
+// parse successfully and expose the nested required list in the input schema.
+func TestRestToolArgObjectRequired(t *testing.T) {
+	toolJSON := `{
+		"name": "queryListCgHead",
+		"description": "query with paging",
+		"args": [
+			{
+				"name": "pageQuery",
+				"description": "paging parameters",
+				"type": "object",
+				"properties": {
+					"pageNum": {"type": "integer", "description": "page number", "default": 1},
+					"pageSize": {"type": "integer", "description": "page size", "default": 10}
+				},
+				"required": ["pageNum", "pageSize"]
+			},
+			{
+				"name": "keyword",
+				"type": "string",
+				"required": true
+			}
+		]
+	}`
+
+	var tool RestTool
+	require.NoError(t, json.Unmarshal([]byte(toolJSON), &tool))
+	require.Len(t, tool.Args, 2)
+
+	pageQuery := tool.Args[0]
+	assert.Equal(t, "object", pageQuery.Type)
+	assert.False(t, pageQuery.Required, "object-level required array must not mark the arg itself required")
+	assert.Equal(t, []string{"pageNum", "pageSize"}, pageQuery.ObjectRequired)
+	assert.NotNil(t, pageQuery.Properties)
+
+	keyword := tool.Args[1]
+	assert.True(t, keyword.Required)
+	assert.Nil(t, keyword.ObjectRequired)
+
+	mcpTool := RestMCPTool{toolConfig: tool}
+	schema := mcpTool.InputSchema()
+
+	properties, ok := schema["properties"].(map[string]interface{})
+	require.True(t, ok)
+	pageQuerySchema, ok := properties["pageQuery"].(map[string]interface{})
+	require.True(t, ok, "pageQuery must be present in the input schema")
+	assert.NotNil(t, pageQuerySchema["properties"])
+	assert.Equal(t, []string{"pageNum", "pageSize"}, pageQuerySchema["required"])
+
+	// top-level required only contains the boolean-required arg
+	assert.Equal(t, []string{"keyword"}, schema["required"])
+}
+
+func TestRestToolArgRequiredInvalidValue(t *testing.T) {
+	var arg RestToolArg
+	err := json.Unmarshal([]byte(`{"name": "a", "required": 123}`), &arg)
+	require.Error(t, err)
+}

--- a/registry/mcp_model.go
+++ b/registry/mcp_model.go
@@ -14,6 +14,11 @@
 
 package registry
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 const (
 	JsonGoTemplateType = "json-go-template"
 
@@ -77,7 +82,43 @@ type ToolArgs struct {
 	Enum        []interface{} `json:"enum,omitempty"`
 	Items       interface{}   `json:"items,omitempty"`
 	Properties  interface{}   `json:"properties,omitempty"`
-	Position    string        `json:"position,omitempty"`
+	// ObjectRequired lists the required nested properties when Type is "object".
+	// In raw JSON Schema this is the object schema's own "required" array, which
+	// conflicts with the boolean "required" of this DSL, so it is stored under a
+	// dedicated key.
+	ObjectRequired []string `json:"objectRequired,omitempty"`
+	Position       string   `json:"position,omitempty"`
+}
+
+// UnmarshalJSON accepts both meanings of the "required" key: the boolean of
+// this DSL (argument is required), and the string array of raw JSON Schema
+// object schemas (required nested properties), which lands in ObjectRequired.
+// Without this, tools imported from Nacos whose inputSchema contains an
+// object-typed parameter with a "required" array would fail to parse and the
+// whole parameter would be dropped.
+func (a *ToolArgs) UnmarshalJSON(data []byte) error {
+	type toolArgsAlias ToolArgs
+	tmp := &struct {
+		Required json.RawMessage `json:"required,omitempty"`
+		*toolArgsAlias
+	}{toolArgsAlias: (*toolArgsAlias)(a)}
+	if err := json.Unmarshal(data, tmp); err != nil {
+		return err
+	}
+	if len(tmp.Required) == 0 {
+		return nil
+	}
+	var requiredBool bool
+	if err := json.Unmarshal(tmp.Required, &requiredBool); err == nil {
+		a.Required = requiredBool
+		return nil
+	}
+	var requiredList []string
+	if err := json.Unmarshal(tmp.Required, &requiredList); err == nil {
+		a.ObjectRequired = requiredList
+		return nil
+	}
+	return fmt.Errorf("invalid \"required\" value %s: expect boolean or string array", string(tmp.Required))
 }
 
 type RequestTemplate struct {

--- a/registry/nacos/mcpserver/watcher_test.go
+++ b/registry/nacos/mcpserver/watcher_test.go
@@ -15,6 +15,7 @@
 package mcpserver
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -590,5 +591,50 @@ func Test_Watcher(t *testing.T) {
 				t.Errorf("dr is not equal, want %v\n, got %v", wantDr, dr)
 			}
 		})
+	}
+}
+
+// Regression test for https://github.com/higress-group/higress/issues/4004:
+// an object-typed inputSchema parameter whose sub-schema carries a JSON Schema
+// "required" array used to fail parseMcpArgs (array vs bool) and be dropped.
+func Test_ParseMcpArgs_ObjectWithNestedRequired(t *testing.T) {
+	rawSchema := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(`{
+		"type": "object",
+		"description": "paging parameters",
+		"properties": {
+			"pageNum": {"type": "integer", "description": "page number", "default": 1},
+			"pageSize": {"type": "integer", "description": "page size", "default": 10}
+		},
+		"required": ["pageNum", "pageSize"]
+	}`), &rawSchema); err != nil {
+		t.Fatal(err)
+	}
+
+	args, err := parseMcpArgs(rawSchema)
+	if err != nil {
+		t.Fatalf("parseMcpArgs should accept object schema with nested required array, got error: %v", err)
+	}
+	if args.Type != "object" {
+		t.Errorf("Type = %q, want %q", args.Type, "object")
+	}
+	if args.Properties == nil {
+		t.Error("Properties should be preserved")
+	}
+	if args.Required {
+		t.Error("nested required array must not mark the arg itself required")
+	}
+	if !reflect.DeepEqual(args.ObjectRequired, []string{"pageNum", "pageSize"}) {
+		t.Errorf("ObjectRequired = %v, want [pageNum pageSize]", args.ObjectRequired)
+	}
+
+	// boolean required keeps working
+	boolSchema := map[string]interface{}{"type": "string", "required": true}
+	args, err = parseMcpArgs(boolSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !args.Required {
+		t.Error("boolean required should be preserved")
 	}
 }


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

When Higress reads MCP tool configuration from Nacos, an `inputSchema` parameter of `type: object` is a raw JSON Schema sub-schema, so it may carry its own `"required": ["pageNum", "pageSize"]` **array**. The Higress args DSL, however, reuses the `required` key as a **boolean** ("this argument is required"). As a result:

```
json: cannot unmarshal array into Go struct field ToolArgs.required of type bool
```

`parseMcpArgs` returned this error and the watcher silently dropped the **whole parameter** — `tools/list` then exposed an `inputSchema` where the object parameter (e.g. `pageQuery`) was completely missing, along with its nested `properties` and `required` declarations. This is exactly the behavior reported in #4004.

This PR makes both ends of the pipeline accept either form of `required`:

- **`registry/mcp_model.go` (`ToolArgs`)**: custom `UnmarshalJSON` — a boolean keeps its existing meaning; a string array is stored in the new `objectRequired` field. Any other type is a proper error.
- **`plugins/wasm-go/pkg/mcp/server/rest_server.go` (`RestToolArg`)**: same lenient unmarshal (so hand-written WasmPlugin configs that paste raw JSON Schema object parameters also work), plus `RestMCPTool.InputSchema()` now emits `objectRequired` back as the object schema's `required` list in `tools/list`.

End-to-end result for the #4004 reproduction: `pageQuery` is preserved with its nested `properties` **and** its `required: ["pageNum", "pageSize"]` declaration, and top-level boolean `required` semantics are unchanged.

## Ⅱ. Does this pull request fix one issue?

fixes #4004

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Test cases are added on both sides:

- `Test_ParseMcpArgs_ObjectWithNestedRequired` (`registry/nacos/mcpserver/watcher_test.go`) — uses the exact `pageQuery` schema from #4004; verifies the parameter is no longer dropped, `properties` survives, the nested required array lands in `ObjectRequired`, and boolean `required` still parses.
- `TestRestToolArgObjectRequired` (`plugins/wasm-go/pkg/mcp/server/rest_server_test.go`) — unmarshals a tool JSON mixing an object arg with a `required` array and a string arg with `required: true`, then checks `InputSchema()` output: `pageQuery.required = ["pageNum","pageSize"]` nested in the object schema, top-level `required = ["keyword"]` only.
- `TestRestToolArgRequiredInvalidValue` — a non-bool/non-array `required` value still fails loudly.

## Ⅳ. Describe how to verify it

```bash
# controller side
go test ./registry/nacos/mcpserver/...
# wasm mcp-server SDK side
cd plugins/wasm-go/pkg/mcp && go test ./...
```

Both suites pass locally (Go 1.24.4). Functional verification: import an HTTP-TO-MCP service into Nacos whose tool has an object parameter with nested `required` (as in #4004), point a McpBridge at it, and call `tools/list` through the gateway — the object parameter and its `required` list are now present.

## Ⅴ. Special notes for reviews

- The wire format between controller and wasm plugin gains one optional key (`objectRequired`); old configs without it behave exactly as before, and old plugins simply ignore the unknown key, so the change is compatible in both directions.
- `Required` stays a plain `bool` everywhere — no consumer of the existing field changes behavior.
- The nested `required` of deeper levels (objects inside `properties` of an object arg) already survived via the opaque `properties` passthrough; only the top level of the arg sub-schema had the collision.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Tool: Claude Code (Anthropic)
>
> Prompt (translated from Chinese): "Review recent open issues of higress-group/higress, pick worthwhile bugs to fix, fix them following the project's contribution requirements, verify locally thoroughly, and submit PRs."
>
> The tool selected issue #4004, reproduced the root cause with a standalone Go program (`json: cannot unmarshal array into Go struct field ToolArgs.required of type bool`), traced the config pipeline (Nacos inputSchema → `parseMcpArgs`/`ToolArgs` → WasmPlugin config → `RestToolArg` → `InputSchema()`), implemented the dual-form `required` handling on both ends, and ran both packages' test suites locally.

### AI Coding Summary

- **Key decisions**:
  - Store the object schema's required array under a dedicated `objectRequired` key rather than overloading `required` on the wire, because a single JSON key cannot carry both the DSL boolean and the JSON Schema array (an arg can legitimately need both).
  - Implement the lenient unmarshal symmetrically on `RestToolArg` too, so raw-JSON-Schema-style hand-written configs don't fail the whole tool parse either.
  - Reject non-bool/non-array `required` values with an explicit error instead of silently ignoring them.
- **Major changes**: custom `UnmarshalJSON` on `ToolArgs` and `RestToolArg`; new `ObjectRequired` field on both; `InputSchema()` emits nested `required`; 3 new tests.
- **Considerations/limitations**: `higress-console`'s MCP config editor is unaware of `objectRequired` (it doesn't need to be — the controller derives it from the raw schema); deeper-nested `required` arrays inside `properties` were already passed through opaquely and are unaffected.
