### PR TITLE
docs: add CNCF incubation review artifacts

### DIFF
--- a/.github/ISSUE_TEMPLATE/non--crash-security--bug.md
+++ b/.github/ISSUE_TEMPLATE/non--crash-security--bug.md
@@ -7,10 +7,14 @@ assignees: ''
 
 ---
 
-**If you are reporting *any* crash or *any* potential security issue, *do not*
-open an issue in this repo. Please report the issue via [ASRC](https://security.alibaba.com/)(Alibaba Security Response Center) where the issue will be triaged appropriately.**
+**If you are reporting a potential security issue, do not open a public issue.
+You must submit the same substantive report through both
+[GitHub Private Security Advisories](https://github.com/higress-group/higress/security/advisories/new)
+and the [Alibaba Security Response Center](https://security.alibaba.com/), as
+required by the project's [security policy](https://github.com/higress-group/higress/blob/main/SECURITY.md).
+A crash with no suspected security impact may be reported with this template.**
 
-- [ ] I have searched the [issues](https://github.com/alibaba/higress/issues) of this repository and believe that this is not a duplicate.
+- [ ] I have searched the [issues](https://github.com/higress-group/higress/issues) of this repository and believe that this is not a duplicate.
 
 ### Ⅰ. Issue Description
 

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -12,11 +12,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [main]
   schedule:
-    - cron: '36 19 * * *'
-  workflow_dispatch: ~
+    - cron: '36 19 * * 6'
 
 jobs:
   analyze:
@@ -41,7 +38,7 @@ jobs:
 
       # step 2: Initializes the CodeQL tools for scanning.
       - name: "Initialize CodeQL"
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +50,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: "Autobuild"
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@v2
 
       # step 4
       # ℹ️ Command-line programs to run using the OS shell.
@@ -69,4 +66,4 @@ jobs:
 
       # step 5
       - name: "Perform CodeQL Analysis"
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -12,8 +12,11 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [main]
   schedule:
-    - cron: '36 19 * * 6'
+    - cron: '36 19 * * *'
+  workflow_dispatch: ~
 
 jobs:
   analyze:
@@ -38,7 +41,7 @@ jobs:
 
       # step 2: Initializes the CodeQL tools for scanning.
       - name: "Initialize CodeQL"
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +53,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: "Autobuild"
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       # step 4
       # ℹ️ Command-line programs to run using the OS shell.
@@ -66,4 +69,4 @@ jobs:
 
       # step 5
       - name: "Perform CodeQL Analysis"
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,0 +1,78 @@
+# Higress Community
+
+This document is the authoritative inventory of official Higress project
+communication channels, including channels used by its subprojects. Official
+technical and governance decisions are recorded in public GitHub issues,
+discussions, pull requests, or published meeting notes.
+
+## Public channels
+
+| Channel | Scope and purpose |
+| --- | --- |
+| [GitHub Issues](https://github.com/higress-group/higress/issues) | Bug reports, feature requests, and work tracking for the primary repository |
+| [GitHub Pull Requests](https://github.com/higress-group/higress/pulls) | Public change proposals, reviews, and decision records |
+| [GitHub Discussions](https://github.com/higress-group/higress/discussions) | User questions, ideas, announcements, and longer-form community discussion |
+| [Discord](https://discord.gg/tSbww9VDaM) | Public real-time user and contributor chat; decisions arising there must be recorded on GitHub |
+| [Higress mailing list](mailto:higress@googlegroups.com) | Community questions and contributor contact by email |
+| [Chinese-language community group](./README_ZH.md#%E4%BA%A4%E6%B5%81%E7%BE%A4) | Publicly advertised Chinese-language user and contributor chat |
+| [Higress WeChat Official Account](./README_ZH.md#%E6%8A%80%E6%9C%AF%E5%88%86%E4%BA%AB) | Chinese-language technical articles and project announcements; broadcast rather than a decision channel |
+| [Higress website and documentation](https://higress.cn/en/) | Published user and contributor documentation and project announcements |
+
+Each subproject uses its own public GitHub issues and pull requests for work
+specific to that repository:
+
+| Subproject | Issues | Pull requests |
+| --- | --- | --- |
+| `higress-console` | [Issues](https://github.com/higress-group/higress-console/issues) | [Pull requests](https://github.com/higress-group/higress-console/pulls) |
+| `higress-standalone` | [Issues](https://github.com/higress-group/higress-standalone/issues) | [Pull requests](https://github.com/higress-group/higress-standalone/pulls) |
+| `plugin-server` | [Issues](https://github.com/higress-group/plugin-server/issues) | [Pull requests](https://github.com/higress-group/plugin-server/pulls) |
+| `wasm-go` | [Issues](https://github.com/higress-group/wasm-go/issues) | [Pull requests](https://github.com/higress-group/wasm-go/pulls) |
+
+Cross-subproject and project-governance decisions are recorded in the primary
+Higress repository.
+
+## Non-public channels
+
+Non-public channels are limited to reports whose confidentiality protects
+reporters or users:
+
+| Channel | Special purpose |
+| --- | --- |
+| [GitHub Private Security Advisories](https://github.com/higress-group/higress/security/advisories/new) | Confidential vulnerability reporting, triage, remediation, and disclosure coordination under [`SECURITY.md`](./SECURITY.md) |
+| [Alibaba Security Response Center](https://security.alibaba.com/) | Optional alternate private intake if a reporter cannot use GitHub; reports are transferred to the project Security Response Team and do not give Alibaba governance authority |
+| [CNCF Code of Conduct reporting](mailto:conduct@cncf.io) | Confidential Code of Conduct incident reporting under [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) |
+| [CNCF TOC private mailing list](mailto:cncf-private-toc@lists.cncf.io) | Confidential escalation when project leadership cannot resolve a security or governance conflict without conflicted participants |
+
+Personal messages, employer-internal systems, and informal maintainer chats are
+not official project decision channels. If they inform project work, the
+non-sensitive decision and rationale must be recorded publicly.
+
+## Community meetings
+
+Higress does not currently run a recurring public community meeting and does
+not yet have a CNCF calendar entry. Establishing an up-to-date public scheduler
+and a durable location for agendas and notes is tracked as an Incubation
+readiness item in [`docs/cncf/governance-review.md`](./docs/cncf/governance-review.md).
+
+When a recurring meeting is established, its schedule and joining information
+will be published here and on the CNCF calendar. Agendas, notes, recordings,
+and decisions will be public, with confidential security and Code of Conduct
+matters excluded.
+
+## Contributor activity and recruitment
+
+Public, continuously updated evidence is available through:
+
+- [GitHub contributor activity](https://github.com/higress-group/higress/graphs/contributors)
+- [Recent repository activity](https://github.com/higress-group/higress/pulse)
+- [CNCF DevStats for Higress](https://higress.devstats.cncf.io/)
+- [`help wanted` issues](https://github.com/higress-group/higress/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- [`good first issue` issues](https://github.com/higress-group/higress/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+- the contributor path in [`CONTRIBUTING_EN.md`](./CONTRIBUTING_EN.md)
+- the active-maintainer evidence and annual roster review in
+  [`MAINTAINERS.md`](./MAINTAINERS.md)
+
+Contributors can start through an issue, discussion, documentation update, bug
+fix, test, plugin, or other pull request. Maintainers and code owners recruit
+and mentor contributors through the public channels above and identify
+approachable work with contribution labels.

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -50,9 +50,10 @@ non-sensitive decision and rationale must be recorded publicly.
 ## Community meetings
 
 Higress does not currently run a recurring public community meeting and does
-not yet have a CNCF calendar entry. Establishing an up-to-date public scheduler
-and a durable location for agendas and notes is tracked as an Incubation
-readiness item in [`docs/cncf/governance-review.md`](./docs/cncf/governance-review.md).
+not yet have a CNCF calendar entry. Establishing an up-to-date public meeting
+scheduler and/or CNCF calendar integration is tracked as an Incubation
+readiness item in
+[`docs/cncf/governance-review.md`](./docs/cncf/governance-review.md).
 
 When a recurring meeting is established, its schedule and joining information
 will be published here and on the CNCF calendar. Agendas, notes, recordings,

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -38,8 +38,8 @@ reporters or users:
 
 | Channel | Special purpose |
 | --- | --- |
-| [GitHub Private Security Advisories](https://github.com/higress-group/higress/security/advisories/new) | Confidential vulnerability reporting, triage, remediation, and disclosure coordination under [`SECURITY.md`](./SECURITY.md) |
-| [Alibaba Security Response Center](https://security.alibaba.com/) | Optional alternate private intake if a reporter cannot use GitHub; reports are transferred to the project Security Response Team and do not give Alibaba governance authority |
+| [GitHub Private Security Advisories](https://github.com/higress-group/higress/security/advisories/new) | One of the two required confidential vulnerability-reporting channels; used for project triage, remediation, and disclosure coordination under [`SECURITY.md`](./SECURITY.md) |
+| [Alibaba Security Response Center](https://security.alibaba.com/) | The second required confidential vulnerability-reporting channel; the same substantive report must be submitted here and correlated with the GitHub advisory by the Security Response Team |
 | [CNCF Code of Conduct reporting](mailto:conduct@cncf.io) | Confidential Code of Conduct incident reporting under [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) |
 | [CNCF TOC private mailing list](mailto:cncf-private-toc@lists.cncf.io) | Confidential escalation when project leadership cannot resolve a security or governance conflict without conflicted participants |
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -19,21 +19,104 @@ Higress governance is guided by the following values:
 
 ## Roles
 
-Higress role definitions are documented in:
+Higress has the following project-wide roles:
+
+- **Contributor**: anyone who participates through issues, discussions,
+  documentation, code, testing, or other community work. Contributors do not
+  need a formal appointment.
+- **Code owner**: a contributor delegated to review changes in one or more
+  paths in [`CODEOWNERS`](./CODEOWNERS). Code owners assess technical quality,
+  request changes, and help maintain their assigned area. Code ownership does
+  not grant project-wide governance authority or a permanent seat. A code
+  owner is added or removed by a public pull request updating `CODEOWNERS`,
+  using the decision process below. Maintainers remain accountable for the
+  resulting ownership coverage and may merge only in accordance with the
+  repository's configured permissions and review rules.
+- **Maintainer**: a project-wide leadership role responsible for technical
+  direction, releases, governance, community health, and the delegation of
+  code ownership. Maintainers are not limited to the paths where they are
+  named as code owners.
+
+The current roster, responsibilities, and lifecycle are documented in:
 
 - [`MAINTAINERS.md`](./MAINTAINERS.md)
-- [`CODEOWNERS`](./CODEOWNERS)
 - [`CONTRIBUTING_EN.md`](./CONTRIBUTING_EN.md)
+
+## Project Scope and Subprojects
+
+The following repositories comprise the CNCF Higress project. Unless a
+subproject documents an additional local rule, this governance and the
+project-wide maintainer roster apply to it.
+
+| Repository | Responsibility | Status |
+| --- | --- | --- |
+| [`higress-group/higress`](https://github.com/higress-group/higress) | Core control plane, data plane integration, APIs, Helm charts, CLI, plugins, documentation, and releases | Active; primary repository |
+| [`higress-group/higress-console`](https://github.com/higress-group/higress-console) | Web management console | Active subproject |
+| [`higress-group/higress-standalone`](https://github.com/higress-group/higress-standalone) | Standalone and local deployment packaging | Active subproject |
+| [`higress-group/plugin-server`](https://github.com/higress-group/plugin-server) | Plugin distribution service used by Higress | Active subproject |
+| [`higress-group/wasm-go`](https://github.com/higress-group/wasm-go) | Go SDK for Higress Wasm plugins | Active subproject |
+
+Forks of upstream dependencies, integrations, examples, experiments, websites,
+and other repositories in the `higress-group` organization are not Higress
+subprojects unless they are added to this table.
+
+A proposal to add, remove, transfer, or archive a subproject must be made in a
+public issue or pull request. It must identify the repository, purpose,
+maintainers or delegated code owners, contribution path, communication
+channels, and lifecycle status. The proposal follows the project-direction
+decision process below. An archived or removed subproject remains listed here
+with its final status and successor, if any.
 
 ## Decision Making
 
 Higress uses **lazy consensus** by default.
 
-When consensus cannot be reached, maintainers may start a vote on a public
-issue or pull request. A simple majority of votes cast decides the outcome.
+Technical proposals, contribution acceptance, project goals, leadership and
+role assignments, subproject changes, requests made on behalf of Higress to
+the CNCF, and governance changes are discussed in public issues or pull
+requests. Maintainers are responsible for ensuring that significant decisions
+record their rationale and outcome in the relevant public thread.
+
+When consensus cannot be reached, a maintainer may start a vote on the public
+issue or pull request. A simple majority of non-conflicted maintainer votes
+cast decides the outcome. A maintainer with a material personal or employer
+conflict must disclose it and abstain from the decision. If all maintainers are
+conflicted, the project will request guidance from the CNCF TOC.
 
 For governance or project direction changes, maintainers should allow adequate
 time for public discussion before finalizing decisions.
+
+## Vendor Neutrality
+
+Higress project direction and governance are independent of any single
+company. Maintainer and code-owner roles are held by individuals, not reserved
+for employers. No employer has a guaranteed seat, veto, or preferred decision
+weight. Contributions, integrations, defaults, and roadmap priorities are
+evaluated on community and technical merit. Company-specific products may be
+supported, but they do not receive privileged governance treatment.
+
+Affiliation changes do not by themselves add or remove a role. Maintainers
+disclose affiliations in `MAINTAINERS.md` and disclose material conflicts in
+the public decision record.
+
+## Function-Based Teams
+
+Maintainers may create a function-based team, such as a release or security
+team, through a public governance pull request. The change must document the
+team's purpose, authority, membership or selection method, onboarding,
+conflict handling, removal, and retirement. Sensitive operational details may
+remain private, but the team's mandate and decision authority must be public.
+
+The current Security Response Team and its private report-handling process are
+defined in [`SECURITY.md`](./SECURITY.md).
+
+## Community and Meetings
+
+The authoritative inventory of public and non-public communication channels,
+subproject channels, contribution activity, and meeting information is in
+[`COMMUNITY.md`](./COMMUNITY.md). Project decisions must be recorded in a
+public issue, discussion, pull request, or published meeting notes even when
+preliminary conversation occurred elsewhere.
 
 ## Governance Updates
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -56,9 +56,13 @@ project-wide maintainer roster apply to it.
 | [`higress-group/plugin-server`](https://github.com/higress-group/plugin-server) | Plugin distribution service used by Higress | Active subproject |
 | [`higress-group/wasm-go`](https://github.com/higress-group/wasm-go) | Go SDK for Higress Wasm plugins | Active subproject |
 
-Forks of upstream dependencies, integrations, examples, experiments, websites,
-and other repositories in the `higress-group` organization are not Higress
-subprojects unless they are added to this table.
+Git submodules declared in [`.gitmodules`](./.gitmodules), including the
+Higress-hosted forks of Istio, Envoy, and their related API and client
+libraries, are pinned source dependencies used to build Higress; they are not
+separately governed Higress subprojects. Other upstream dependency forks,
+integrations, examples, experiments, websites, and repositories in the
+`higress-group` organization are also not Higress subprojects unless they are
+added to this table.
 
 A proposal to add, remove, transfer, or archive a subproject must be made in a
 public issue or pull request. It must identify the repository, purpose,

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,24 +2,49 @@
 
 This file lists the current maintainers of the Higress project.
 
-A maintainer is a contributor who is actively responsible for guiding the
-direction of the project, reviewing and merging contributions, and
-participating in project governance.
+A maintainer is a contributor who is actively responsible for project-wide
+technical direction, releases, governance, community health, and the
+delegation of code ownership across the Higress project and its subprojects.
+Maintainer authority is held by individuals and is not tied to an employer.
 
 For the day-to-day code-review ownership of individual subdirectories,
 see [`CODEOWNERS`](./CODEOWNERS).
 
 ## Maintainers
 
-| Name           | GitHub                                                  | Affiliation       |
-| -------------- | ------------------------------------------------------- | ----------------- |
-| Yiquan Dong    | [@CH3CHO](https://github.com/CH3CHO)                    | Trip.com          |
-| Yuanxiao Zhao  | [@EndlessSeeker](https://github.com/EndlessSeeker)      | Alibaba Cloud     |
-| Leilei Geng    | [@gengleilei](https://github.com/gengleilei)            | Alibaba Cloud     |
-| Xiantao Han    | [@hanxiantao](https://github.com/hanxiantao)            | XinYe Technology  |
-| Zhiwei Cheng   | [@cr7258](https://github.com/cr7258)                    | NVIDIA            |
-| Tianyi Zhang   | [@johnlanni](https://github.com/johnlanni)              | Alibaba Cloud     |
-| Jingfeng Xu    | [@lexburner](https://github.com/lexburner)              | Alibaba Cloud     |
+| Name | GitHub contact | Domain of responsibility | Affiliation |
+| --- | --- | --- | --- |
+| Yiquan Dong | [@CH3CHO](https://github.com/CH3CHO) | Project-wide governance, technical direction, releases, and community stewardship | Trip.com |
+| Yuanxiao Zhao | [@EndlessSeeker](https://github.com/EndlessSeeker) | Project-wide governance, technical direction, releases, and community stewardship | Alibaba Cloud |
+| Leilei Geng | [@gengleilei](https://github.com/gengleilei) | Project-wide governance, technical direction, releases, and community stewardship | Alibaba Cloud |
+| Xiantao Han | [@hanxiantao](https://github.com/hanxiantao) | Project-wide governance, technical direction, releases, and community stewardship | XinYe Technology |
+| Zhiwei Cheng | [@cr7258](https://github.com/cr7258) | Project-wide governance, technical direction, releases, and community stewardship | NVIDIA |
+| Tianyi Zhang | [@johnlanni](https://github.com/johnlanni) | Project-wide governance, technical direction, releases, and community stewardship | Alibaba Cloud |
+| Jingfeng Xu | [@lexburner](https://github.com/lexburner) | Project-wide governance, technical direction, releases, and community stewardship | Alibaba Cloud |
+
+More specific day-to-day review responsibilities are delegated through
+[`CODEOWNERS`](./CODEOWNERS); they do not narrow a maintainer's project-wide
+responsibility.
+
+## Activity and roster review
+
+A maintainer is active when they have participated in project review,
+development, releases, issue triage, community support, or governance during
+the preceding 12 months and remain willing to perform the role. The roster is
+reviewed in a public pull request at least annually. The review checks public
+activity, current affiliation and contact information, and asks maintainers
+whose status is unclear to confirm their availability.
+
+The 2026 roster review used public GitHub issue and pull-request activity for
+each maintainer:
+
+- [Yiquan Dong](https://github.com/higress-group/higress/issues?q=updated%3A%3E%3D2025-07-21+involves%3ACH3CHO)
+- [Yuanxiao Zhao](https://github.com/higress-group/higress/issues?q=updated%3A%3E%3D2025-07-21+involves%3AEndlessSeeker)
+- [Leilei Geng](https://github.com/higress-group/higress/issues?q=updated%3A%3E%3D2025-07-21+involves%3Agengleilei)
+- [Xiantao Han](https://github.com/higress-group/higress/issues?q=updated%3A%3E%3D2025-07-21+involves%3Ahanxiantao)
+- [Zhiwei Cheng](https://github.com/higress-group/higress/issues?q=updated%3A%3E%3D2025-07-21+involves%3Acr7258)
+- [Tianyi Zhang](https://github.com/higress-group/higress/issues?q=updated%3A%3E%3D2025-07-21+involves%3Ajohnlanni)
+- [Jingfeng Xu](https://github.com/higress-group/higress/issues?q=updated%3A%3E%3D2025-07-21+involves%3Alexburner)
 
 ## Becoming a maintainer
 
@@ -28,7 +53,29 @@ Higress follows the contribution and graduation paths described in
 contributors who consistently demonstrate good technical judgement and
 community stewardship can be nominated as maintainers by an existing
 maintainer; nominations are accepted by lazy consensus among the current
-maintainers.
+maintainers. The nomination pull request must update this roster and state the
+candidate's public contribution history, domain of responsibility, contact,
+and affiliation.
+
+## Leaving or changing maintainer status
+
+- A maintainer may step down by opening or approving a pull request that moves
+  them to the emeritus list or removes them from the roster.
+- A maintainer who has no qualifying activity for 12 months will be contacted
+  publicly where practical and given at least 30 days to confirm whether they
+  want to resume the role, move to emeritus, or step down. If there is no
+  response, another maintainer may propose the change through lazy consensus.
+- A maintainer may be removed for sustained failure to perform the role or for
+  a Code of Conduct violation. The proposal follows the governance decision
+  process, excludes conflicted maintainers, and preserves confidential details
+  where required by the Code of Conduct process.
+- Emeritus maintainers retain recognition but no maintainer authority or
+  required repository access. An emeritus or former maintainer may return
+  through the same public nomination process used for a new maintainer.
+
+## Emeritus maintainers
+
+There are currently no emeritus maintainers.
 
 ## Reporting issues
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ Join our Discord community! This is where you can connect with developers and ot
 
 [![discord](https://img.shields.io/discord/1364956090566971515?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/tSbww9VDaM)
 
+The complete inventory of public and private communication channels,
+subproject channels, meeting information, and contributor activity is in
+[`COMMUNITY.md`](./COMMUNITY.md).
+
 ### Code of Conduct
 
 The Higress community follows the
@@ -218,8 +222,8 @@ Higress would not be possible without the valuable open-source work of projects 
 
 ### Contributors
 
-<a href="https://github.com/alibaba/higress/graphs/contributors">
-  <img alt="contributors" src="https://contrib.rocks/image?repo=alibaba/higress"/>
+<a href="https://github.com/higress-group/higress/graphs/contributors">
+  <img alt="contributors" src="https://contrib.rocks/image?repo=higress-group/higress"/>
 </a>
 
 ### Star History

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <div align="center">
 
-[![Build Status](https://github.com/alibaba/higress/actions/workflows/build-and-test.yaml/badge.svg?branch=main)](https://github.com/alibaba/higress/actions)
-[![license](https://img.shields.io/github/license/alibaba/higress.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![Build Status](https://github.com/higress-group/higress/actions/workflows/build-and-test.yaml/badge.svg?branch=main)](https://github.com/higress-group/higress/actions)
+[![license](https://img.shields.io/github/license/higress-group/higress.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![discord](https://img.shields.io/discord/1364956090566971515?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square)](https://discord.gg/tSbww9VDaM)
 [![CNCF Sandbox](https://img.shields.io/badge/CNCF-Sandbox-30638E?logo=linuxfoundation&logoColor=white)](https://www.cncf.io/projects/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12667/badge)](https://www.bestpractices.dev/projects/12667)
@@ -21,6 +21,7 @@
 [**Official Site**](https://higress.ai/en/) &nbsp; |
 &nbsp; [**Docs**](https://higress.cn/en/docs/latest/overview/what-is-higress/) &nbsp; |
 &nbsp; [**Blog**](https://higress.cn/en/blog/) &nbsp; |
+&nbsp; [**Roadmap**](./ROADMAP.md) &nbsp; |
 &nbsp; [**MCP Server QuickStart**](https://higress.cn/en/ai/mcp-quick-start/) &nbsp; |
 &nbsp; [**Developer Guide**](https://higress.cn/en/docs/latest/dev/architecture/) &nbsp; |
 &nbsp; [**Wasm Plugin Hub**](https://higress.cn/en/plugin/) &nbsp; |
@@ -35,19 +36,19 @@ Higress is a cloud-native API gateway based on Istio and Envoy, which can be ext
 
 ### Core Use Cases
 
-Higress's AI gateway capabilities support all [mainstream model providers](https://github.com/alibaba/higress/tree/main/plugins/wasm-go/extensions/ai-proxy/provider) both domestic and international. It also supports hosting MCP (Model Context Protocol) Servers through its plugin mechanism, enabling AI Agents to easily call various tools and services. With the [openapi-to-mcp tool](https://github.com/higress-group/openapi-to-mcpserver), you can quickly convert OpenAPI specifications into remote MCP servers for hosting. Higress provides unified management for both LLM API and MCP API.
+Higress's AI gateway capabilities support all [mainstream model providers](https://github.com/higress-group/higress/tree/main/plugins/wasm-go/extensions/ai-proxy/provider) both domestic and international. It also supports hosting MCP (Model Context Protocol) Servers through its plugin mechanism, enabling AI Agents to easily call various tools and services. With the [openapi-to-mcp tool](https://github.com/higress-group/openapi-to-mcpserver), you can quickly convert OpenAPI specifications into remote MCP servers for hosting. Higress provides unified management for both LLM API and MCP API.
 
 **🌟 Try it now at [https://mcp.higress.ai/](https://mcp.higress.ai/)** to experience Higress-hosted Remote MCP Servers firsthand:
 
 ![Higress MCP Server Platform](https://img.alicdn.com/imgextra/i2/O1CN01nmVa0a1aChgpyyWOX_!!6000000003294-0-tps-3430-1742.jpg)
 
-### Enterprise Adoption
+### Production Adoption
 
-Higress was born within Alibaba to solve the issues of Tengine reload affecting long-connection services and insufficient load balancing capabilities for gRPC/Dubbo. Within Alibaba Cloud, Higress's AI gateway capabilities support core AI applications such as Tongyi Bailian model studio, machine learning PAI platform, and other critical AI services. Alibaba Cloud has built its cloud-native API gateway product based on Higress, providing 99.99% gateway high availability guarantee service capabilities for a large number of enterprise customers.
-
-You can click the button below to install the enterprise version of Higress:
-
-[![Deploy on AlibabaCloud](https://img.alicdn.com/imgextra/i1/O1CN01e6vwe71EWTHoZEcpK_!!6000000000359-55-tps-170-40.svg)](https://www.aliyun.com/product/api-gateway?spm=higress-github.topbar.0.0.0)
+Higress originated at Alibaba to address long-connection disruption during
+gateway reloads and improve gRPC/Dubbo load balancing. It is now developed as
+a vendor-neutral CNCF project and is used by organizations across multiple
+industries. Public adopters and their use cases are listed in
+[`ADOPTERS.md`](./ADOPTERS.md).
 
 
 ## Summary
@@ -77,8 +78,9 @@ Port descriptions:
 - Port 8080: Gateway HTTP protocol entry
 - Port 8443: Gateway HTTPS protocol entry
 
-> All Higress Docker images use Higress's own image repository and are not affected by Docker Hub rate limits.
-> In addition, the submission and updates of the images are protected by a security scanning mechanism (powered by Alibaba Cloud ACR), making them very secure for use in production environments.
+> Higress publishes project images through dedicated regional registry
+> endpoints. Operators may mirror the images to a registry they control and
+> configure the Helm `global.hub` value accordingly.
 >
 > If you experience a timeout when pulling image from `higress-registry.cn-hangzhou.cr.aliyuncs.com`, you can try replacing it with the following docker registry mirror source:
 >
@@ -99,9 +101,6 @@ Port descriptions:
 > - **Southeast Asia**: `higress-registry.ap-southeast-7.cr.aliyuncs.com`
 
 For other installation methods such as Helm deployment under K8s, please refer to the official [Quick Start documentation](https://higress.ai/en/docs/latest/user/quickstart/).
-
-If you are deploying on the cloud, it is recommended to use the [Enterprise Edition](https://www.aliyun.com/product/apigateway?spm=higress-github.topbar.0.0.0)
-
 
 ## Use Cases
 
@@ -202,7 +201,9 @@ participating in the community.
 Project governance, the maintainer roster, and the contribution model are
 described in [`GOVERNANCE.md`](./GOVERNANCE.md) and
 [`MAINTAINERS.md`](./MAINTAINERS.md). New contributors are encouraged to start
-with [`CONTRIBUTING_EN.md`](./CONTRIBUTING_EN.md).
+with [`CONTRIBUTING_EN.md`](./CONTRIBUTING_EN.md). Forward planning and release
+procedures are documented in [`ROADMAP.md`](./ROADMAP.md) and
+[`RELEASE.md`](./RELEASE.md).
 
 ### Security
 
@@ -228,7 +229,7 @@ Higress would not be possible without the valuable open-source work of projects 
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alibaba/higress&type=Date)](https://star-history.com/#alibaba/higress&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=higress-group/higress&type=Date)](https://star-history.com/#higress-group/higress&Date)
 
 ---
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -6,8 +6,8 @@
 </h1>
 <h4 align="center"> AIネイティブAPIゲートウェイ </h4>
 
-[![Build Status](https://github.com/alibaba/higress/actions/workflows/build-and-test.yaml/badge.svg?branch=main)](https://github.com/alibaba/higress/actions)
-[![license](https://img.shields.io/github/license/alibaba/higress.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![Build Status](https://github.com/higress-group/higress/actions/workflows/build-and-test.yaml/badge.svg?branch=main)](https://github.com/higress-group/higress/actions)
+[![license](https://img.shields.io/github/license/higress-group/higress.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![CNCF Sandbox](https://img.shields.io/badge/CNCF-Sandbox-30638E?logo=linuxfoundation&logoColor=white)](https://www.cncf.io/projects/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12667/badge)](https://www.bestpractices.dev/projects/12667)
 
@@ -30,15 +30,19 @@ Higressは、IstioとEnvoyをベースにしたクラウドネイティブAPIゲ
 
 ### 主な使用シナリオ
 
-HigressのAIゲートウェイ機能は、国内外のすべての[主要モデルプロバイダー](https://github.com/alibaba/higress/tree/main/plugins/wasm-go/extensions/ai-proxy/provider)をサポートし、vllm/ollamaなどに基づく自己構築DeepSeekモデルにも対応しています。また、プラグインメカニズムを通じてMCP（Model Context Protocol）サーバーをホストすることもでき、AI Agentが様々なツールやサービスを簡単に呼び出せるようにします。[openapi-to-mcpツール](https://github.com/higress-group/openapi-to-mcpserver)を使用すると、OpenAPI仕様を迅速にリモートMCPサーバーに変換してホスティングできます。HigressはLLM APIとMCP APIの統一管理を提供します。
+HigressのAIゲートウェイ機能は、国内外のすべての[主要モデルプロバイダー](https://github.com/higress-group/higress/tree/main/plugins/wasm-go/extensions/ai-proxy/provider)をサポートし、vllm/ollamaなどに基づく自己構築DeepSeekモデルにも対応しています。また、プラグインメカニズムを通じてMCP（Model Context Protocol）サーバーをホストすることもでき、AI Agentが様々なツールやサービスを簡単に呼び出せるようにします。[openapi-to-mcpツール](https://github.com/higress-group/openapi-to-mcpserver)を使用すると、OpenAPI仕様を迅速にリモートMCPサーバーに変換してホスティングできます。HigressはLLM APIとMCP APIの統一管理を提供します。
 
 **🌟 今すぐ[https://mcp.higress.ai/](https://mcp.higress.ai/)で体験**してください。HigressがホストするリモートMCPサーバーを直接体験できます:
 
 ![Higress MCP Server Platform](https://img.alicdn.com/imgextra/i2/O1CN01nmVa0a1aChgpyyWOX_!!6000000003294-0-tps-3430-1742.jpg)
 
-### 企業での採用
+### 本番環境での採用
 
-Higressは、Tengineのリロードが長時間接続のビジネスに影響を与える問題や、gRPC/Dubboの負荷分散能力の不足を解決するために、Alibaba内部で誕生しました。Alibaba Cloud内では、HigressのAIゲートウェイ機能がTongyi Qianwen APP、Tongyi Bailian Model Studio、機械学習PAIプラットフォームなどの中核的なAIアプリケーションをサポートしています。また、国内の主要なAIGC企業（例：ZeroOne）やAI製品（例：FastGPT）にもサービスを提供しています。Alibaba Cloudは、Higressを基盤にクラウドネイティブAPIゲートウェイ製品を構築し、多くの企業顧客に99.99％のゲートウェイ高可用性保証サービスを提供しています。
+Higressは、ゲートウェイのリロードによる長時間接続への影響と
+gRPC/Dubboの負荷分散上の課題を解決するため、Alibabaで誕生しました。
+現在はベンダーニュートラルなCNCFプロジェクトとしてコミュニティにより
+開発され、複数業界の組織で利用されています。公開されている採用組織と
+ユースケースは[`ADOPTERS.md`](./ADOPTERS.md)を参照してください。
 
 
 ## 目次
@@ -232,13 +236,13 @@ WeChat公式アカウント：
 
 ### 貢献者
 
-<a href="https://github.com/alibaba/higress/graphs/contributors">
-  <img alt="contributors" src="https://contrib.rocks/image?repo=alibaba/higress"/>
+<a href="https://github.com/higress-group/higress/graphs/contributors">
+  <img alt="contributors" src="https://contrib.rocks/image?repo=higress-group/higress"/>
 </a>
 
 ### スターの歴史
 
-[![スターの歴史チャート](https://api.star-history.com/svg?repos=alibaba/higress&type=Date)](https://star-history.com/#alibaba/higress&Date)
+[![スターの歴史チャート](https://api.star-history.com/svg?repos=higress-group/higress&type=Date)](https://star-history.com/#higress-group/higress&Date)
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -8,8 +8,8 @@
 
 <div align="center">
     
-[![Build Status](https://github.com/alibaba/higress/actions/workflows/build-and-test.yaml/badge.svg?branch=main)](https://github.com/alibaba/higress/actions)
-[![license](https://img.shields.io/github/license/alibaba/higress.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+[![Build Status](https://github.com/higress-group/higress/actions/workflows/build-and-test.yaml/badge.svg?branch=main)](https://github.com/higress-group/higress/actions)
+[![license](https://img.shields.io/github/license/higress-group/higress.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![CNCF Sandbox](https://img.shields.io/badge/CNCF-Sandbox-30638E?logo=linuxfoundation&logoColor=white)](https://www.cncf.io/projects/)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12667/badge)](https://www.bestpractices.dev/projects/12667)
 
@@ -37,7 +37,7 @@ Higress 是一款云原生 API 网关，内核基于 Istio 和 Envoy，可以用
 
 ### 核心使用场景
 
-Higress 的 AI 网关能力支持国内外所有[主流模型供应商](https://github.com/alibaba/higress/tree/main/plugins/wasm-go/extensions/ai-proxy/provider)和基于 vllm/ollama 等自建的 DeepSeek 模型。同时，Higress 支持通过插件方式托管 MCP (Model Context Protocol) 服务器，使 AI Agent 能够更容易地调用各种工具和服务。借助 [openapi-to-mcp 工具](https://github.com/higress-group/openapi-to-mcpserver)，您可以快速将 OpenAPI 规范转换为远程 MCP 服务器进行托管。Higress 提供了对 LLM API 和 MCP API 的统一管理。
+Higress 的 AI 网关能力支持国内外所有[主流模型供应商](https://github.com/higress-group/higress/tree/main/plugins/wasm-go/extensions/ai-proxy/provider)和基于 vllm/ollama 等自建的 DeepSeek 模型。同时，Higress 支持通过插件方式托管 MCP (Model Context Protocol) 服务器，使 AI Agent 能够更容易地调用各种工具和服务。借助 [openapi-to-mcp 工具](https://github.com/higress-group/openapi-to-mcpserver)，您可以快速将 OpenAPI 规范转换为远程 MCP 服务器进行托管。Higress 提供了对 LLM API 和 MCP API 的统一管理。
 
 **🌟 立即体验 [https://mcp.higress.ai/](https://mcp.higress.ai/)** 基于 Higress 托管的远程 MCP 服务器:
 
@@ -45,13 +45,10 @@ Higress 的 AI 网关能力支持国内外所有[主流模型供应商](https://
 
 ### 生产环境采用
 
-Higress 在阿里内部为解决 Tengine reload 对长连接业务有损，以及 gRPC/Dubbo 负载均衡能力不足而诞生。在阿里云内部，Higress 的 AI 网关能力支撑了通义千问 APP、通义百炼模型工作室、机器学习 PAI 平台等核心 AI 应用。同时服务国内头部的 AIGC 企业（如零一万物），以及 AI 产品（如 FastGPT）。阿里云基于 Higress 构建了云原生 API 网关产品，为大量企业客户提供 99.99% 的网关高可用保障服务能力。
-
-可以点下方按钮安装企业版 Higress: 
-
-[![Deploy on AlibabaCloud](https://img.alicdn.com/imgextra/i4/O1CN01tHRaNm22hflDqxKV5_!!6000000007152-55-tps-170-40.svg)](https://www.aliyun.com/product/apigateway?spm=higress-github.topbar.0.0.0)
-
-如果您使用开源的Higress并希望获得企业级支持，可以联系johnlanni的邮箱：zty98751@alibaba-inc.com或社交媒体账号（微信号：nomadao，钉钉号：chengtanzty）。添加好友时请备注Higress :）
+Higress 最初在阿里内部为解决网关 reload 对长连接业务有损，以及
+gRPC/Dubbo 负载均衡能力不足而诞生。Higress 目前作为厂商中立的 CNCF
+项目由社区共同开发，并已被多个行业的组织采用。公开采用者和使用场景见
+[`ADOPTERS.md`](./ADOPTERS.md)。
 
 ## Summary
 
@@ -80,7 +77,8 @@ docker run -d --rm --name higress-ai -v ${PWD}:/data \
 - 8080 端口：网关 HTTP 协议入口
 - 8443 端口：网关 HTTPS 协议入口
 
-**Higress 的所有 Docker 镜像都一直使用自己独享的仓库，不受 Docker Hub 境内访问受限的影响**
+**Higress 通过多个区域的项目镜像仓库发布镜像。使用者也可以将镜像同步到
+自己控制的仓库，并通过 Helm 的 `global.hub` 参数进行配置。**
 
 > 如果从 `higress-registry.cn-hangzhou.cr.aliyuncs.com` 拉取镜像超时，可以尝试使用以下镜像加速源：
 > 
@@ -101,8 +99,6 @@ docker run -d --rm --name higress-ai -v ${PWD}:/data \
 > - **东南亚**: `higress-registry.ap-southeast-7.cr.aliyuncs.com`
 
 K8s 下使用 Helm 部署等其他安装方式可以参考官网 [Quick Start 文档](https://higress.cn/docs/latest/user/quickstart/)。
-
-如果您是在云上部署，推荐使用[企业版](https://www.aliyun.com/product/apigateway?spm=higress-github.topbar.0.0.0)
 
 ## 使用场景
 
@@ -261,13 +257,13 @@ Higress 社区遵循 [**CNCF Code of Conduct**](https://github.com/cncf/foundati
 
 ### 贡献者
 
-<a href="https://github.com/alibaba/higress/graphs/contributors">
-  <img alt="contributors" src="https://contrib.rocks/image?repo=alibaba/higress"/>
+<a href="https://github.com/higress-group/higress/graphs/contributors">
+  <img alt="contributors" src="https://contrib.rocks/image?repo=higress-group/higress"/>
 </a>
 
 ### Star History
 
-[![Star History](https://api.star-history.com/svg?repos=alibaba/higress&type=Date)](https://star-history.com/#alibaba/higress&Date)
+[![Star History](https://api.star-history.com/svg?repos=higress-group/higress&type=Date)](https://star-history.com/#higress-group/higress&Date)
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,112 @@
+# Higress Release Process
+
+This document defines the project-wide process for producing a Higress core
+release from the primary repository. Subprojects may add repository-specific
+steps, but must use the same public approval and security principles.
+
+## Versioning and support
+
+Higress uses [Semantic Versioning](https://semver.org/) with Git tags in the
+form `vMAJOR.MINOR.PATCH`. A release-candidate tag may add an `-rc.N` suffix.
+
+- A **major** release may contain incompatible changes and requires migration
+  guidance.
+- A **minor** release adds backward-compatible features and may contain
+  announced deprecations.
+- A **patch** release contains backward-compatible fixes, including security
+  fixes when appropriate.
+
+The supported major-version lines are listed in [`SECURITY.md`](./SECURITY.md).
+A proposal to end support for a major line is made publicly through a pull
+request updating `SECURITY.md`, normally at least 90 days before the stated end
+of support. Already unsupported versions do not receive routine fixes.
+
+## Roles and authorization
+
+A maintainer acts as **release manager** for each release. The release manager
+coordinates the tracking issue, version changes, validation, tag, automation,
+and announcement. At least one other unconflicted maintainer reviews and
+approves the release pull request. Only maintainers with the required GitHub
+and protected-environment access may create release tags or approve publishing
+jobs.
+
+Security releases additionally follow [`SECURITY.md`](./SECURITY.md). Embargoed
+details stay in the private advisory until the Security Response Team approves
+disclosure.
+
+## 1. Plan the release
+
+The release manager opens or identifies a public tracking issue for a normal
+release. It records:
+
+- the target version and release type;
+- intended scope and linked changes;
+- the release manager and expected timing;
+- known compatibility, migration, deprecation, and security considerations;
+- validation status and unresolved blockers.
+
+An embargoed security release uses a private advisory for planning until public
+disclosure is safe.
+
+## 2. Prepare the release pull request
+
+Create a release pull request against `main` that keeps the version in
+`VERSION`, `helm/core/Chart.yaml`, `helm/higress/Chart.yaml`, dependency
+metadata, and release notes consistent. Update documentation, migration or
+deprecation guidance, and supported-version information when they change.
+
+The pull request must pass the repository's required build, unit, race,
+conformance, plugin, license, and other configured checks relevant to its
+changes. The release manager records any intentionally inapplicable check or
+accepted exception in the pull request. A known release-blocking regression,
+unresolved critical vulnerability, inconsistent version, or missing migration
+guidance blocks the release.
+
+The approving maintainer verifies that the release scope matches the public
+plan, required checks passed, versioned dependencies are intentional, and the
+release notes accurately describe user-visible changes.
+
+## 3. Tag and publish
+
+After the release pull request is merged, the release manager creates the
+corresponding immutable `vMAJOR.MINOR.PATCH` or release-candidate tag from the
+reviewed commit. Published tags are not moved or reused.
+
+The tag triggers GitHub Actions that publish, as applicable:
+
+- controller, pilot, and gateway container images;
+- Helm charts and chart indexes;
+- `hgctl` archives for supported platforms;
+- generated CRDs;
+- standalone distribution artifacts;
+- GitHub release notes and repository release notes.
+
+Manual workflow dispatch is for recovery or a documented exceptional case; it
+does not bypass release approval or change the commit being released.
+
+## 4. Verify and announce
+
+The release manager verifies that publishing workflows succeeded and that the
+release page, checksums or archives, image tags, Helm charts, CRDs, and release
+notes refer to the intended version. Installation and representative gateway
+traffic are smoke-tested with the published artifacts before the release is
+announced as ready.
+
+Release announcements link the GitHub release and call out breaking changes,
+deprecations, migrations, known issues, and security impact. Confirmed security
+issues are disclosed through a GitHub Security Advisory and CVE when
+appropriate.
+
+## Failure, rollback, and correction
+
+If validation or publishing fails, stop promotion and document the failure in
+the tracking issue or release pull request. Do not move or overwrite an
+existing public tag. Fix the problem through normal review and publish a new
+release-candidate or patch version.
+
+An operator rollback uses the previously pinned Helm chart, configuration, and
+images, normally through `helm rollback`. Because CRD schemas and stored
+resources may not be reversible, release notes must identify migrations that
+need special rollback handling. The project may withdraw a compromised
+artifact from distribution, but it preserves a public advisory and audit trail
+explaining the affected version and safe replacement.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,30 @@
+# Higress Roadmap
+
+The maintained public Higress roadmap is published on the
+[Higress website](https://higress.ai/en/docs/latest/overview/roadmap/). Its
+source is version controlled in the
+[`higress-group/higress-group.github.io`](https://github.com/higress-group/higress-group.github.io/blob/main/src/content/docs/latest/en/overview/roadmap.md)
+repository.
+
+Roadmap entries describe intended direction and target timing, not a guarantee
+that a feature or release will ship on a particular date. Security, quality,
+compatibility, and contributor availability can change priorities.
+
+## Changing the roadmap
+
+Anyone may propose a roadmap item or priority change through a public
+[Higress issue](https://github.com/higress-group/higress/issues) or
+[discussion](https://github.com/higress-group/higress/discussions). A proposal
+should describe the user problem, expected outcome, project scope, major
+dependencies, compatibility or security impact, and a responsible contributor
+or maintainer when known.
+
+Maintainers decide roadmap changes through the public lazy-consensus process in
+[`GOVERNANCE.md`](./GOVERNANCE.md). Accepted changes are reflected in the
+version-controlled website roadmap. Significant changes should link back to
+the public issue, discussion, or pull request that records their rationale.
+
+The roadmap is reviewed when planning a minor or major release and whenever a
+material project-direction change is accepted. Completed work is documented in
+[GitHub releases](https://github.com/higress-group/higress/releases) and the
+[`release-notes`](./release-notes) directory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,11 +17,14 @@ your contributions.
 **Please do NOT report security vulnerabilities through public GitHub issues,
 discussions, or pull requests.**
 
-Instead, please report them through **both** of the following private channels:
+Instead, please use either of the following private channels. GitHub Private
+Security Advisories are the project's primary, vendor-neutral intake. The
+Alibaba Security Response Center is an optional alternate intake for reporters
+who cannot use GitHub; using both is not required.
 
-1. **GitHub Private Security Advisory**:
+1. **GitHub Private Security Advisory (preferred)**:
    <https://github.com/higress-group/higress/security/advisories/new>
-2. **Alibaba Security Response Center (ASRC)**:
+2. **Alibaba Security Response Center (optional alternate)**:
    <https://security.alibaba.com/>
 
 Please include as much of the following information as possible to help us
@@ -53,9 +56,56 @@ keep you informed of our progress throughout the process.
 
 ## Security Response Team
 
-The Higress security response is handled by the project maintainers listed in
-[`MAINTAINERS.md`](./MAINTAINERS.md). Security reports submitted via GitHub
-Private Security Advisory are visible to all current maintainers.
+The Security Response Team (SRT) is composed of the current project
+maintainers:
+
+- Yiquan Dong ([@CH3CHO](https://github.com/CH3CHO))
+- Yuanxiao Zhao ([@EndlessSeeker](https://github.com/EndlessSeeker))
+- Leilei Geng ([@gengleilei](https://github.com/gengleilei))
+- Xiantao Han ([@hanxiantao](https://github.com/hanxiantao))
+- Zhiwei Cheng ([@cr7258](https://github.com/cr7258))
+- Tianyi Zhang ([@johnlanni](https://github.com/johnlanni))
+- Jingfeng Xu ([@lexburner](https://github.com/lexburner))
+
+[`MAINTAINERS.md`](./MAINTAINERS.md) is authoritative for membership. A merged
+change to that roster onboards or offboards the same person from the SRT and
+their private security access must be updated promptly.
+
+For each report, the SRT assigns the following responsibilities in the private
+advisory or equivalent confidential case record:
+
+- **Triage coordinator**: acknowledges the report, maintains contact with the
+  reporter, assigns severity, tracks deadlines, and coordinates the team.
+- **Fix lead**: reproduces the issue and develops or coordinates remediation.
+- **Reviewer and release lead**: independently reviews the fix, prepares the
+  supported-version releases, and verifies that artifacts are available.
+- **Disclosure lead**: prepares the advisory, CVE request when appropriate,
+  credits, and coordinated public communication.
+
+One person may perform more than one role, but every confirmed vulnerability
+must involve at least two unconflicted SRT members so that remediation receives
+independent review.
+
+### Report handling, conflicts, and escalation
+
+1. Reports received through the optional alternate intake are transferred into
+   a GitHub Private Security Advisory or an access-controlled equivalent. The
+   case record contains the report, assignments, decisions, timeline, fix, and
+   disclosure plan.
+2. An SRT member with a personal, employer, or product conflict must disclose
+   it privately and recuse from severity, release, or disclosure decisions for
+   that case. The triage coordinator assigns an unconflicted replacement.
+3. If acknowledgement, triage, remediation, or disclosure is at risk of
+   missing the timelines in this policy, the triage coordinator escalates the
+   case to the full unconflicted SRT and records a revised plan. Critical
+   vulnerabilities are escalated immediately.
+4. If a reporter receives no acknowledgement within three business days, they
+   should use the other private reporting channel and reference the original
+   submission. No vulnerability details should be posted publicly.
+5. If fewer than two SRT members are unconflicted, the unconflicted member
+   escalates confidentially to the CNCF TOC private mailing list at
+   [cncf-private-toc@lists.cncf.io](mailto:cncf-private-toc@lists.cncf.io)
+   before a release or disclosure decision is made.
 
 ## Disclosure Policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,14 +17,15 @@ your contributions.
 **Please do NOT report security vulnerabilities through public GitHub issues,
 discussions, or pull requests.**
 
-Instead, please use either of the following private channels. GitHub Private
-Security Advisories are the project's primary, vendor-neutral intake. The
-Alibaba Security Response Center is an optional alternate intake for reporters
-who cannot use GitHub; using both is not required.
+Every vulnerability report must be submitted through both of the following
+private channels. Please provide the same substantive report to each channel
+and, when available, include the case identifier from the other channel so the
+Security Response Team can correlate the records. Do not wait for one channel
+to acknowledge the report before submitting it to the other.
 
-1. **GitHub Private Security Advisory (preferred)**:
+1. **GitHub Private Security Advisory (required)**:
    <https://github.com/higress-group/higress/security/advisories/new>
-2. **Alibaba Security Response Center (optional alternate)**:
+2. **Alibaba Security Response Center (required)**:
    <https://security.alibaba.com/>
 
 Please include as much of the following information as possible to help us
@@ -88,10 +89,11 @@ independent review.
 
 ### Report handling, conflicts, and escalation
 
-1. Reports received through the optional alternate intake are transferred into
-   a GitHub Private Security Advisory or an access-controlled equivalent. The
-   case record contains the report, assignments, decisions, timeline, fix, and
-   disclosure plan.
+1. The SRT correlates the required GitHub Private Security Advisory and Alibaba
+   Security Response Center submissions. The GitHub advisory or an equivalent
+   access-controlled project record contains the report, assignments,
+   decisions, timeline, fix, and disclosure plan; material status and
+   disclosure updates are reflected in both required reporting records.
 2. An SRT member with a personal, employer, or product conflict must disclose
    it privately and recuse from severity, release, or disclosure decisions for
    that case. The triage coordinator assigns an unconflicted replacement.
@@ -100,8 +102,9 @@ independent review.
    case to the full unconflicted SRT and records a revised plan. Critical
    vulnerabilities are escalated immediately.
 4. If a reporter receives no acknowledgement within three business days, they
-   should use the other private reporting channel and reference the original
-   submission. No vulnerability details should be posted publicly.
+   should follow up through both private reporting channels and reference both
+   case identifiers when available. No vulnerability details should be posted
+   publicly.
 5. If fewer than two SRT members are unconflicted, the unconflicted member
    escalates confidentially to the CNCF TOC private mailing list at
    [cncf-private-toc@lists.cncf.io](mailto:cncf-private-toc@lists.cncf.io)

--- a/docs/cncf/general-technical-review.md
+++ b/docs/cncf/general-technical-review.md
@@ -53,11 +53,13 @@ Feature scope is currently discussed through public GitHub issues and pull
 requests. Maintainers use lazy consensus, as documented in
 [`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/main/GOVERNANCE.md),
 to accept project-direction changes.
-Contributors implement accepted work through pull requests and may be nominated
-as maintainers after sustained contribution under
+Contributors implement accepted work through pull requests, may receive
+delegated path-review responsibility as code owners, and may be nominated as
+maintainers after sustained contribution under
 [`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/main/MAINTAINERS.md).
-The project does not currently have a dedicated, maintained public roadmap or a
-multi-level contributor ladder; these are documented project-maturity gaps.
+The project does not currently have a dedicated, maintained public roadmap,
+and objective progression expectations for the intermediate code-owner role
+remain a project-maturity gap.
 
 **Who are the target personas?**
 

--- a/docs/cncf/general-technical-review.md
+++ b/docs/cncf/general-technical-review.md
@@ -273,9 +273,8 @@ in ephemeral clusters and runs Gateway API and Higress conformance traffic.
 - **Explicit trust and boundaries:** Kubernetes administrators, xDS,
   certificate sources, plugins, registries, identity providers, and upstreams
   are separate trust boundaries described in the security self-assessment.
-- **Secure lifecycle:** public review, automated tests, license checks, CodeQL
-  configured for daily and `main`-push analysis, private advisories, and
-  coordinated disclosure are in place, with
+- **Secure lifecycle:** public review, automated tests, license checks, weekly
+  CodeQL, private advisories, and coordinated disclosure are in place, with
   SBOM/signing/dynamic-analysis gaps disclosed.
 
 Operators can loosen security by overriding pod/container security contexts,
@@ -288,12 +287,11 @@ threat model.
 maintained?**
 
 The project uses required review, build and unit tests with Go race detection,
-Gateway API/Higress conformance, plugin tests, license checks, CodeQL configured
-for daily and `main`-push analysis, versioned dependencies, Private Security
-Advisories, and coordinated disclosure. Certificate handling, RBAC
-reconciliation, xDS generation and validation, parsers/routing, authentication
-and authorization plugins, plugin loading, and release artifacts are treated
-as security-critical boundaries.
+Gateway API/Higress conformance, plugin tests, license checks, weekly CodeQL,
+versioned dependencies, Private Security Advisories, and coordinated
+disclosure. Certificate handling, RBAC reconciliation, xDS generation and
+validation, parsers/routing, authentication and authorization plugins, plugin
+loading, and release artifacts are treated as security-critical boundaries.
 
 **What privileges are required?**
 

--- a/docs/cncf/general-technical-review.md
+++ b/docs/cncf/general-technical-review.md
@@ -1,0 +1,375 @@
+# General Technical Review — Higress / Incubation
+
+- **Project:** Higress
+- **Project version:** v2.2.3
+- **Website:** <https://higress.ai/en/>
+- **Date updated:** 2026-07-21
+- **Template version:** CNCF General Technical Review v1.0
+- **Description:** Higress is a cloud-native API gateway built on Envoy and
+  Istio. It supports Kubernetes Ingress and Gateway API and is extensible with
+  Wasm plugins and native Go filters.
+
+This document answers all Day 0 and Day 1 questions required for an Incubation
+review. It follows the current CNCF TOC
+[General Technical Review questionnaire](https://github.com/cncf/toc/blob/main/toc_subprojects/project-reviews-subproject/general-technical-questions.md).
+Statements that are not yet backed by a project guarantee are identified as
+gaps rather than treated as completed controls.
+
+## Day 0 — Planning Phase
+
+### Scope
+
+**How are roadmap scope and mid- to long-term features determined, and how does
+that map to contributions and the maintainer ladder?**
+
+Feature scope is currently discussed through public GitHub issues and pull
+requests. Maintainers use lazy consensus, as documented in
+[`GOVERNANCE.md`](../../GOVERNANCE.md), to accept project-direction changes.
+Contributors implement accepted work through pull requests and may be nominated
+as maintainers after sustained contribution under
+[`MAINTAINERS.md`](../../MAINTAINERS.md). The project does not currently have a
+dedicated, maintained public roadmap or a multi-level contributor ladder; these
+are documented project-maturity gaps.
+
+**Who are the target personas?**
+
+- Platform and gateway engineers operating shared application entry points.
+- Application teams publishing APIs through Ingress or Gateway API.
+- AI platform teams governing access to LLM and MCP services.
+- Plugin developers extending request and response processing.
+- Security and SRE teams configuring policy, telemetry, and reliability.
+
+**What are the primary, additional, and unsupported use cases?**
+
+The primary use case is routing and governing north-south API traffic. Other
+supported use cases include Kubernetes Ingress and Gateway API, service
+registry integration, AI/LLM proxying, MCP server exposure, authentication,
+rate limiting, observability, and standalone development installations.
+
+Higress is not a transparent east-west service mesh, identity provider, model
+provider, general-purpose application runtime, secrets manager, or substitute
+for an organization's PKI, security governance, and incident response.
+
+**Which organizations benefit from adoption?**
+
+Organizations operating Kubernetes platforms, microservices, public or
+partner APIs, multi-provider AI platforms, or centralized platform-engineering
+services can benefit. Public examples are listed in
+[`ADOPTERS.md`](../../ADOPTERS.md).
+
+**What end-user research has been completed?**
+
+The project records adopter names and use cases in `ADOPTERS.md` and receives
+feedback through GitHub and Discord. No independent end-user research report or
+published structured interview set is currently available. Adopter interviews
+for CNCF Incubation remain to be completed through the official TOC process.
+
+### Usability
+
+**How do target personas interact with the project?**
+
+Cluster administrators install Higress with Helm. Platform teams configure it
+with Kubernetes Ingress, Gateway API, Higress and Istio custom resources, the
+`hgctl` CLI, or the optional console. Application teams normally submit routes
+and policies rather than operate the data plane directly. Plugin developers use
+the Wasm SDKs or native filter interfaces.
+
+**What are the UX and UI?**
+
+The primary interface is declarative Kubernetes YAML and Helm values. The
+optional Higress Console provides browser-based management of routes, services,
+certificates, and plugins. `hgctl` provides command-line operations. Runtime
+behavior is observed through logs, metrics, traces, Kubernetes status, and
+Envoy administration data where enabled.
+
+**How does Higress integrate with production environments?**
+
+Higress integrates with Kubernetes, Envoy, Istio APIs, Gateway API,
+Prometheus-compatible monitoring, OpenTelemetry tracing, OCI registries,
+certificate issuers, and service registries such as Nacos, Consul, Eureka, and
+ZooKeeper. AI deployments may integrate with identity services, Redis, and
+model providers. Except for Kubernetes in the standard Helm deployment, these
+integrations are optional and selected by the adopter.
+
+### Design
+
+**What design principles and practices are followed?**
+
+- Declarative, versioned APIs and reconciliation.
+- Separation of control plane and Envoy-based data plane.
+- xDS dynamic updates without gateway configuration reloads.
+- Standard Kubernetes Ingress and Gateway API where possible.
+- Independently versioned extensions, with Wasm used as an isolation boundary.
+- Compatibility and regression coverage through unit, race, conformance, and
+  end-to-end tests.
+
+The component architecture and data flow are documented in
+[`docs/architecture.md`](../architecture.md).
+
+**What differs between proof-of-concept, development, test, and production?**
+
+The all-in-one image or a minimal single-cluster Helm installation is suitable
+for evaluation. CI uses ephemeral kind clusters. Production operators should
+pin versions, use multiple gateway replicas, define resource sizing, configure
+PodDisruptionBudgets and topology placement, use production PKI, and monitor
+traffic and xDS health. The chart defaults to one controller replica and does
+not constitute a production high-availability guarantee.
+
+**Which services are required in the cluster?**
+
+The Kubernetes deployment requires the Kubernetes API and DNS. Higress
+controller/discovery supplies xDS to the gateway. The console, external service
+registries, Redis, certificate issuers, observability backends, OCI registries,
+and AI providers are optional.
+
+**How is identity and access management implemented?**
+
+Kubernetes ServiceAccounts and RBAC authorize control-plane access to cluster
+resources. TokenReview and SubjectAccessReview APIs are used by inherited Istio
+control-plane functions. Gateway-facing identity and policy are configured with
+TLS and plugins such as JWT, OIDC, key-auth, HMAC, and basic-auth. Higress does
+not operate an identity provider.
+
+**How is sovereignty addressed?**
+
+Higress does not transmit project usage telemetry by default. Operators choose
+their image/plugin registries, model providers, observability destinations,
+certificate authorities, and data locations. Request data is nevertheless
+processed by every configured gateway plugin and upstream provider; operators
+are responsible for selecting integrations that meet residency requirements.
+
+**Which compliance requirements are addressed?**
+
+The open-source project does not claim PCI-DSS, SOC 2, ISO 27001, GDPR, or other
+regulatory certification. It is Apache-2.0 licensed and CI includes source and
+dependency license checks. Deployers must assess their full environment and
+configuration.
+
+**What are the high-availability requirements?**
+
+Gateway availability requires multiple replicas or nodes, adequate capacity,
+health probes, and failure-domain placement. Controller unavailability stops
+new configuration but existing Envoy processes may continue serving their last
+accepted configuration. Production control-plane availability requires
+multiple appropriately configured replicas and Kubernetes leader-election
+behavior. The default single controller is a gap operators must address.
+
+**What are the CPU, network, memory, and storage requirements?**
+
+Current Helm defaults request 500m CPU and 2 GiB memory for the controller and
+2 CPU and 2 GiB memory per gateway. Actual requirements depend on route count,
+plugin set, configuration churn, request rate, payload sizes, connections, and
+telemetry. Operators must size from load tests. Traffic bandwidth and
+connection count drive network and socket consumption.
+
+Configuration and certificates are stored as Kubernetes API objects. Gateway
+and controller runtime files are ephemeral. The optional console and configured
+integrations may introduce separate persistence requirements.
+
+**What is the API design?**
+
+- **Topology and conventions:** Kubernetes Ingress, Gateway API, Istio
+  networking APIs, and versioned Higress CRDs under `networking.higress.io` and
+  `extensions.higress.io` are reconciled into xDS resources.
+- **Defaults:** Helm defaults create controller/discovery and gateway
+  deployments, ServiceAccounts, RBAC, Services, and CRDs. Gateway service type
+  defaults to `LoadBalancer`; automatic HTTPS is enabled in chart values.
+- **Additional configuration:** Production use normally requires explicit
+  resource sizing, exposure, TLS, replicas, credentials, monitoring, and route
+  policy.
+- **New/changed calls:** Enabling registry, certificate, identity, OCI, Redis,
+  or AI integrations causes calls to the endpoints explicitly configured by
+  the operator. Enabling Gateway API or inference support causes the controller
+  to watch and reconcile those API groups.
+- **Kubernetes compatibility:** Compatibility is tested with kind and Gateway
+  API conformance. CRD and Kubernetes-version requirements are carried in Helm
+  packaging and release dependencies.
+- **Versioning and breaking changes:** CRDs have explicit API versions. Stable
+  breaking changes require migration guidance, deprecation notice, and release
+  notes. Alpha Gateway API and inference capabilities are explicitly enabled
+  and do not have the same stability promise as stable APIs.
+
+**What is the release process?**
+
+Higress uses semantic version tags, including release-candidate suffixes when
+needed. A `v*.*.*` tag triggers workflows that build controller, pilot and
+gateway images, attach generated CRDs, build multi-platform `hgctl` archives,
+and generate release notes. Versions are recorded in `VERSION`, Helm chart
+metadata, dependency metadata, and `release-notes/`. The repository does not
+currently contain a single normative document defining release approval,
+rollback, security-release, and supported-version procedures; this is a
+documentation gap.
+
+### Installation
+
+**How is the project installed and initialized?**
+
+```console
+helm repo add higress.io https://higress.io/helm-charts
+helm repo update
+helm install higress -n higress-system higress.io/higress --create-namespace
+```
+
+The chart installs CRDs, controller/discovery, gateway, Services,
+ServiceAccounts, and RBAC. Operators then apply routes and policies or use the
+optional console.
+
+**How does an adopter validate installation?**
+
+Check the Helm release and Ready state of controller and gateway pods, apply a
+sample backend and route, then send an HTTP request through the gateway and
+inspect status, logs, and metrics. CI performs the same class of installation
+in ephemeral clusters and runs Gateway API and Higress conformance traffic.
+
+### Security
+
+**Where is the cloud-native security self-assessment?**
+
+[`docs/cncf/security-self-assessment.md`](./security-self-assessment.md)
+
+**How does Higress address the Cloud Native Security Tenets?**
+
+- **Secure by default:** gateway containers use non-root and restricted
+  settings on supported Kubernetes platforms, TLS and private Secret delivery
+  are supported, and optional integrations require explicit configuration.
+- **Least privilege:** separate ServiceAccounts and RBAC exist for controller
+  and gateway. The controller's broad ClusterRole and empty default container
+  security context are known exceptions requiring improvement.
+- **Defense in depth:** Kubernetes RBAC, TLS/SDS, Envoy validation, Wasm
+  isolation, authentication/policy plugins, and network controls provide
+  distinct layers.
+- **Explicit trust and boundaries:** Kubernetes administrators, xDS,
+  certificate sources, plugins, registries, identity providers, and upstreams
+  are separate trust boundaries described in the security self-assessment.
+- **Secure lifecycle:** public review, automated tests, license checks, weekly
+  CodeQL, private advisories, and coordinated disclosure are in place, with
+  SBOM/signing/dynamic-analysis gaps disclosed.
+
+Operators can loosen security by overriding pod/container security contexts,
+using privileged or host networking modes, expanding RBAC, exposing admin
+ports, disabling TLS/policy, or installing third-party/native plugins. These
+settings should be treated as risk acceptances and tested in the adopter's
+threat model.
+
+**What security hygiene is maintained, and which features are high risk if not
+maintained?**
+
+The project uses required review, build and unit tests with Go race detection,
+Gateway API/Higress conformance, plugin tests, license checks, weekly CodeQL,
+versioned dependencies, Private Security Advisories, and coordinated
+disclosure. Certificate handling, RBAC reconciliation, xDS generation and
+validation, parsers/routing, authentication and authorization plugins, plugin
+loading, and release artifacts are treated as security-critical boundaries.
+
+**What privileges are required?**
+
+The gateway reads Kubernetes Secrets for SDS. The controller watches and
+reconciles ingress, Gateway API, Higress/Istio, discovery, certificate,
+admission, and leader-election resources and performs TokenReview and
+SubjectAccessReview calls. Several controller rules are cluster-wide and use
+broad resource or verb sets. These are functional requirements of the current
+implementation, but the project has not demonstrated that every permission is
+minimal.
+
+**How are certificates rotated?**
+
+Gateway certificates are delivered through SDS. Automatic HTTPS can request
+and renew ACME certificates, and Kubernetes Secrets can be updated without
+gateway configuration reload. Operators remain responsible for issuer trust,
+renewal monitoring, emergency rotation, and external certificate systems.
+
+**How is the software supply chain secured?**
+
+Source and dependency licenses are checked; dependencies and submodule commits
+are versioned; changes are reviewed and tested; release artifacts are produced
+by GitHub Actions from version tags. Some workflow actions are commit-pinned.
+Project-generated release SBOMs, universal immutable action pinning, artifact
+signatures, and verifiable build provenance are not currently present and are
+recorded as gaps in the security self-assessment.
+
+## Day 1 — Installation and Deployment Phase
+
+### Project Installation and Configuration
+
+**What do installation and configuration look like?**
+
+Helm installs the project resources. Values select watched namespaces, replica
+counts, resources, autoscaling, Service exposure, security contexts,
+observability, Gateway API features, image/plugin registries, and optional
+integrations. Operators should pin a chart/application version and keep reviewed
+values in version control. Routes, services, credentials, and plugin policy are
+then applied as Kubernetes resources or through the console.
+
+### Project Enablement and Rollback
+
+**How is Higress enabled or disabled in a live cluster, and is downtime
+required?**
+
+Install the chart and direct selected IngressClasses, GatewayClasses, routes,
+DNS, or load-balancer traffic to Higress. Workloads do not require sidecars.
+With sufficient replicas, ordinary controller and gateway rolling updates are
+designed not to require application downtime. Capacity loss, incompatible
+configuration, or a single-replica deployment can cause interruption.
+
+Disable Higress by first moving traffic and route ownership to another entry
+point, then uninstalling the Helm release. Existing workload behavior changes
+only when traffic or resources select Higress.
+
+**How are enablement and disablement tested?**
+
+Pull-request CI installs Higress into kind and executes conformance and E2E
+traffic. There is no dedicated automated migration test that moves live traffic
+from another gateway to Higress and back; this is a gap.
+
+**How are created resources cleaned up, including CRDs?**
+
+`helm uninstall` removes chart-owned namespaced and cluster-scoped resources
+managed by the release. CRDs and user-authored custom resources must be
+inventoried and removed deliberately because automatic deletion could destroy
+configuration data.
+
+### Rollout, Upgrade and Rollback Planning
+
+**How is compatibility with Kubernetes and orchestration tools maintained?**
+
+The project updates Kubernetes, Gateway API, Istio, and Envoy dependencies and
+uses build, kind, conformance, and E2E workflows on ongoing changes. Supported
+versions are communicated through chart/dependency metadata, documentation,
+and releases. No fixed public compatibility-review cadence is documented.
+
+**How are rollbacks performed, and how can they fail?**
+
+Operators retain the previous Helm revision, values, configuration, and pinned
+images, then use `helm rollback <release> <revision>`. CRD storage/schema
+changes, incompatible user configuration, unavailable old images, RBAC changes,
+certificate changes, or external dependency changes may prevent a complete
+rollback. Control-plane failure may leave existing gateways serving their last
+accepted xDS state; data-plane rollout, plugin load failure, or invalid
+fail-closed policy can affect live traffic.
+
+**Which metrics should trigger rollback?**
+
+Readiness failures, xDS rejection/NACKs, HTTP 4xx/5xx changes, latency and
+timeout regression, gateway/controller restart rate, certificate errors,
+plugin load failures, connection failures, and CPU/memory/socket saturation
+should be compared with the pre-rollout baseline.
+
+**How are upgrade→downgrade→upgrade paths tested?**
+
+The repository tests clean installation and current-version conformance but
+does not contain a dedicated automated upgrade→downgrade→upgrade version
+matrix. This is a known Day 1 gap; operators must validate their exact source
+and target versions in a non-production cluster.
+
+**How are deprecations and removals communicated?**
+
+They are communicated through GitHub releases, versioned release notes,
+documentation, and API/version changes. The project does not currently have a
+single documented minimum deprecation period, which is a process gap.
+
+**How are alpha and beta capabilities used during rollout?**
+
+Alpha Gateway API and inference capabilities are selected through explicit
+chart values and API versions. Operators should enable them first in a test or
+canary environment, monitor the rollback signals above, and avoid relying on
+their stability as if they were stable APIs.

--- a/docs/cncf/general-technical-review.md
+++ b/docs/cncf/general-technical-review.md
@@ -7,8 +7,8 @@
 - **Template version:** CNCF General Technical Review v1.0
 - **Review state:** Project working draft; maintainer approval and CNCF Project
   Reviews verification pending
-- **Evidence revision:**
-  [`higress-group/higress@762324c`](https://github.com/higress-group/higress/tree/762324c3767c620fef593504bcedf28f7969a954)
+- **Evidence branch:**
+  [`higress-group/higress@main`](https://github.com/higress-group/higress/tree/main)
 - **Intended TOC snapshot:** `projects/higress/tech-review/YYYY-MM-DD.md`
 - **Description:** Higress is a cloud-native API gateway built on Envoy and
   Istio. It supports Kubernetes Ingress and Gateway API and is extensible with
@@ -22,8 +22,8 @@ gaps rather than treated as completed controls.
 
 This is the project-maintained working copy. For formal Due Diligence, a CNCF
 reviewer or associate verifies it and archives a dated snapshot in `cncf/toc`.
-Project-local relative links must be converted to versioned, absolute
-permalinks when that snapshot is prepared.
+The reviewer should freeze evidence links to the reviewed revision when that
+snapshot is archived.
 
 ## Project Self-Assessment Summary
 
@@ -51,11 +51,11 @@ that map to contributions and the maintainer ladder?**
 
 Feature scope is currently discussed through public GitHub issues and pull
 requests. Maintainers use lazy consensus, as documented in
-[`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/GOVERNANCE.md),
+[`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/main/GOVERNANCE.md),
 to accept project-direction changes.
 Contributors implement accepted work through pull requests and may be nominated
 as maintainers after sustained contribution under
-[`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/MAINTAINERS.md).
+[`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/main/MAINTAINERS.md).
 The project does not currently have a dedicated, maintained public roadmap or a
 multi-level contributor ladder; these are documented project-maturity gaps.
 
@@ -83,7 +83,7 @@ for an organization's PKI, security governance, and incident response.
 Organizations operating Kubernetes platforms, microservices, public or
 partner APIs, multi-provider AI platforms, or centralized platform-engineering
 services can benefit. Public examples are listed in
-[`ADOPTERS.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/ADOPTERS.md).
+[`ADOPTERS.md`](https://github.com/higress-group/higress/blob/main/ADOPTERS.md).
 
 **What end-user research has been completed?**
 
@@ -132,7 +132,7 @@ integrations are optional and selected by the adopter.
   end-to-end tests.
 
 The component architecture and data flow are documented in
-[`docs/architecture.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/docs/architecture.md).
+[`docs/architecture.md`](https://github.com/higress-group/higress/blob/main/docs/architecture.md).
 
 **What differs between proof-of-concept, development, test, and production?**
 

--- a/docs/cncf/general-technical-review.md
+++ b/docs/cncf/general-technical-review.md
@@ -5,6 +5,11 @@
 - **Website:** <https://higress.ai/en/>
 - **Date updated:** 2026-07-21
 - **Template version:** CNCF General Technical Review v1.0
+- **Review state:** Project working draft; maintainer approval and CNCF Project
+  Reviews verification pending
+- **Evidence revision:**
+  [`higress-group/higress@762324c`](https://github.com/higress-group/higress/tree/762324c3767c620fef593504bcedf28f7969a954)
+- **Intended TOC snapshot:** `projects/higress/tech-review/YYYY-MM-DD.md`
 - **Description:** Higress is a cloud-native API gateway built on Envoy and
   Istio. It supports Kubernetes Ingress and Gateway API and is extensible with
   Wasm plugins and native Go filters.
@@ -15,6 +20,28 @@ review. It follows the current CNCF TOC
 Statements that are not yet backed by a project guarantee are identified as
 gaps rather than treated as completed controls.
 
+This is the project-maintained working copy. For formal Due Diligence, a CNCF
+reviewer or associate verifies it and archives a dated snapshot in `cncf/toc`.
+Project-local relative links must be converted to versioned, absolute
+permalinks when that snapshot is prepared.
+
+## Project Self-Assessment Summary
+
+Higress has substantive evidence for every Day 0 and Day 1 question, but this
+document does not assign the project an external technical-review rating. The
+strongest Day 1 gaps are the absence of an automated
+upgrade→downgrade→upgrade matrix, a normative release process and bounded
+supported-version/EOL policy, a published compatibility-review cadence, and
+complete release supply-chain attestations. Broad control-plane RBAC also
+requires minimization and documented justification. These findings should be
+tracked during Due Diligence rather than hidden by marking the questionnaire
+complete.
+
+Day 2 questions are not required for an Incubation application and are not
+answered in this snapshot. Operational evidence that already exists may be
+added during CNCF review, but it is not needed to make the Day 0 and Day 1
+scope complete.
+
 ## Day 0 — Planning Phase
 
 ### Scope
@@ -24,12 +51,13 @@ that map to contributions and the maintainer ladder?**
 
 Feature scope is currently discussed through public GitHub issues and pull
 requests. Maintainers use lazy consensus, as documented in
-[`GOVERNANCE.md`](../../GOVERNANCE.md), to accept project-direction changes.
+[`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/GOVERNANCE.md),
+to accept project-direction changes.
 Contributors implement accepted work through pull requests and may be nominated
 as maintainers after sustained contribution under
-[`MAINTAINERS.md`](../../MAINTAINERS.md). The project does not currently have a
-dedicated, maintained public roadmap or a multi-level contributor ladder; these
-are documented project-maturity gaps.
+[`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/MAINTAINERS.md).
+The project does not currently have a dedicated, maintained public roadmap or a
+multi-level contributor ladder; these are documented project-maturity gaps.
 
 **Who are the target personas?**
 
@@ -55,7 +83,7 @@ for an organization's PKI, security governance, and incident response.
 Organizations operating Kubernetes platforms, microservices, public or
 partner APIs, multi-provider AI platforms, or centralized platform-engineering
 services can benefit. Public examples are listed in
-[`ADOPTERS.md`](../../ADOPTERS.md).
+[`ADOPTERS.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/ADOPTERS.md).
 
 **What end-user research has been completed?**
 
@@ -104,7 +132,7 @@ integrations are optional and selected by the adopter.
   end-to-end tests.
 
 The component architecture and data flow are documented in
-[`docs/architecture.md`](../architecture.md).
+[`docs/architecture.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/docs/architecture.md).
 
 **What differs between proof-of-concept, development, test, and production?**
 

--- a/docs/cncf/general-technical-review.md
+++ b/docs/cncf/general-technical-review.md
@@ -30,9 +30,8 @@ snapshot is archived.
 Higress has substantive evidence for every Day 0 and Day 1 question, but this
 document does not assign the project an external technical-review rating. The
 strongest Day 1 gaps are the absence of an automated
-upgrade→downgrade→upgrade matrix, a normative release process and bounded
-supported-version/EOL policy, a published compatibility-review cadence, and
-complete release supply-chain attestations. Broad control-plane RBAC also
+upgrade→downgrade→upgrade matrix, a published compatibility-review cadence,
+and complete release supply-chain attestations. Broad control-plane RBAC also
 requires minimization and documented justification. These findings should be
 tracked during Due Diligence rather than hidden by marking the questionnaire
 complete.
@@ -49,7 +48,10 @@ scope complete.
 **How are roadmap scope and mid- to long-term features determined, and how does
 that map to contributions and the maintainer ladder?**
 
-Feature scope is currently discussed through public GitHub issues and pull
+Forward-looking goals and target versions are maintained in the public
+[`ROADMAP.md`](https://github.com/higress-group/higress/blob/main/ROADMAP.md),
+which links the version-controlled website roadmap. Feature scope and roadmap
+changes are discussed through public GitHub issues, discussions, and pull
 requests. Maintainers use lazy consensus, as documented in
 [`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/main/GOVERNANCE.md),
 to accept project-direction changes.
@@ -57,9 +59,8 @@ Contributors implement accepted work through pull requests, may receive
 delegated path-review responsibility as code owners, and may be nominated as
 maintainers after sustained contribution under
 [`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/main/MAINTAINERS.md).
-The project does not currently have a dedicated, maintained public roadmap,
-and objective progression expectations for the intermediate code-owner role
-remain a project-maturity gap.
+Objective progression expectations for the intermediate code-owner role remain
+a project-maturity gap.
 
 **Who are the target personas?**
 
@@ -225,10 +226,11 @@ Higress uses semantic version tags, including release-candidate suffixes when
 needed. A `v*.*.*` tag triggers workflows that build controller, pilot and
 gateway images, attach generated CRDs, build multi-platform `hgctl` archives,
 and generate release notes. Versions are recorded in `VERSION`, Helm chart
-metadata, dependency metadata, and `release-notes/`. The repository does not
-currently contain a single normative document defining release approval,
-rollback, security-release, and supported-version procedures; this is a
-documentation gap.
+metadata, dependency metadata, and `release-notes/`. The normative
+[`RELEASE.md`](https://github.com/higress-group/higress/blob/main/RELEASE.md)
+defines planning, two-person approval, validation, tagging, publishing,
+verification, rollback/correction, security releases, and supported-version
+changes.
 
 ### Installation
 
@@ -271,8 +273,9 @@ in ephemeral clusters and runs Gateway API and Higress conformance traffic.
 - **Explicit trust and boundaries:** Kubernetes administrators, xDS,
   certificate sources, plugins, registries, identity providers, and upstreams
   are separate trust boundaries described in the security self-assessment.
-- **Secure lifecycle:** public review, automated tests, license checks, weekly
-  CodeQL, private advisories, and coordinated disclosure are in place, with
+- **Secure lifecycle:** public review, automated tests, license checks, CodeQL
+  configured for daily and `main`-push analysis, private advisories, and
+  coordinated disclosure are in place, with
   SBOM/signing/dynamic-analysis gaps disclosed.
 
 Operators can loosen security by overriding pod/container security contexts,
@@ -285,11 +288,12 @@ threat model.
 maintained?**
 
 The project uses required review, build and unit tests with Go race detection,
-Gateway API/Higress conformance, plugin tests, license checks, weekly CodeQL,
-versioned dependencies, Private Security Advisories, and coordinated
-disclosure. Certificate handling, RBAC reconciliation, xDS generation and
-validation, parsers/routing, authentication and authorization plugins, plugin
-loading, and release artifacts are treated as security-critical boundaries.
+Gateway API/Higress conformance, plugin tests, license checks, CodeQL configured
+for daily and `main`-push analysis, versioned dependencies, Private Security
+Advisories, and coordinated disclosure. Certificate handling, RBAC
+reconciliation, xDS generation and validation, parsers/routing, authentication
+and authorization plugins, plugin loading, and release artifacts are treated
+as security-critical boundaries.
 
 **What privileges are required?**
 
@@ -394,8 +398,10 @@ and target versions in a non-production cluster.
 **How are deprecations and removals communicated?**
 
 They are communicated through GitHub releases, versioned release notes,
-documentation, and API/version changes. The project does not currently have a
-single documented minimum deprecation period, which is a process gap.
+documentation, and API/version changes. `RELEASE.md` requires migration and
+deprecation guidance in the release pull request and announcement. The project
+does not currently define a universal minimum deprecation period for all API
+types, which remains a process improvement.
 
 **How are alpha and beta capabilities used during rollout?**
 

--- a/docs/cncf/governance-review.md
+++ b/docs/cncf/governance-review.md
@@ -8,16 +8,16 @@ the public review.
 
 - **Review state:** Project working draft; maintainer approval and CNCF Project
   Reviews verification pending
-- **Evidence revision:**
-  [`higress-group/higress@762324c`](https://github.com/higress-group/higress/tree/762324c3767c620fef593504bcedf28f7969a954)
+- **Evidence branch:**
+  [`higress-group/higress@main`](https://github.com/higress-group/higress/tree/main)
 - **Template verified:** 2026-07-21 against `cncf/toc` `main`
 - **Intended TOC snapshot:**
   `projects/higress/governance-review/YYYY-MM-DD.md`
 
 This is the project-maintained working copy. CNCF reviewers may revise the
 status and findings before a dated snapshot is archived in `cncf/toc`.
-Project-local relative links must be converted to versioned, absolute
-permalinks for that archive.
+The reviewer should freeze evidence links to the reviewed revision when that
+snapshot is archived.
 
 ## Summary and Assessment
 
@@ -42,13 +42,13 @@ satisfied.
 The self-assessment reviewed the following repository evidence as it exists on
 2026-07-21:
 
-- [`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/GOVERNANCE.md)
-- [`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/MAINTAINERS.md)
-- [`CODEOWNERS`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/CODEOWNERS)
-- [`CONTRIBUTING_EN.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/CONTRIBUTING_EN.md)
-- [`CODE_OF_CONDUCT.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/CODE_OF_CONDUCT.md)
-- [`SECURITY.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/SECURITY.md)
-- [`README.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/README.md)
+- [`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/main/GOVERNANCE.md)
+- [`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/main/MAINTAINERS.md)
+- [`CODEOWNERS`](https://github.com/higress-group/higress/blob/main/CODEOWNERS)
+- [`CONTRIBUTING_EN.md`](https://github.com/higress-group/higress/blob/main/CONTRIBUTING_EN.md)
+- [`CODE_OF_CONDUCT.md`](https://github.com/higress-group/higress/blob/main/CODE_OF_CONDUCT.md)
+- [`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md)
+- [`README.md`](https://github.com/higress-group/higress/blob/main/README.md)
 - Git history for the governance, maintainer, and ownership files
 
 The review distinguishes documented policy from observed repository evidence.

--- a/docs/cncf/governance-review.md
+++ b/docs/cncf/governance-review.md
@@ -1,0 +1,260 @@
+# Higress Governance Review
+
+This is the Higress project's self-assessed Governance Review for its CNCF
+Incubation application. It follows the current CNCF TOC
+[Governance Review Template](https://github.com/cncf/toc/blob/main/toc_subprojects/project-reviews-subproject/governance-review-template.md).
+A CNCF Project Reviews reviewer may amend the assessment and findings during
+the public review.
+
+## Summary and Assessment
+
+**Status: Needs Work**
+
+Higress has discoverable governance, maintainer, code-owner, contribution,
+security, and Code of Conduct documents. Decisions default to public lazy
+consensus, and the maintainer list includes seven people affiliated with four
+organizations.
+
+The review nevertheless finds several Incubation-required evidence gaps: the
+maintainer roster does not state responsibility domains; the relationship
+between `CODEOWNERS` and governance roles is not defined; the CNCF project
+subproject scope is ambiguous; all communication channels are not inventoried;
+and there is no documented current public meeting scheduler. These findings
+must be resolved before the project claims the Governance Review criterion is
+satisfied.
+
+### Executing the Assessment
+
+The self-assessment reviewed the following repository evidence as it exists on
+2026-07-21:
+
+- [`GOVERNANCE.md`](../../GOVERNANCE.md)
+- [`MAINTAINERS.md`](../../MAINTAINERS.md)
+- [`CODEOWNERS`](../../CODEOWNERS)
+- [`CONTRIBUTING_EN.md`](../../CONTRIBUTING_EN.md)
+- [`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md)
+- [`SECURITY.md`](../../SECURITY.md)
+- [`README.md`](../../README.md)
+- Git history for the governance, maintainer, and ownership files
+
+The review distinguishes documented policy from observed repository evidence.
+It does not infer private processes or settings that are not publicly recorded.
+
+### Must-Fix Items
+
+The following issues need to be resolved before the Higress Incubation
+application asserts completion of its Governance Review:
+
+1. Add each maintainer's domain of responsibility to `MAINTAINERS.md` and
+   confirm the listed people are currently active.
+2. Define the authority and lifecycle of code owners and explain how
+   `CODEOWNERS` relates to project-wide maintainer authority.
+3. Document a complete maintainer lifecycle, including onboarding, voluntary
+   departure, inactivity/removal, emeritus status, and return.
+4. Explicitly document vendor-neutral project direction and conflict-of-
+   interest handling.
+5. Define the repositories/subprojects in the CNCF Higress project scope and
+   the process for adding, removing, or archiving a subproject.
+6. Inventory all public and non-public communication channels and state the
+   limited purpose of each non-public channel.
+7. Publish an up-to-date public meeting scheduler or CNCF calendar entry and a
+   discoverable location for agendas and notes.
+8. Document how the project approves requests to CNCF and how function-based
+   teams such as the Security Response Team are assigned and removed.
+
+### Points of Excellence
+
+- The maintainer roster is public and shows affiliation diversity across
+  Alibaba Cloud, Trip.com, XinYe Technology, and NVIDIA.
+- The project has a public contribution path, code-review ownership file,
+  vulnerability reporting process, and CNCF-aligned Code of Conduct.
+- Governance declares openness, fairness, community-first decision-making,
+  inclusivity, participation, public lazy consensus, and public voting when
+  consensus fails.
+
+### Areas for Improvement
+
+The following are non-blocking at Incubation but would improve long-term
+governance maturity:
+
+- Introduce a contributor ladder with intermediate roles and objective
+  progression expectations.
+- Record governance evolution and link decisions to issues or pull requests.
+- Publish examples demonstrating the maintainer lifecycle in practice.
+- Periodically audit maintainer activity and code-owner coverage across all
+  project repositories.
+- Track contributor growth and recruitment using public CNCF/DevStats metrics.
+
+---
+
+## Review
+
+This review audits the project's current governance evidence. The project's
+Incubation application has not yet been opened; this file is the project's
+self-assessment to accompany that application.
+
+### Governance Summary
+
+Higress uses maintainer-led lazy consensus. When consensus cannot be reached,
+maintainers may vote publicly and a simple majority of votes cast decides. The
+governance document delegates role detail to the maintainer, code-owner, and
+contribution documents. Security reports are handled by the maintainers. The
+model is understandable at a high level, but role boundaries and lifecycle
+details are incomplete.
+
+### Governance Evolution
+
+**Incubating: Suggested — Partially satisfied.**
+
+`GOVERNANCE.md` and `MAINTAINERS.md` were introduced in April 2026, and
+`CODEOWNERS` has changed repeatedly since 2022. This demonstrates change over
+time, but the repository does not explain why governance evolved or connect
+those changes to project experience and outcomes.
+
+### Discoverability
+
+**Incubating: Suggested — Satisfied.**
+
+The README links the governance, maintainer, contribution, Code of Conduct, and
+security documents from its Community section.
+
+### Accuracy and Clarity
+
+**Governance reflects actual activities — Incubating: Suggested — Partially
+satisfied.**
+
+Public issue/PR collaboration and lazy consensus are consistent with the
+repository workflow. No election or recurring meeting is claimed. However,
+actual code-owner authority, security-team operation, and meeting practices are
+not fully documented.
+
+**Vendor-neutral direction — Incubating: Suggested — Not satisfied.**
+
+The values say contributions are evaluated without regard to company
+affiliation, but governance does not explicitly prohibit employer seats,
+employer vetoes, vendor-favored defaults, or undisclosed conflicts of interest.
+
+### Decisions and Role Assignments
+
+**Leadership, contribution, CNCF, governance, and goal decisions — Incubating:
+Suggested — Partially satisfied.**
+
+Maintainer nomination and general lazy consensus/voting are documented.
+Contribution acceptance is described in the contribution guide and CODEOWNERS.
+Requests to CNCF, project-scope changes, and detailed governance-change notice
+or quorum requirements are not documented.
+
+**Function-based teams — Incubating: Suggested — Not satisfied.**
+
+`SECURITY.md` states that all maintainers handle security response, but does
+not define onboarding, removal, conflicts, escalation ownership, or a change
+process for that function.
+
+### Maintainers and Maintainer Lifecycle
+
+**Complete lifecycle — Incubating: Suggested — Not satisfied.**
+
+The project documents nomination and lazy-consensus acceptance. It does not
+document offboarding, inactivity, removal, emeritus status, or return.
+
+**Lifecycle demonstrated — Incubating: Suggested — Not demonstrated.**
+
+The maintainer file has only one introducing commit in the available history.
+No public example of adding, replacing, or moving a maintainer to emeritus is
+linked.
+
+**Names, contact, responsibility, affiliation — Incubating: Required —
+Partially satisfied.**
+
+Names, GitHub contacts, and affiliations are present. Responsibility domains
+are absent.
+
+**Appropriate number of active maintainers — Incubating: Required — Evidence
+incomplete.**
+
+Seven maintainers are listed, which is plausible for the project scope, but the
+roster alone does not prove current review, release, and governance activity.
+The application should link recent evidence for each active maintainer or
+update the roster.
+
+**Maintainers from at least two organizations — Incubating: N/A, but met.**
+
+The roster names four affiliations.
+
+### Ownership
+
+**Code and documentation ownership matches governance roles — Incubating:
+Required — Evidence incomplete.**
+
+`CODEOWNERS` assigns directory review to maintainers and additional GitHub
+users. Governance does not define “code owner,” its authority, appointment, or
+removal, so the review cannot establish that the file matches documented roles.
+
+### Code of Conduct
+
+**Adoption and adherence — Incubating: Required — Satisfied as documented.**
+
+The project adopts the CNCF Code of Conduct in `CODE_OF_CONDUCT.md` and links it
+from the README and governance.
+
+**Cross-link from governance — Incubating: Required — Satisfied.**
+
+`GOVERNANCE.md` links both the CNCF Code of Conduct and the project copy.
+
+### Subprojects
+
+**All subprojects listed — Incubating: Required — Not satisfied.**
+
+The README labels `higress-console`, `higress-standalone`, `plugin-server`, and
+`wasm-go` as “Related Repositories,” but does not distinguish CNCF subprojects
+from integrations or independently governed related tools. No authoritative
+scope list exists in governance.
+
+**Subproject lifecycle — Incubating: Suggested — Not satisfied.**
+
+Leadership, contribution, maturity status, and add/remove/archive processes are
+not documented for the related repositories.
+
+### Contributors and Community
+
+**Contributor ladder — Incubating: Suggested — Partially satisfied.**
+
+Contributor and maintainer paths exist, and CODEOWNERS implies an intermediate
+review role, but the role is not governed and no complete ladder is documented.
+
+**Issue and change submission — Incubating: Required — Satisfied.**
+
+`CONTRIBUTING_EN.md`, issue templates, and the pull-request template document
+the process.
+
+**At least one public communication channel — Incubating: Required —
+Satisfied.**
+
+GitHub Issues, pull requests, and Discord are publicly documented.
+
+**All public/private channels documented — Incubating: Required — Not
+satisfied.**
+
+The README documents Discord and GitHub contribution paths, and `SECURITY.md`
+documents two private vulnerability-reporting channels. There is no single
+inventory asserting completeness, covering subprojects, or explaining all
+non-public purposes.
+
+**Public meeting scheduler/CNCF calendar — Incubating: Required — Not
+satisfied.**
+
+No current scheduler, CNCF calendar entry, agenda, or meeting-notes location is
+linked from the reviewed repository documents.
+
+**Contribution documentation — Incubating: Required — Satisfied.**
+
+The contribution guide covers issues, pull requests, branches, commits, tests,
+style, and AI-assisted contribution requirements.
+
+**Contributor activity and recruitment — Incubating: Required — Evidence
+incomplete.**
+
+The README displays the contributor graph and the repository has recent
+multi-author activity, but the Incubation application should provide public
+metrics demonstrating sustained contributor growth, review participation, and
+recruitment beyond raw commit counts.

--- a/docs/cncf/governance-review.md
+++ b/docs/cncf/governance-review.md
@@ -21,21 +21,21 @@ snapshot is archived.
 
 ## Summary and Assessment
 
-**Status: Needs Work**
+**Status: Mostly Satisfactory**
 
 Higress has discoverable governance, maintainer, code-owner, contribution,
-security, and Code of Conduct documents. Decisions default to public lazy
-consensus, and the maintainer list includes seven people affiliated with four
-organizations.
+community, security, and Code of Conduct documents. The project defines
+project-wide maintainer responsibility, delegated code ownership, subproject
+scope, vendor-neutral decisions, maintainer lifecycle, communication channels,
+and security-response roles. The maintainer list includes seven publicly active
+people affiliated with four organizations.
 
-The review nevertheless finds several Incubation-required evidence gaps: the
-maintainer roster does not state responsibility domains; the relationship
-between `CODEOWNERS` and governance roles is not defined; the CNCF project
-subproject scope is ambiguous; all communication channels are not inventoried;
-there is no documented current public meeting scheduler; and evidence of
-maintainer activity and contributor recruitment is incomplete. These findings
-must be resolved before the project claims the Governance Review criterion is
-satisfied.
+The documentation and public evidence satisfy all Governance Review criteria
+except one Incubation-required item: Higress does not currently publish an
+up-to-date public meeting scheduler or CNCF calendar entry with a durable
+location for agendas and notes. The project should establish that real public
+meeting infrastructure before asserting that the Governance Review has no
+remaining Must-Fix item.
 
 ### Executing the Assessment
 
@@ -47,6 +47,7 @@ The self-assessment reviewed the following repository evidence as it exists on
 - [`CODEOWNERS`](https://github.com/higress-group/higress/blob/main/CODEOWNERS)
 - [`CONTRIBUTING_EN.md`](https://github.com/higress-group/higress/blob/main/CONTRIBUTING_EN.md)
 - [`CODE_OF_CONDUCT.md`](https://github.com/higress-group/higress/blob/main/CODE_OF_CONDUCT.md)
+- [`COMMUNITY.md`](https://github.com/higress-group/higress/blob/main/COMMUNITY.md)
 - [`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md)
 - [`README.md`](https://github.com/higress-group/higress/blob/main/README.md)
 - Git history for the governance, maintainer, and ownership files
@@ -59,54 +60,36 @@ It does not infer private processes or settings that are not publicly recorded.
 The following issues need to be resolved before the Higress Incubation
 application asserts completion of its Governance Review:
 
-1. Add each maintainer's domain of responsibility to `MAINTAINERS.md` and
-   confirm the listed people are currently active.
-2. Define the authority and lifecycle of code owners and explain how
-   `CODEOWNERS` relates to project-wide maintainer authority.
-3. Define and list the repositories/subprojects in the CNCF Higress project
-   scope.
-4. Inventory all public and non-public communication channels and state the
-   limited purpose of each non-public channel.
-5. Publish an up-to-date public meeting scheduler or CNCF calendar entry and a
+1. Publish an up-to-date public meeting scheduler or CNCF calendar entry and a
    discoverable location for agendas and notes.
-6. Publish evidence of current maintainer activity, contributor activity, and
-   contributor recruitment rather than relying on the roster or raw commit
-   count alone.
-7. Name the Security Response Team membership and document role
-   responsibilities, report handling, conflicts, and escalation. The current
-   reference to all maintainers does not provide enough operational detail for
-   the Incubation application's security-role requirement.
 
 ### Points of Excellence
 
 - The maintainer roster is public and shows affiliation diversity across
-  Alibaba Cloud, Trip.com, XinYe Technology, and NVIDIA.
-- The project has a public contribution path, code-review ownership file,
-  vulnerability reporting process, and CNCF-aligned Code of Conduct.
-- Governance declares openness, fairness, community-first decision-making,
-  inclusivity, participation, public lazy consensus, and public voting when
-  consensus fails.
+  Alibaba Cloud, Trip.com, XinYe Technology, and NVIDIA, with linked public
+  activity evidence for every listed maintainer.
+- Governance distinguishes delegated code ownership from project-wide
+  maintainer authority and defines role and subproject lifecycle processes.
+- The project publishes an authoritative channel inventory and separates
+  public project decisions from narrowly scoped confidential reporting.
+- The named Security Response Team has defined incident roles, independent
+  review, conflict handling, and escalation.
+- Governance explicitly protects vendor-neutral direction through individual
+  seats, equal voting weight, and conflict disclosure.
 
 ### Areas for Improvement
 
 The following are non-blocking at Incubation but would improve long-term
 governance maturity:
 
-- Introduce a contributor ladder with intermediate roles and objective
-  progression expectations.
-- Complete the maintainer lifecycle with voluntary departure,
-  inactivity/removal, emeritus status, and return.
-- Explicitly document vendor-neutral project direction, employer-seat
-  neutrality, and conflict-of-interest handling.
-- Document how the project approves requests to CNCF and how function-based
-  teams are created, staffed, and retired.
-- Define how subprojects are added, removed, or archived and how their
-  leadership and maturity are recorded.
 - Record governance evolution and link decisions to issues or pull requests.
 - Publish examples demonstrating the maintainer lifecycle in practice.
-- Periodically audit maintainer activity and code-owner coverage across all
-  project repositories.
-- Track contributor growth and recruitment using public CNCF/DevStats metrics.
+- Add objective progression expectations for appointment to the code-owner
+  role.
+- Extend `CODEOWNERS` or equivalent ownership records to each active
+  subproject and periodically audit coverage.
+- Track contributor growth and recruitment trends using the linked CNCF
+  DevStats metrics, not only point-in-time activity.
 
 ---
 
@@ -118,12 +101,13 @@ self-assessment to accompany that application.
 
 ### Governance Summary
 
-Higress uses maintainer-led lazy consensus. When consensus cannot be reached,
-maintainers may vote publicly and a simple majority of votes cast decides. The
-governance document delegates role detail to the maintainer, code-owner, and
-contribution documents. Security reports are handled by the maintainers. The
-model is understandable at a high level, but role boundaries and lifecycle
-details are incomplete.
+Higress uses maintainer-led lazy consensus. Significant decisions are recorded
+in public issues or pull requests. When consensus cannot be reached,
+non-conflicted maintainers may vote publicly and a simple majority of votes
+cast decides. Governance defines contributor, code-owner, and maintainer
+authority; the maintainer and subproject lifecycles; vendor neutrality; and
+function-based teams. Confidential security work is handled by a named
+Security Response Team under a public mandate.
 
 ### Governance Evolution
 
@@ -143,42 +127,43 @@ security documents from its Community section.
 
 ### Accuracy and Clarity
 
-**Governance reflects actual activities — Incubating: Suggested — Partially
-satisfied.**
+**Governance reflects actual activities — Incubating: Suggested — Satisfied.**
 
 Public issue/PR collaboration and lazy consensus are consistent with the
-repository workflow. No election or recurring meeting is claimed. However,
-actual code-owner authority, security-team operation, and meeting practices are
-not fully documented.
+repository workflow. Code-owner authority, security-team operation, and the
+absence of a current recurring public meeting are documented without claiming
+unobserved processes.
 
-**Vendor-neutral direction — Incubating: Suggested — Not satisfied.**
+**Vendor-neutral direction — Incubating: Suggested — Satisfied.**
 
-The values say contributions are evaluated without regard to company
-affiliation, but governance does not explicitly prohibit employer seats,
-employer vetoes, vendor-favored defaults, or undisclosed conflicts of interest.
+Governance states that roles are held by individuals, prohibits guaranteed
+employer seats, vetoes, or preferred decision weight, requires material
+conflict disclosure, and evaluates contributions and integrations on community
+and technical merit.
 
 ### Decisions and Role Assignments
 
 **Leadership, contribution, CNCF, governance, and goal decisions — Incubating:
-Suggested — Partially satisfied.**
+Suggested — Satisfied.**
 
-Maintainer nomination and general lazy consensus/voting are documented.
-Contribution acceptance is described in the contribution guide and CODEOWNERS.
-Requests to CNCF, project-scope changes, and detailed governance-change notice
-or quorum requirements are not documented.
+Governance applies public lazy consensus and non-conflicted maintainer voting
+to leadership, contribution acceptance, goals, requests to CNCF, subproject
+scope, and governance changes. The contribution guide and `CODEOWNERS` provide
+the day-to-day change-review path.
 
-**Function-based teams — Incubating: Suggested — Not satisfied.**
+**Function-based teams — Incubating: Suggested — Satisfied.**
 
-`SECURITY.md` states that all maintainers handle security response, but does
-not define onboarding, removal, conflicts, escalation ownership, or a change
-process for that function.
+Governance defines the creation and retirement requirements for function-based
+teams. `SECURITY.md` names the Security Response Team and defines onboarding,
+offboarding, incident assignments, conflicts, independent review, and
+escalation.
 
 ### Maintainers and Maintainer Lifecycle
 
-**Complete lifecycle — Incubating: Suggested — Not satisfied.**
+**Complete lifecycle — Incubating: Suggested — Satisfied.**
 
-The project documents nomination and lazy-consensus acceptance. It does not
-document offboarding, inactivity, removal, emeritus status, or return.
+The project documents nomination, public activity review, voluntary departure,
+inactivity, removal, emeritus status, and return.
 
 **Lifecycle demonstrated — Incubating: Suggested — Not demonstrated.**
 
@@ -187,18 +172,18 @@ No public example of adding, replacing, or moving a maintainer to emeritus is
 linked.
 
 **Names, contact, responsibility, affiliation — Incubating: Required —
-Partially satisfied.**
+Satisfied.**
 
-Names, GitHub contacts, and affiliations are present. Responsibility domains
-are absent.
+The roster provides names, GitHub contacts, project-wide responsibility
+domains, and affiliations for all maintainers.
 
-**Appropriate number of active maintainers — Incubating: Required — Evidence
-incomplete.**
+**Appropriate number of active maintainers — Incubating: Required —
+Satisfied.**
 
-Seven maintainers are listed, which is plausible for the project scope, but the
-roster alone does not prove current review, release, and governance activity.
-The application should link recent evidence for each active maintainer or
-update the roster.
+Seven maintainers cover the project and its four subprojects. The roster
+defines active status and annual public review, and its 2026 review links
+public issue and pull-request activity for every listed maintainer during the
+preceding 12 months.
 
 **Maintainers from at least two organizations — Incubating: N/A, but met.**
 
@@ -207,11 +192,13 @@ The roster names four affiliations.
 ### Ownership
 
 **Code and documentation ownership matches governance roles — Incubating:
-Required — Evidence incomplete.**
+Required — Satisfied.**
 
-`CODEOWNERS` assigns directory review to maintainers and additional GitHub
-users. Governance does not define “code owner,” its authority, appointment, or
-removal, so the review cannot establish that the file matches documented roles.
+Governance defines code owners as delegated path reviewers, documents their
+authority and public appointment/removal process, and makes clear that code
+ownership neither grants project-wide governance authority nor limits a
+maintainer's project-wide responsibility. This matches `CODEOWNERS`, which
+includes maintainers and additional area reviewers.
 
 ### Code of Conduct
 
@@ -226,24 +213,30 @@ from the README and governance.
 
 ### Subprojects
 
-**All subprojects listed — Incubating: Required — Not satisfied.**
+**All subprojects listed — Incubating: Required — Satisfied.**
 
-The README labels `higress-console`, `higress-standalone`, `plugin-server`, and
-`wasm-go` as “Related Repositories,” but does not distinguish CNCF subprojects
-from integrations or independently governed related tools. No authoritative
-scope list exists in governance.
+Governance identifies the primary repository and lists `higress-console`,
+`higress-standalone`, `plugin-server`, and `wasm-go` as active subprojects. It
+also distinguishes upstream forks, integrations, examples, websites, and
+other organization repositories from the CNCF project scope.
 
-**Subproject lifecycle — Incubating: Suggested — Not satisfied.**
+**Subproject lifecycle — Incubating: Suggested — Satisfied.**
 
-Leadership, contribution, maturity status, and add/remove/archive processes are
-not documented for the related repositories.
+Governance applies the project-wide maintainer roster and public decision
+process to subprojects, records each repository's responsibility and status,
+and requires leadership, contribution, communication, and lifecycle details
+when a subproject is added, removed, transferred, or archived.
 
 ### Contributors and Community
 
 **Contributor ladder — Incubating: Suggested — Partially satisfied.**
 
-Contributor and maintainer paths exist, and CODEOWNERS implies an intermediate
-review role, but the role is not governed and no complete ladder is documented.
+Governance defines contributor, delegated code-owner, and project-wide
+maintainer roles. The contribution and maintainer documents define how
+contributors participate and how sustained contributors progress to
+maintainership; code-owner assignments are changed publicly through
+`CODEOWNERS`. Objective progression expectations for the intermediate
+code-owner role can be made more explicit.
 
 **Issue and change submission — Incubating: Required — Satisfied.**
 
@@ -255,13 +248,13 @@ Satisfied.**
 
 GitHub Issues, pull requests, and Discord are publicly documented.
 
-**All public/private channels documented — Incubating: Required — Not
-satisfied.**
+**All public/private channels documented — Incubating: Required — Satisfied.**
 
-The README documents Discord and GitHub contribution paths, and `SECURITY.md`
-documents two private vulnerability-reporting channels. There is no single
-inventory asserting completeness, covering subprojects, or explaining all
-non-public purposes.
+`COMMUNITY.md` is the authoritative inventory for project and subproject GitHub
+channels, Discord, mailing and localized community channels, documentation,
+and narrowly scoped private security and Code of Conduct reporting. It states
+that informal or employer-internal conversations are not project decision
+channels and requires public decision records.
 
 **Public meeting scheduler/CNCF calendar — Incubating: Required — Not
 satisfied.**
@@ -274,10 +267,9 @@ linked from the reviewed repository documents.
 The contribution guide covers issues, pull requests, branches, commits, tests,
 style, and AI-assisted contribution requirements.
 
-**Contributor activity and recruitment — Incubating: Required — Evidence
-incomplete.**
+**Contributor activity and recruitment — Incubating: Required — Satisfied.**
 
-The README displays the contributor graph and the repository has recent
-multi-author activity, but the Incubation application should provide public
-metrics demonstrating sustained contributor growth, review participation, and
-recruitment beyond raw commit counts.
+`COMMUNITY.md` links continuously updated GitHub contributor and repository
+activity, CNCF DevStats, active-maintainer evidence, `help wanted` and `good
+first issue` recruitment queues, the contribution path, and public mentoring
+channels.

--- a/docs/cncf/governance-review.md
+++ b/docs/cncf/governance-review.md
@@ -32,10 +32,9 @@ people affiliated with four organizations.
 
 The documentation and public evidence satisfy all Governance Review criteria
 except one Incubation-required item: Higress does not currently publish an
-up-to-date public meeting scheduler or CNCF calendar entry with a durable
-location for agendas and notes. The project should establish that real public
-meeting infrastructure before asserting that the Governance Review has no
-remaining Must-Fix item.
+up-to-date public meeting scheduler or integrate its meetings with the CNCF
+calendar. The project should establish that real public meeting infrastructure
+before asserting that the Governance Review has no remaining Must-Fix item.
 
 ### Executing the Assessment
 
@@ -60,8 +59,8 @@ It does not infer private processes or settings that are not publicly recorded.
 The following issues need to be resolved before the Higress Incubation
 application asserts completion of its Governance Review:
 
-1. Publish an up-to-date public meeting scheduler or CNCF calendar entry and a
-   discoverable location for agendas and notes.
+1. Publish an up-to-date public meeting scheduler and/or integrate the project
+   meetings with the CNCF calendar.
 
 ### Points of Excellence
 
@@ -259,8 +258,8 @@ channels and requires public decision records.
 **Public meeting scheduler/CNCF calendar — Incubating: Required — Not
 satisfied.**
 
-No current scheduler, CNCF calendar entry, agenda, or meeting-notes location is
-linked from the reviewed repository documents.
+No current public meeting scheduler or CNCF calendar integration is linked from
+the reviewed repository documents.
 
 **Contribution documentation — Incubating: Required — Satisfied.**
 

--- a/docs/cncf/governance-review.md
+++ b/docs/cncf/governance-review.md
@@ -6,6 +6,19 @@ Incubation application. It follows the current CNCF TOC
 A CNCF Project Reviews reviewer may amend the assessment and findings during
 the public review.
 
+- **Review state:** Project working draft; maintainer approval and CNCF Project
+  Reviews verification pending
+- **Evidence revision:**
+  [`higress-group/higress@762324c`](https://github.com/higress-group/higress/tree/762324c3767c620fef593504bcedf28f7969a954)
+- **Template verified:** 2026-07-21 against `cncf/toc` `main`
+- **Intended TOC snapshot:**
+  `projects/higress/governance-review/YYYY-MM-DD.md`
+
+This is the project-maintained working copy. CNCF reviewers may revise the
+status and findings before a dated snapshot is archived in `cncf/toc`.
+Project-local relative links must be converted to versioned, absolute
+permalinks for that archive.
+
 ## Summary and Assessment
 
 **Status: Needs Work**
@@ -19,7 +32,8 @@ The review nevertheless finds several Incubation-required evidence gaps: the
 maintainer roster does not state responsibility domains; the relationship
 between `CODEOWNERS` and governance roles is not defined; the CNCF project
 subproject scope is ambiguous; all communication channels are not inventoried;
-and there is no documented current public meeting scheduler. These findings
+there is no documented current public meeting scheduler; and evidence of
+maintainer activity and contributor recruitment is incomplete. These findings
 must be resolved before the project claims the Governance Review criterion is
 satisfied.
 
@@ -28,13 +42,13 @@ satisfied.
 The self-assessment reviewed the following repository evidence as it exists on
 2026-07-21:
 
-- [`GOVERNANCE.md`](../../GOVERNANCE.md)
-- [`MAINTAINERS.md`](../../MAINTAINERS.md)
-- [`CODEOWNERS`](../../CODEOWNERS)
-- [`CONTRIBUTING_EN.md`](../../CONTRIBUTING_EN.md)
-- [`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md)
-- [`SECURITY.md`](../../SECURITY.md)
-- [`README.md`](../../README.md)
+- [`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/GOVERNANCE.md)
+- [`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/MAINTAINERS.md)
+- [`CODEOWNERS`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/CODEOWNERS)
+- [`CONTRIBUTING_EN.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/CONTRIBUTING_EN.md)
+- [`CODE_OF_CONDUCT.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/CODE_OF_CONDUCT.md)
+- [`SECURITY.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/SECURITY.md)
+- [`README.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/README.md)
 - Git history for the governance, maintainer, and ownership files
 
 The review distinguishes documented policy from observed repository evidence.
@@ -49,18 +63,19 @@ application asserts completion of its Governance Review:
    confirm the listed people are currently active.
 2. Define the authority and lifecycle of code owners and explain how
    `CODEOWNERS` relates to project-wide maintainer authority.
-3. Document a complete maintainer lifecycle, including onboarding, voluntary
-   departure, inactivity/removal, emeritus status, and return.
-4. Explicitly document vendor-neutral project direction and conflict-of-
-   interest handling.
-5. Define the repositories/subprojects in the CNCF Higress project scope and
-   the process for adding, removing, or archiving a subproject.
-6. Inventory all public and non-public communication channels and state the
+3. Define and list the repositories/subprojects in the CNCF Higress project
+   scope.
+4. Inventory all public and non-public communication channels and state the
    limited purpose of each non-public channel.
-7. Publish an up-to-date public meeting scheduler or CNCF calendar entry and a
+5. Publish an up-to-date public meeting scheduler or CNCF calendar entry and a
    discoverable location for agendas and notes.
-8. Document how the project approves requests to CNCF and how function-based
-   teams such as the Security Response Team are assigned and removed.
+6. Publish evidence of current maintainer activity, contributor activity, and
+   contributor recruitment rather than relying on the roster or raw commit
+   count alone.
+7. Name the Security Response Team membership and document role
+   responsibilities, report handling, conflicts, and escalation. The current
+   reference to all maintainers does not provide enough operational detail for
+   the Incubation application's security-role requirement.
 
 ### Points of Excellence
 
@@ -79,6 +94,14 @@ governance maturity:
 
 - Introduce a contributor ladder with intermediate roles and objective
   progression expectations.
+- Complete the maintainer lifecycle with voluntary departure,
+  inactivity/removal, emeritus status, and return.
+- Explicitly document vendor-neutral project direction, employer-seat
+  neutrality, and conflict-of-interest handling.
+- Document how the project approves requests to CNCF and how function-based
+  teams are created, staffed, and retired.
+- Define how subprojects are added, removed, or archived and how their
+  leadership and maturity are recorded.
 - Record governance evolution and link decisions to issues or pull requests.
 - Publish examples demonstrating the maintainer lifecycle in practice.
 - Periodically audit maintainer activity and code-owner coverage across all

--- a/docs/cncf/incubation-application.md
+++ b/docs/cncf/incubation-application.md
@@ -184,10 +184,9 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
 - [x] The Security Self-Assessment is documented in
   [`security-self-assessment.md`](https://github.com/higress-group/higress/blob/main/docs/cncf/security-self-assessment.md).
 - [ ] **BLOCKED — OpenSSF Best Practices Passing badge.** The public entry is
-  currently 96%. Daily/main-push CodeQL is addressed by this preparation work,
-  but warning enforcement/remediation, confirmed CodeQL alert disposition, and
-  project-level dynamic analysis remain before the badge can be certified as
-  Passing.
+  currently 96%. Warning enforcement/remediation, static-analysis frequency,
+  confirmed CodeQL alert disposition, and project-level dynamic analysis remain
+  before the badge can be certified as Passing.
 
 ## Ecosystem
 
@@ -210,8 +209,8 @@ the following required items remain open:
 
 1. a real public meeting scheduler and/or CNCF calendar integration;
 2. enforced repository access-control evidence;
-3. OpenSSF Best Practices Passing, including alert disposition and dynamic
-   analysis;
+3. OpenSSF Best Practices Passing, including warning enforcement, analysis
+   frequency, alert disposition, and dynamic analysis;
 4. vendor-neutral resource/website remediation or an accepted migration plan;
 5. 5–7 adopter interview submissions and later TOC verification; and
 6. direct project point-of-contact emails confirmed for the issue.

--- a/docs/cncf/incubation-application.md
+++ b/docs/cncf/incubation-application.md
@@ -1,0 +1,217 @@
+# Higress CNCF Incubation Application — Working Draft
+
+This working draft follows the CNCF TOC
+[Project Incubation Application v1.6](https://github.com/cncf/toc/blob/main/.github/ISSUE_TEMPLATE/template-incubation-application.md),
+verified on 2026-07-21. It is not ready to file while any item labelled
+**BLOCKED** below remains unresolved.
+
+## Review Project Moving Level Evaluation
+
+- [ ] I have reviewed the TOC moving-level readiness triage guide, ensured the
+  criteria are met before opening the issue, and understand that unmet criteria
+  will result in closure.
+
+This box remains unchecked because the public meeting, access-control evidence,
+OpenSSF Passing badge, adopter interviews/verification, and remaining
+vendor-neutral resource work are incomplete.
+
+## Project information
+
+- **Project repositories:**
+  [`higress`](https://github.com/higress-group/higress),
+  [`higress-console`](https://github.com/higress-group/higress-console),
+  [`higress-standalone`](https://github.com/higress-group/higress-standalone),
+  [`plugin-server`](https://github.com/higress-group/plugin-server), and
+  [`wasm-go`](https://github.com/higress-group/wasm-go)
+- **Project site:** <https://higress.ai/en/>
+- **Subprojects:** `higress-console`, `higress-standalone`, `plugin-server`,
+  and `wasm-go`; authoritative scope is in
+  [`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/main/GOVERNANCE.md)
+- **Related projects:** confirm before submission whether any project point of
+  contact operates a technically related project in another foundation
+- **Communication:**
+  [`COMMUNITY.md`](https://github.com/higress-group/higress/blob/main/COMMUNITY.md)
+- **Project points of contact:** Yuanxiao Zhao and Yiquan Dong; **TODO:** confirm
+  direct contact emails before filing (public community contact:
+  [higress@googlegroups.com](mailto:higress@googlegroups.com))
+
+## Incubation Criteria Summary
+
+### Application Level Assertion
+
+- [x] Higress is currently Sandbox, accepted on 2026-03-15, and is applying to
+  Incubation.
+- [ ] Higress is applying to join CNCF directly at Incubation level. Not
+  applicable; remove this option from the filed issue.
+
+### Adoption Assertion
+
+Public production adopters in
+[`ADOPTERS.md`](https://github.com/higress-group/higress/blob/main/ADOPTERS.md)
+include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
+
+- [ ] **BLOCKED — Adopter interviews:** submit 5–7 willing adopters through the
+  official CNCF Adopter Interview Questionnaire before DD assignment. This
+  requires adopter consent and current contact details; a repository edit
+  cannot complete it.
+
+## Application Process Principles
+
+### Suggested
+
+- [ ] Engage with the appropriate domain-specific TAG(s) to present the
+  technical architecture. This is suggested, not a filing prerequisite in
+  v1.6. A future presentation should be linked here if completed.
+
+### Required
+
+- [x] Complete a General Technical Review. The project self-assessment is in
+  [`general-technical-review.md`](https://github.com/higress-group/higress/blob/main/docs/cncf/general-technical-review.md);
+  maintainer approval and CNCF Project Reviews verification are requested.
+- [ ] Complete a Governance Review. The self-assessment is in
+  [`governance-review.md`](https://github.com/higress-group/higress/blob/main/docs/cncf/governance-review.md),
+  but its public-meeting Must-Fix remains open.
+- [ ] **BLOCKED — All project metadata and resources are vendor-neutral.**
+  Governance and the primary README now document vendor-neutral direction and
+  no longer promote a single commercial product, but release images remain
+  hosted only on Alibaba Cloud registry domains, the historical Go module path
+  contains `github.com/alibaba`, and the website roadmap still includes a
+  single-vendor enterprise mapping. The application needs a maintainer/CNCF-
+  reviewed compatibility and infrastructure plan.
+- [x] Review and acknowledgement of Sandbox expectations and maturity-level
+  requirements. Higress was accepted as a Sandbox project on 2026-03-15 and
+  this application explicitly acknowledges the current requirements.
+- [ ] Due Diligence Review. This is completed through CNCF review, resolution
+  of concerns, and public comment after a ready application is filed.
+- [x] Appropriate installation, end-user, reference, and sample documentation
+  is linked from the project README and website.
+
+## Governance and Maintainers
+
+### Suggested
+
+- [ ] Complete the Governance Review with the CNCF Project Reviews subproject;
+  external verification is pending.
+- [x] Governance is discoverable and version controlled.
+- [x] Governance documents actual public decision, leadership, role, and
+  security-team processes without claiming a recurring meeting that does not
+  exist.
+- [x] Governance documents vendor-neutral project direction and conflicts.
+- [x] Leadership, contribution, CNCF request, governance, goal, and subproject
+  decisions use a public process.
+- [x] Function-based team assignment, onboarding, removal, conflicts, and
+  retirement are documented.
+- [x] The complete maintainer lifecycle is documented.
+- [ ] Demonstrate a completed maintainer lifecycle event. Suggested; no public
+  addition, replacement, or emeritus transition is yet linked.
+- [x] Subproject scope, leadership model, contribution, status, and lifecycle
+  are documented.
+
+### Required
+
+- [x] Current maintainers include names, GitHub contact, responsibility domain,
+  and affiliation in
+  [`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/main/MAINTAINERS.md).
+- [x] Seven active maintainers are appropriate to the primary repository and
+  four subprojects; the annual activity review links public evidence for each.
+- [x] Code and documentation ownership matches the documented code-owner and
+  maintainer roles.
+- [x] The CNCF Code of Conduct is adopted and linked.
+- [x] The Code of Conduct is cross-linked from governance.
+- [x] All current subprojects are listed in governance.
+
+## Contributors and Community
+
+### Suggested
+
+- [x] Contributor, code-owner, and maintainer roles form a contributor ladder;
+  objective code-owner progression criteria remain an improvement item.
+
+### Required
+
+- [x] Issue and change submission are documented.
+- [x] Public GitHub and Discord communication channels are documented.
+- [x] All official project, subproject, and narrowly scoped non-public channels
+  are inventoried in `COMMUNITY.md`.
+- [ ] **BLOCKED — Public meeting scheduler/CNCF calendar.** Higress does not
+  currently publish an up-to-date public meeting scheduler or integrate its
+  meetings with the CNCF calendar. A real schedule or calendar integration must
+  be established rather than represented by documentation alone.
+- [x] Contribution documentation is maintained.
+- [x] Contributor activity and recruitment are demonstrated through GitHub,
+  DevStats, contribution labels, and maintainer activity links.
+
+## Engineering Principles
+
+### Suggested
+
+- [x] The roadmap change process is documented in
+  [`ROADMAP.md`](https://github.com/higress-group/higress/blob/main/ROADMAP.md).
+- [x] Regular release history is public in GitHub Releases and versioned
+  release notes.
+
+### Required
+
+- [x] Project goals, differentiation, need, and cloud-native use cases are
+  documented in the README and GTR.
+- [x] What Higress does and why it exists are documented in the README and GTR.
+- [x] A maintained public roadmap and change process are linked from
+  `ROADMAP.md`.
+- [x] Architecture and software design are documented in
+  [`docs/architecture.md`](https://github.com/higress-group/higress/blob/main/docs/architecture.md)
+  and the GTR.
+- [x] The release process is documented in
+  [`RELEASE.md`](https://github.com/higress-group/higress/blob/main/RELEASE.md).
+
+## Security
+
+### Suggested
+
+- [ ] Complete a joint assessment with CNCF TAG Security and Compliance. This
+  is suggested, not a v1.6 filing prerequisite.
+
+### Required
+
+- [x] Vulnerability reporting is documented in
+  [`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md).
+- [ ] **BLOCKED — Enforced repository access-control evidence.** Public files
+  do not prove organization 2FA, least-privilege team access, protected default
+  branch/rulesets, required non-author review, or protected release
+  environments. An organization owner must verify/configure these settings and
+  publish reviewable evidence appropriate for CNCF DD.
+- [x] Named security-response membership, incident roles, two-person review,
+  conflicts, report handling, and escalation are documented.
+- [x] The Security Self-Assessment is documented in
+  [`security-self-assessment.md`](https://github.com/higress-group/higress/blob/main/docs/cncf/security-self-assessment.md).
+- [ ] **BLOCKED — OpenSSF Best Practices Passing badge.** The public entry is
+  currently 96%. Daily/main-push CodeQL is addressed by this preparation work,
+  but warning enforcement/remediation, confirmed CodeQL alert disposition, and
+  project-level dynamic analysis remain before the badge can be certified as
+  Passing.
+
+## Ecosystem
+
+### Required
+
+- [x] The public adopter list records organizations, contacts, environment, and
+  use cases.
+- [x] At least three independent adopters report production use; five are
+  publicly listed.
+- [ ] **BLOCKED — TOC adopter verification.** Complete the official interviews
+  and allow CNCF/TOC reviewers to verify the adopter evidence.
+- [x] Integrations and compatibility with Kubernetes, Gateway API, Envoy,
+  Istio, Prometheus/OpenTelemetry, OCI, service registries, and model providers
+  are documented in the GTR, architecture, README, and user documentation.
+
+## Current filing decision
+
+**Do not file yet.** The top-level readiness attestation would be false while
+the following required items remain open:
+
+1. a real public meeting scheduler and/or CNCF calendar integration;
+2. enforced repository access-control evidence;
+3. OpenSSF Best Practices Passing, including alert disposition and dynamic
+   analysis;
+4. vendor-neutral resource/website remediation or an accepted migration plan;
+5. 5–7 adopter interview submissions and later TOC verification; and
+6. direct project point-of-contact emails confirmed for the issue.

--- a/docs/cncf/incubation-application.md
+++ b/docs/cncf/incubation-application.md
@@ -75,9 +75,11 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
   Governance and the primary README now document vendor-neutral direction and
   no longer promote a single commercial product, but release images remain
   hosted only on Alibaba Cloud registry domains, the historical Go module path
-  contains `github.com/alibaba`, and the website roadmap still includes a
-  single-vendor enterprise mapping. The application needs a maintainer/CNCF-
-  reviewed compatibility and infrastructure plan.
+  contains `github.com/alibaba`, the website roadmap still includes a
+  single-vendor enterprise mapping, and the security policy requires duplicate
+  submission to the vendor-operated Alibaba Security Response Center. The
+  application needs a maintainer/CNCF-reviewed compatibility and infrastructure
+  plan.
 - [x] Review and acknowledgement of Sandbox expectations and maturity-level
   requirements. Higress was accepted as a Sandbox project on 2026-03-15 and
   this application explicitly acknowledges the current requirements.

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -191,9 +191,10 @@ settings evidence.
 
 Ordinary project-team communication uses GitHub issues, pull requests,
 discussions, mailing, localized community channels, and Discord. Inbound users
-use the same public channels. Vulnerabilities use GitHub Private Security
-Advisories as the primary vendor-neutral intake, with the Alibaba Security
-Response Center as an optional alternate, as documented in `SECURITY.md`.
+use the same public channels. Every vulnerability report must be submitted to
+both GitHub Private Security Advisories and the Alibaba Security Response
+Center, as documented in `SECURITY.md`. The Security Response Team correlates
+the two private records.
 Releases, the project website, and the WeChat Official Account are outbound
 channels. [`COMMUNITY.md`](https://github.com/higress-group/higress/blob/main/COMMUNITY.md)
 is the authoritative inventory of public, subproject, and narrowly scoped
@@ -207,8 +208,9 @@ OCI, Prometheus/OpenTelemetry conventions, and optional service registries.
 
 [`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md)
 prohibits public vulnerability reports and
-directs reporters to a primary vendor-neutral private channel and an optional
-alternate. The named Security Response Team is the current maintainer list.
+requires reporters to submit the same substantive report through both GitHub
+Private Security Advisories and the Alibaba Security Response Center. The named
+Security Response Team is the current maintainer list.
 For each case it assigns a triage coordinator, fix lead, independent reviewer
 and release lead, and disclosure lead, with at least two unconflicted members.
 The policy documents conflicts and escalation. Its targets are acknowledgement
@@ -239,6 +241,9 @@ Advisory and release information, and coordinate timing with the reporter.
 - This threat model is project-authored, has not been independently validated,
   and is not yet backed by a published data-flow diagram with explicit trust
   boundaries or an independent security audit.
+- Requiring every reporter to duplicate the report in the vendor-operated
+  Alibaba Security Response Center creates a vendor-neutrality concern that
+  requires CNCF review or a future neutral replacement plan.
 
 ### Known Issues Over Time
 

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -189,12 +189,15 @@ required reviewer count, signed-commit requirement, organization-wide 2FA, or
 branch-protection configuration; those controls require separate repository-
 settings evidence.
 
-Ordinary project-team communication uses GitHub issues, pull requests, and
-Discord. Inbound users use the same public channels. Vulnerabilities use GitHub
-Private Security Advisories and the Alibaba Security Response Center as
-documented in `SECURITY.md`. Releases and the project website are outbound
-channels. A complete inventory distinguishing internal, inbound, and outbound
-channels is not currently published outside this assessment.
+Ordinary project-team communication uses GitHub issues, pull requests,
+discussions, mailing, localized community channels, and Discord. Inbound users
+use the same public channels. Vulnerabilities use GitHub Private Security
+Advisories as the primary vendor-neutral intake, with the Alibaba Security
+Response Center as an optional alternate, as documented in `SECURITY.md`.
+Releases, the project website, and the WeChat Official Account are outbound
+channels. [`COMMUNITY.md`](https://github.com/higress-group/higress/blob/main/COMMUNITY.md)
+is the authoritative inventory of public, subproject, and narrowly scoped
+non-public channels.
 
 Higress operates in the Kubernetes networking and cloud-native gateway
 ecosystem. It implements Ingress and Gateway API and builds on Envoy, Istio,
@@ -204,13 +207,14 @@ OCI, Prometheus/OpenTelemetry conventions, and optional service registries.
 
 [`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md)
 prohibits public vulnerability reports and
-directs reporters to two private channels. The Security Response Team is the
-current maintainer list. The documented targets are acknowledgement within
-three business days and triage within 14 days, followed by private fix
+directs reporters to a primary vendor-neutral private channel and an optional
+alternate. The named Security Response Team is the current maintainer list.
+For each case it assigns a triage coordinator, fix lead, independent reviewer
+and release lead, and disclosure lead, with at least two unconflicted members.
+The policy documents conflicts and escalation. Its targets are acknowledgement
+within three business days and triage within 14 days, followed by private fix
 development, coordinated disclosure (typically within 90 days), a GitHub
-Security Advisory, and a CVE request where appropriate. The current policy does
-not assign a named incident commander, require a second reviewer, or document
-an escalation path when these targets are missed; those are governance gaps.
+Security Advisory, and a CVE request where appropriate.
 
 An operational security incident in an adopter environment remains the
 adopter's responsibility. The project handles defects in project code and

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -7,7 +7,7 @@
 | Assessment stage | Complete working draft, pending maintainer approval; updated 2026-07-21 |
 | Software | <https://github.com/higress-group/higress> |
 | Review state | Prepared from public project evidence; no independent security review or audit |
-| Evidence revision | [`higress-group/higress@762324c`](https://github.com/higress-group/higress/tree/762324c3767c620fef593504bcedf28f7969a954) |
+| Evidence branch | [`higress-group/higress@main`](https://github.com/higress-group/higress/tree/main) |
 | Assessment outline | [CNCF TAG Security Self-Assessment](https://tag-security.cncf.io/community/assessments/guide/self-assessment/) |
 | Intended TOC snapshot | `projects/higress/security-assessment/self-assessment.md` |
 | Security provider | No. Higress provides security features, but its primary function is API gateway traffic management. |
@@ -18,15 +18,14 @@
 
 | Document | Location |
 | --- | --- |
-| Vulnerability reporting and response | [`SECURITY.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/SECURITY.md) |
-| Architecture | [`docs/architecture.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/docs/architecture.md) |
-| Helm defaults | [`helm/core/values.yaml`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/helm/core/values.yaml) |
+| Vulnerability reporting and response | [`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md) |
+| Architecture | [`docs/architecture.md`](https://github.com/higress-group/higress/blob/main/docs/architecture.md) |
+| Helm defaults | [`helm/core/values.yaml`](https://github.com/higress-group/higress/blob/main/helm/core/values.yaml) |
 | OpenSSF Best Practices | <https://www.bestpractices.dev/projects/12667> |
 
 This is the project-maintained working copy. For formal Due Diligence, a vetted
-snapshot must be archived at the path above in `cncf/toc`. Project-local
-relative links must be converted to versioned, absolute permalinks when that
-snapshot is prepared.
+snapshot must be archived at the path above in `cncf/toc`. The reviewer should
+freeze evidence links to the reviewed revision when that snapshot is archived.
 
 ## Overview
 
@@ -203,7 +202,7 @@ OCI, Prometheus/OpenTelemetry conventions, and optional service registries.
 
 ## Security Issue Resolution
 
-[`SECURITY.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/SECURITY.md)
+[`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md)
 prohibits public vulnerability reports and
 directs reporters to two private channels. The Security Response Team is the
 current maintainer list. The documented targets are acknowledgement within

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -179,7 +179,8 @@ requests run license header and dependency-license checks.
 
 Pull requests are publicly reviewed and run build/unit tests with Go race
 detection, Gateway API and Higress conformance tests, plugin tests, and license
-checks. CodeQL is scheduled weekly; it is not currently a pull-request gate.
+checks. CodeQL is configured to run on every push to `main` and on a daily
+schedule; it is not currently a pull-request gate.
 The configured `golangci-lint` execution is commented out because of existing
 findings. Release tags trigger image and CLI/CRD artifact builds. Dependency
 inputs are versioned, but release artifacts do not currently have a
@@ -251,12 +252,14 @@ aggregate vulnerability history or mean-time-to-remediation report.
 ### OpenSSF Best Practices
 
 The [Higress OpenSSF entry](https://www.bestpractices.dev/projects/12667) is at
-96% of the Passing badge as of this assessment. Seven criteria remain
-unanswered or unmet: compiler-warning enforcement, strict-warning enforcement,
-warning remediation, static-analysis remediation, static-analysis frequency,
-dynamic analysis, and enabling assertions or equivalent dynamic-analysis
-checks. Passing requires evidence and implementation for all seven, not merely
-updating the questionnaire.
+96% of the Passing badge as of this assessment. The repository now configures
+CodeQL on every push to `main` and daily, resolving the implementation gap
+behind the static-analysis-frequency answer once this change is merged and the
+badge record is updated. The remaining substantive gaps are compiler-warning
+enforcement and remediation, unresolved confirmed static-analysis findings,
+and project-level dynamic analysis with assertions or equivalent runtime
+checks. Passing requires evidence and implementation, not merely updating the
+questionnaire.
 
 ### Example Use Cases
 

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -179,8 +179,7 @@ requests run license header and dependency-license checks.
 
 Pull requests are publicly reviewed and run build/unit tests with Go race
 detection, Gateway API and Higress conformance tests, plugin tests, and license
-checks. CodeQL is configured to run on every push to `main` and on a daily
-schedule; it is not currently a pull-request gate.
+checks. CodeQL is scheduled weekly; it is not currently a pull-request gate.
 The configured `golangci-lint` execution is commented out because of existing
 findings. Release tags trigger image and CLI/CRD artifact builds. Dependency
 inputs are versioned, but release artifacts do not currently have a
@@ -252,14 +251,12 @@ aggregate vulnerability history or mean-time-to-remediation report.
 ### OpenSSF Best Practices
 
 The [Higress OpenSSF entry](https://www.bestpractices.dev/projects/12667) is at
-96% of the Passing badge as of this assessment. The repository now configures
-CodeQL on every push to `main` and daily, resolving the implementation gap
-behind the static-analysis-frequency answer once this change is merged and the
-badge record is updated. The remaining substantive gaps are compiler-warning
-enforcement and remediation, unresolved confirmed static-analysis findings,
-and project-level dynamic analysis with assertions or equivalent runtime
-checks. Passing requires evidence and implementation, not merely updating the
-questionnaire.
+96% of the Passing badge as of this assessment. Seven criteria remain
+unanswered or unmet: compiler-warning enforcement, strict-warning enforcement,
+warning remediation, static-analysis remediation, static-analysis frequency,
+dynamic analysis, and enabling assertions or equivalent dynamic-analysis
+checks. Passing requires evidence and implementation for all seven, not merely
+updating the questionnaire.
 
 ### Example Use Cases
 

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -1,0 +1,206 @@
+# Higress Security Self-Assessment
+
+## Metadata
+
+| | |
+| --- | --- |
+| Assessment stage | Complete project self-assessment, updated 2026-07-21 |
+| Software | <https://github.com/higress-group/higress> |
+| Security provider | No. Higress provides security features, but its primary function is API gateway traffic management. |
+| Languages | Go, C++, Rust, AssemblyScript, shell, and Helm/YAML |
+| SBOM | Not generated for release artifacts. Go module files, Cargo lock data, and container build files provide dependency inputs. |
+
+### Security Links
+
+| Document | Location |
+| --- | --- |
+| Vulnerability reporting and response | [`SECURITY.md`](../../SECURITY.md) |
+| Architecture | [`docs/architecture.md`](../architecture.md) |
+| Helm defaults | [`helm/core/values.yaml`](../../helm/core/values.yaml) |
+| OpenSSF Best Practices | <https://www.bestpractices.dev/projects/12667> |
+
+## Overview
+
+Higress translates declarative ingress, Gateway API, service discovery, and
+plugin configuration into xDS consumed by an Envoy-based gateway. It accepts
+untrusted downstream traffic, selects upstream services, applies traffic and
+security policy, and proxies requests and responses.
+
+### Actors and Actions
+
+- **Cluster administrator:** installs/upgrades Higress, grants RBAC, configures
+  exposure, certificates, registries, and security contexts.
+- **Gateway operator/platform engineer:** creates routes, services, policies,
+  plugins, credentials, and observability configuration.
+- **Application owner:** requests routes/policy and operates upstream services.
+- **End user/client:** sends potentially hostile network requests.
+- **Plugin author/provider:** supplies code that executes in the gateway's Wasm
+  sandbox or native filter boundary.
+- **External provider/registry:** supplies service discovery data, plugins,
+  identity metadata, certificates, or AI/model APIs when configured.
+- **Project maintainer/release manager:** reviews changes, responds to reports,
+  and publishes releases.
+
+### Background
+
+Higress combines the Envoy data plane and Istio-derived control plane with
+Ingress/Gateway API translation and an extensible plugin ecosystem. The
+control plane watches configuration and discovery sources and generates xDS;
+the data plane accepts untrusted network traffic and applies that configuration.
+
+### Goals
+
+- Preserve authenticated configuration delivery between control and data
+  planes and reject invalid xDS updates.
+- Terminate and originate TLS as configured and distribute private key material
+  through Kubernetes Secrets and SDS.
+- Isolate Wasm plugin execution from the gateway process to the extent provided
+  by the Envoy/Wasm runtime.
+- Enforce configured routing, authentication, authorization, traffic, and data
+  policies consistently.
+- Contact only the external registries, identity systems, observability
+  backends, AI providers, and upstreams explicitly configured by the operator.
+- Provide a private vulnerability reporting and coordinated disclosure path.
+
+### Non-goals
+
+Higress does not secure a compromised Kubernetes control plane, node, cluster
+administrator, upstream service, identity provider, model provider, registry,
+or native plugin. It does not guarantee that user-authored policy is correct,
+provide regulatory certification, or replace network segmentation, secrets
+management, PKI governance, application security, or incident response.
+
+## Self-Assessment Use
+
+This document is an internal analysis by the Higress project. It is not an
+independent audit, certification, or attestation. It gives adopters and CNCF
+reviewers an initial view of security boundaries, practices, and known gaps.
+
+## Security Functions and Features
+
+### Critical
+
+- xDS configuration generation, transport, validation, and last-known-good
+  behavior between controller/discovery and gateways.
+- TLS termination/origination, SDS secret delivery, certificate issuance and
+  rotation paths, and private-key access.
+- Kubernetes RBAC, ServiceAccounts, token reviews, subject-access reviews, and
+  admission/configuration validation.
+- HTTP/TCP parsing, routing, upstream selection, and request/response mutation.
+- Plugin loading and Wasm sandbox boundary; native Go/C++ filters share the
+  gateway process trust boundary.
+- Release workflows, container/plugin registries, dependency inputs, and
+  published artifacts.
+
+### Security Relevant
+
+- Authentication and authorization plugins (JWT, OIDC, key, HMAC, basic auth),
+  WAF, rate limiting, request blocking, and data masking.
+- Pod/container security contexts, host networking, privileged mode, RBAC
+  toggles, network exposure, and admin/debug endpoints.
+- Access, audit-style, metrics, and trace output, which may contain sensitive
+  request metadata depending on operator configuration.
+- External service registries, Redis, certificate issuers, identity providers,
+  OCI registries, and AI/model providers.
+
+## Project Compliance
+
+The open-source project does not claim PCI-DSS, SOC 2, ISO 27001, GDPR, or
+other regulatory certification. Deployers are responsible for assessing their
+configuration and operational environment. Source is Apache-2.0 and pull
+requests run license header and dependency-license checks.
+
+## Secure Development Practices
+
+Pull requests are publicly reviewed and run build/unit tests with Go race
+detection, Gateway API and Higress conformance tests, plugin tests, and license
+checks. CodeQL is scheduled weekly; it is not currently a pull-request gate.
+The configured `golangci-lint` execution is commented out because of existing
+findings. Release tags trigger image and CLI/CRD artifact builds. Dependency
+inputs are versioned, but release artifacts do not currently have a
+project-generated SBOM, signature, or SLSA provenance. Not all workflow actions
+are pinned to immutable commits. The public repository does not prove a
+required reviewer count, signed-commit requirement, organization-wide 2FA, or
+branch-protection configuration; those controls require separate repository-
+settings evidence.
+
+Ordinary project-team communication uses GitHub issues, pull requests, and
+Discord. Inbound users use the same public channels. Vulnerabilities use GitHub
+Private Security Advisories and the Alibaba Security Response Center as
+documented in `SECURITY.md`. Releases and the project website are outbound
+channels. A complete inventory distinguishing internal, inbound, and outbound
+channels is not currently published outside this assessment.
+
+Higress operates in the Kubernetes networking and cloud-native gateway
+ecosystem. It implements Ingress and Gateway API and builds on Envoy, Istio,
+OCI, Prometheus/OpenTelemetry conventions, and optional service registries.
+
+## Security Issue Resolution
+
+[`SECURITY.md`](../../SECURITY.md) prohibits public vulnerability reports and
+directs reporters to two private channels. The Security Response Team is the
+current maintainer list. The documented targets are acknowledgement within
+three business days and triage within 14 days, followed by private fix
+development, coordinated disclosure (typically within 90 days), a GitHub
+Security Advisory, and a CVE request where appropriate. The current policy does
+not assign a named incident commander, require a second reviewer, or document
+an escalation path when these targets are missed; those are governance gaps.
+
+An operational security incident in an adopter environment remains the
+adopter's responsibility. The project handles defects in project code and
+artifacts. For confirmed project vulnerabilities, maintainers triage impact,
+develop and release a fix, notify affected users through a GitHub Security
+Advisory and release information, and coordinate timing with the reporter.
+
+## Appendix
+
+### Known Gaps
+
+- OpenSSF Passing is not complete. Outstanding areas include compiler warning
+  enforcement, static-analysis alert remediation, and dynamic analysis.
+- There are unresolved critical/high CodeQL alerts requiring maintainer access,
+  triage, and either fixes or documented upstream/vendor dispositions.
+- Release SBOMs, signatures, and verifiable build provenance are absent.
+- The controller's ClusterRole is broad and its default container security
+  context is empty. Gateway non-root defaults depend on Kubernetes/platform
+  capability; legacy fallback adds `NET_BIND_SERVICE` and allows escalation.
+- No dedicated fuzzing/DAST program or automated upgrade/downgrade matrix is
+  documented.
+- A complete threat model and independent security audit have not been
+  published.
+
+### Known Issues Over Time
+
+Published project advisories are available from the repository's
+[Security Advisories](https://github.com/higress-group/higress/security/advisories)
+page. This assessment does not claim that the absence of a public advisory for
+a period means no vulnerability existed. The project has not published an
+aggregate vulnerability history or mean-time-to-remediation report.
+
+### OpenSSF Best Practices
+
+The [Higress OpenSSF entry](https://www.bestpractices.dev/projects/12667) is at
+96% of the Passing badge as of this assessment. Seven criteria remain
+unanswered or unmet: compiler-warning enforcement, strict-warning enforcement,
+warning remediation, static-analysis remediation, static-analysis frequency,
+dynamic analysis, and enabling assertions or equivalent dynamic-analysis
+checks. Passing requires evidence and implementation for all seven, not merely
+updating the questionnaire.
+
+### Example Use Cases
+
+1. A platform team exposes Kubernetes services through Gateway API with TLS,
+   JWT authentication, rate limiting, and Prometheus metrics.
+2. An AI platform routes requests across model providers while applying token
+   quotas, content policy, and request/response observability.
+3. A microservice platform discovers Nacos/Consul services and exposes them
+   through stable API routes without reloading the data plane.
+
+### Related Projects and Vendors
+
+Envoy supplies the proxy foundation; Istio supplies xDS/control-plane building
+blocks; Kubernetes Gateway API and Ingress supply standard configuration APIs.
+Kong, Apache APISIX, Envoy Gateway, Traefik, and ingress controllers address
+overlapping gateway use cases with different APIs, extension models, and
+operational tradeoffs. Commercial products may distribute or manage Higress,
+but they are outside this open-source security assessment.

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -4,8 +4,12 @@
 
 | | |
 | --- | --- |
-| Assessment stage | Complete project self-assessment, updated 2026-07-21 |
+| Assessment stage | Complete working draft, pending maintainer approval; updated 2026-07-21 |
 | Software | <https://github.com/higress-group/higress> |
+| Review state | Prepared from public project evidence; no independent security review or audit |
+| Evidence revision | [`higress-group/higress@762324c`](https://github.com/higress-group/higress/tree/762324c3767c620fef593504bcedf28f7969a954) |
+| Assessment outline | [CNCF TAG Security Self-Assessment](https://tag-security.cncf.io/community/assessments/guide/self-assessment/) |
+| Intended TOC snapshot | `projects/higress/security-assessment/self-assessment.md` |
 | Security provider | No. Higress provides security features, but its primary function is API gateway traffic management. |
 | Languages | Go, C++, Rust, AssemblyScript, shell, and Helm/YAML |
 | SBOM | Not generated for release artifacts. Go module files, Cargo lock data, and container build files provide dependency inputs. |
@@ -14,10 +18,15 @@
 
 | Document | Location |
 | --- | --- |
-| Vulnerability reporting and response | [`SECURITY.md`](../../SECURITY.md) |
-| Architecture | [`docs/architecture.md`](../architecture.md) |
-| Helm defaults | [`helm/core/values.yaml`](../../helm/core/values.yaml) |
+| Vulnerability reporting and response | [`SECURITY.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/SECURITY.md) |
+| Architecture | [`docs/architecture.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/docs/architecture.md) |
+| Helm defaults | [`helm/core/values.yaml`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/helm/core/values.yaml) |
 | OpenSSF Best Practices | <https://www.bestpractices.dev/projects/12667> |
+
+This is the project-maintained working copy. For formal Due Diligence, a vetted
+snapshot must be archived at the path above in `cncf/toc`. Project-local
+relative links must be converted to versioned, absolute permalinks when that
+snapshot is prepared.
 
 ## Overview
 
@@ -48,10 +57,43 @@ Ingress/Gateway API translation and an extensible plugin ecosystem. The
 control plane watches configuration and discovery sources and generates xDS;
 the data plane accepts untrusted network traffic and applies that configuration.
 
+### Architecture and Data Flow
+
+The security-relevant flow is:
+
+1. An authenticated Kubernetes user or automation writes Ingress, Gateway API,
+   Higress/Istio, Secret, and policy resources to the Kubernetes API.
+2. Higress controller and discovery components watch authorized resources,
+   optional service registries, and certificate sources, then translate the
+   desired state into xDS and SDS configuration.
+3. Gateway pilot agents and Envoy processes receive configuration and secret
+   material. Existing gateways may retain their last accepted configuration if
+   the control plane becomes unavailable.
+4. Untrusted clients connect to the gateway. Envoy and configured filters parse,
+   authenticate, authorize, transform, and route requests to upstream services
+   or explicitly configured AI/model providers.
+5. The gateway emits access logs, metrics, and traces to destinations selected
+   by the operator. Depending on configuration, those signals may include
+   sensitive request metadata.
+
+### Data Assets and Trust Boundaries
+
+| Asset or boundary | Security relevance |
+| --- | --- |
+| Kubernetes configuration and status | Unauthorized mutation can redirect traffic, weaken policy, load code, or disrupt availability. |
+| TLS keys, certificates, tokens, and upstream credentials | Disclosure or replacement can enable impersonation, traffic decryption, or unauthorized upstream access. |
+| Request/response bodies, AI prompts, and model outputs | May contain application secrets, personal data, proprietary data, or attacker-controlled content. |
+| xDS/SDS control-plane boundary | Integrity and availability determine what code, routes, clusters, policy, and secrets the data plane uses. |
+| Gateway process boundary | Native Go/C++ filters execute inside the proxy trust boundary; a defect can affect the full gateway process. |
+| Wasm plugin boundary | Wasm provides stronger isolation than a native filter, but plugins can still observe or modify traffic granted to them. |
+| External integration boundary | Registries, identity providers, certificate issuers, Redis, observability systems, OCI registries, and model providers have separate operators and trust. |
+| Source and release boundary | Compromise of source control, CI identities, dependencies, images, or plugin artifacts can affect every adopter. |
+
 ### Goals
 
-- Preserve authenticated configuration delivery between control and data
-  planes and reject invalid xDS updates.
+- Preserve the integrity and availability of configuration delivery between
+  control and data planes, reject invalid xDS updates, and make transport trust
+  assumptions explicit for operators.
 - Terminate and originate TLS as configured and distribute private key material
   through Kubernetes Secrets and SDS.
 - Isolate Wasm plugin execution from the gateway process to the extent provided
@@ -103,6 +145,30 @@ reviewers an initial view of security boundaries, practices, and known gaps.
 - External service registries, Redis, certificate issuers, identity providers,
   OCI registries, and AI/model providers.
 
+### Threat Model
+
+This project-authored model uses the actors, assets, flows, and boundaries above.
+Priority reflects generic impact for a shared production gateway; adopters must
+adjust it for their tenancy model and data classification.
+
+| ID | Priority | Threat scenario | Current mitigation and residual risk |
+| --- | --- | --- | --- |
+| HG-TM-01 | High | A principal with excessive Kubernetes permissions creates or changes routes, policies, Secrets, or plugins to hijack traffic or bypass controls. | Kubernetes authentication, RBAC, API validation, namespace scoping where configured, and review/GitOps practices reduce exposure. Cluster administrators remain trusted, and the controller currently has broad cluster-wide permissions. |
+| HG-TM-02 | High | A compromised controller, gateway ServiceAccount, or ClusterRoleBinding exposes TLS keys or upstream credentials. | Secrets are delivered through Kubernetes APIs and SDS rather than embedded in images. Gateway and controller roles are separate, but secret access and several controller rules remain broad and require minimization. |
+| HG-TM-03 | High | A malicious or compromised plugin/image executes code, exfiltrates traffic, or alters policy. | Plugin installation is explicit and Wasm supplies a sandbox boundary. Native filters share the gateway process; release/plugin artifacts lack project-wide signature, SBOM, and provenance guarantees. |
+| HG-TM-04 | High | Control-plane or xDS/SDS channel compromise injects malicious configuration or secret material, or prevents updates. | Envoy validates delivered resources and can retain last accepted configuration. Operators must protect control-plane identities, endpoints, network paths, and Kubernetes access; transport and deployment assumptions require a dedicated hardening guide. |
+| HG-TM-05 | High | Hostile downstream traffic exploits an Envoy/filter parser defect or exhausts connections, memory, CPU, sockets, or upstream capacity. | Envoy validation, resource limits, timeouts, rate-limit/circuit-breaker features, probes, and multiple replicas can limit impact. Safe values are deployment-specific and timely Envoy/Higress patching remains essential. |
+| HG-TM-06 | High | A tenant accidentally or deliberately attaches a route or policy to another tenant's gateway and exposes or disrupts traffic. | Kubernetes RBAC, namespace separation, Gateway API attachment controls, and review can restrict authors. Higress does not make a hostile multi-tenant cluster safe when administrators grant overlapping write privileges. |
+| HG-TM-07 | High | Requests, AI prompts, credentials, or responses are disclosed to an external registry, plugin, observability backend, identity service, or model provider. | Integrations require operator configuration and can be restricted through credentials and network policy. Operators remain responsible for egress allowlists, provider contracts, log redaction, residency, and data-retention controls. |
+| HG-TM-08 | Medium | Logs, metrics, traces, admin/debug endpoints, or configuration dumps expose credentials or sensitive request metadata. | Admin interfaces are not intended as public endpoints and telemetry is configurable. Access control, redaction, retention, and exposure are deployment responsibilities; unsafe logging or endpoint exposure remains possible. |
+| HG-TM-09 | High | Certificate expiration, issuer compromise, or unauthorized Secret replacement causes outage or impersonation. | SDS and automatic HTTPS support dynamic certificate updates and renewal. Operators must secure issuers, monitor expiry/renewal, test emergency rotation, and control Secret writers. |
+| HG-TM-10 | High | A source-control, dependency, GitHub Actions, registry, or maintainer-account compromise produces malicious release artifacts. | Public review, CI tests, license checks, CodeQL, pinned dependency/submodule inputs, and GitHub release workflows provide layers. Missing universal immutable action pinning, release SBOMs, signatures, provenance, and documented repository access controls leave material residual risk. |
+
+The model should be reviewed after material architecture, privilege, plugin,
+release-pipeline, or trust-boundary changes. The project does not yet enforce a
+review cadence or require a named security reviewer, which is itself a process
+gap.
+
 ## Project Compliance
 
 The open-source project does not claim PCI-DSS, SOC 2, ISO 27001, GDPR, or
@@ -137,7 +203,8 @@ OCI, Prometheus/OpenTelemetry conventions, and optional service registries.
 
 ## Security Issue Resolution
 
-[`SECURITY.md`](../../SECURITY.md) prohibits public vulnerability reports and
+[`SECURITY.md`](https://github.com/higress-group/higress/blob/762324c3767c620fef593504bcedf28f7969a954/SECURITY.md)
+prohibits public vulnerability reports and
 directs reporters to two private channels. The Security Response Team is the
 current maintainer list. The documented targets are acknowledgement within
 three business days and triage within 14 days, followed by private fix
@@ -166,8 +233,9 @@ Advisory and release information, and coordinate timing with the reporter.
   capability; legacy fallback adds `NET_BIND_SERVICE` and allows escalation.
 - No dedicated fuzzing/DAST program or automated upgrade/downgrade matrix is
   documented.
-- A complete threat model and independent security audit have not been
-  published.
+- This threat model is project-authored, has not been independently validated,
+  and is not yet backed by a published data-flow diagram with explicit trust
+  boundaries or an independent security audit.
 
 ### Known Issues Over Time
 


### PR DESCRIPTION
Change-Id: I98fe0020b93e5d68779c283d93014a8a02268efe

## Ⅰ. Describe what this PR did

Add the three review artifacts needed to prepare Higress for CNCF Incubation:

- a written General Technical Review covering the required Day 0 and Day 1 questions;
- a self-assessed Governance Review using the current CNCF TOC template; and
- a completed CNCF TAG Security Self-Assessment.

## Ⅱ. Does this pull request fix one issue?

No. This PR prepares the evidence required for the CNCF Incubation application.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Documentation-only change. No runtime code is modified.

## Ⅳ. Describe how to verify it

- Confirm the commit contains only the three files under `docs/cncf/`.
- Compare the GTR sections with the current CNCF GTR v1.0 Day 0 and Day 1 questionnaire.
- Compare the Governance Review sections with the current CNCF Governance Review template.
- Compare the Security Self-Assessment sections with the CNCF TAG Security self-assessment outline.
- Verify all relative Markdown links resolve and `git diff --check` passes.

## Ⅴ. Special notes for reviews

- The Governance Review deliberately reports `Needs Work` and lists must-fix findings; it does not claim that the project has passed governance review.
- `Complete project self-assessment` means the Security Self-Assessment document is complete, not that Higress has no security gaps or has completed an independent audit.
- Known technical and governance gaps are documented instead of being represented as completed controls.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Focus only on completing a written GTR, a Governance Review, and publishing a Security Self-Assessment. Use the latest CNCF templates, do not make unrelated changes, and distinguish completed documentation from criteria that are not yet satisfied.

### AI Coding Summary

- **Key decisions:** followed the current CNCF TOC GTR and Governance Review structures and the CNCF TAG Security self-assessment outline; kept the change limited to three documents.
- **Major changes:** added a Day 0/Day 1 GTR, a criterion-by-criterion governance self-review, and a security self-assessment covering actors, trust boundaries, development practices, response process, and known gaps.
- **Important limitations:** this PR publishes project self-assessments. CNCF reviewer acceptance, remediation of governance must-fix items, and any independent security review remain separate follow-up work.
