### PR TITLE
fix(ai-cache): enable semantic cache by default when a vector provider is configured

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/config/config.go
+++ b/plugins/wasm-go/extensions/ai-cache/config/config.go
@@ -90,10 +90,12 @@ func (c *PluginConfig) FromJson(json gjson.Result, log log.Log) {
 
 	if json.Get("enableSemanticCache").Exists() {
 		c.EnableSemanticCache = json.Get("enableSemanticCache").Bool()
-	} else if c.GetVectorProvider() == nil {
-		c.EnableSemanticCache = false // set value to false when no vector provider
 	} else {
-		c.EnableSemanticCache = true // set default value to true
+		// The vector provider instance is only created later in Complete(), so
+		// checking GetVectorProvider() here always saw nil and silently disabled
+		// semantic cache even when a vector provider was configured (e.g.
+		// cache + vector). Check the parsed provider config instead.
+		c.EnableSemanticCache = c.vectorProviderConfig.GetProviderType() != ""
 	}
 
 	// compatible with legacy config

--- a/plugins/wasm-go/extensions/ai-cache/main_test.go
+++ b/plugins/wasm-go/extensions/ai-cache/main_test.go
@@ -135,6 +135,34 @@ var vectorOnlyConfig = func() json.RawMessage {
 	return data
 }()
 
+// 测试配置：cache + vector 组合，未显式配置 enableSemanticCache（issue #3880 场景）
+var cacheAndVectorConfig = func() json.RawMessage {
+	data, _ := json.Marshal(map[string]interface{}{
+		"cache": map[string]interface{}{
+			"type":        "redis",
+			"serviceName": "redis.static",
+			"servicePort": 6379,
+		},
+		"embedding": map[string]interface{}{
+			"type":        "dashscope",
+			"serviceName": "dashscope-service",
+			"serviceHost": "dashscope.example.com",
+			"servicePort": 8080,
+			"model":       "text-embedding-v1",
+			"apiKey":      "test-dashscope-key",
+		},
+		"vector": map[string]interface{}{
+			"type":         "dashvector",
+			"serviceName":  "dashvector-service",
+			"serviceHost":  "dashvector.example.com",
+			"servicePort":  8081,
+			"apiKey":       "test-dashvector-key",
+			"collectionID": "test-collection",
+		},
+	})
+	return data
+}()
+
 // 测试配置：禁用缓存策略
 var disabledCacheConfig = func() json.RawMessage {
 	data, _ := json.Marshal(map[string]interface{}{
@@ -320,7 +348,26 @@ func TestParseConfig(t *testing.T) {
 
 			// 验证缓存键策略
 			require.Equal(t, "lastQuestion", config.CacheKeyStrategy)
-			require.False(t, config.EnableSemanticCache)
+			// 配置了向量数据库时，语义化缓存默认开启
+			require.True(t, config.EnableSemanticCache)
+		})
+
+		// 测试 cache + vector 组合、未显式配置 enableSemanticCache 时语义化缓存默认开启
+		// 回归测试：https://github.com/higress-group/higress/issues/3880
+		t.Run("cache and vector config defaults semantic cache enabled", func(t *testing.T) {
+			host, status := test.NewTestHost(cacheAndVectorConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			configRaw, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			require.NotNil(t, configRaw)
+
+			config, ok := configRaw.(*config.PluginConfig)
+			require.True(t, ok, "config should be of type *PluginConfig")
+
+			require.True(t, config.EnableSemanticCache,
+				"semantic cache should default to enabled when a vector provider is configured")
 		})
 
 		// 测试禁用缓存策略


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

The docs describe the `vector (+ embedding) + cache` combination as "enable semantic caching and use the cache service to store LLM responses". In practice, when both `cache` and `vector` were configured **without** an explicit `enableSemanticCache`, only the exact-key cache worked — the vector database was never queried and never written.

Root cause: `PluginConfig.FromJson` decided the `enableSemanticCache` default like this:

```go
} else if c.GetVectorProvider() == nil {
    c.EnableSemanticCache = false // set value to false when no vector provider
} else {
    c.EnableSemanticCache = true
}
```

But `GetVectorProvider()` returns the provider **instance**, which is only created later in `Complete()` — during `FromJson` it is always `nil`. So the intended "default to true when a vector provider is configured" branch was unreachable, and semantic cache silently defaulted to `false`. Downstream effects (as analyzed in #3880):

1. On a cache miss, `handleCacheResponse` skipped `performSimilaritySearch` (`useSimilaritySearch && c.EnableSemanticCache` failed), so the vector DB was never queried.
2. Because the query phase never ran the embedding path, `CACHE_KEY_EMBEDDING_KEY` was never set, and `uploadEmbeddingAndAnswer` returned early in the response phase — so the vector DB was never populated either.

Fix: decide the default from the parsed provider **config** (`c.vectorProviderConfig.GetProviderType() != ""`), which is available at `FromJson` time. Explicit `enableSemanticCache: true/false` continues to override; cache-only / embedding-only setups keep defaulting to `false`.

## Ⅱ. Does this pull request fix one issue?

fixes #3880

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Tests updated/added in `main_test.go`:

- New fixture + subtest `cache and vector config defaults semantic cache enabled` — the exact #3880 scenario (cache + embedding + vector, no explicit `enableSemanticCache`) now defaults to `true`.
- `vector only config` subtest updated from `require.False` to `require.True` — the previous assertion had pinned the buggy always-false behavior.
- All other default cases (`basic redis config`, `minimal config`, `cache only config`, `embedding only config`) still assert `false`, and `complete config` (explicit `true`) is unchanged — verifying no behavior change outside the intended one.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/ai-cache
go test ./...   # all tests pass, in both go and wasm (wazero) modes
GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o /tmp/ai-cache.wasm .
```

Verified locally with Go 1.24.4. Functional verification: configure `cache` + `embedding` + `vector` without `enableSemanticCache`, send two semantically similar but non-identical questions — the second request now performs the similarity search (and the first response is uploaded to the vector DB), instead of only exact-key Redis lookups.

## Ⅴ. Special notes for reviews

- This is a behavior change only for the case "vector provider configured + `enableSemanticCache` not set", which per the README was already documented/intended to be `true`. Users who want the old effective behavior can set `enableSemanticCache: false` explicitly.
- `GetVectorProvider()` remains correct for use after `Complete()`; only the parse-time call was invalid.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

> Tool: Claude Code (Anthropic)
>
> Prompt (translated from Chinese): "Review recent open issues of higress-group/higress, pick worthwhile bugs to fix, fix them following the project's contribution requirements, verify locally thoroughly, and submit PRs."
>
> The tool selected issue #3880, verified the reporter's analysis against `core.go` (`handleCacheResponse` → `performSimilaritySearch` gating and `uploadEmbeddingAndAnswer`'s dependency on `CACHE_KEY_EMBEDDING_KEY`), then located the actual root cause one level up: the parse-time `GetVectorProvider()` nil check in `config.go`. Implemented the one-line-equivalent fix, updated the characterization test, added a regression test, and ran the full plugin suite plus a wasip1 build locally.

### AI Coding Summary

- **Key decisions**:
  - Fix the default-decision at its root (parse-time check of the provider **config** instead of the not-yet-created provider **instance**) rather than patching the downstream symptoms in `core.go`, which are all correct once `EnableSemanticCache` has the intended value.
  - Update the `vector only config` characterization test to the intended semantics instead of preserving the pinned buggy behavior.
- **Major changes**: one conditional in `config.go`; 1 updated + 1 new test with a new fixture.
- **Considerations/limitations**: behavior change is limited to configs with a vector provider and no explicit `enableSemanticCache`; explicit settings always win.
