### PR TITLE
fix: ai-statistics matchRules config should inherit defaultConfig attributes

### DIFF
--- a/plugins/wasm-go/extensions/ai-statistics/main.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main.go
@@ -34,7 +34,7 @@ func main() {}
 func init() {
 	wrapper.SetCtx(
 		"ai-statistics",
-		wrapper.ParseConfig(parseConfig),
+		wrapper.ParseOverrideConfig(parseConfig, parseOverrideConfig),
 		wrapper.ProcessRequestHeaders(onHttpRequestHeaders),
 		wrapper.ProcessRequestBody(onHttpRequestBody),
 		wrapper.ProcessResponseHeaders(onHttpResponseHeaders),
@@ -543,6 +543,86 @@ func isContentTypeEnabled(contentType string, enabledContentTypes []string) bool
 	return false
 }
 
+// parseAttributeArray parses the user-configured attributes array and validates rule values.
+func parseAttributeArray(attributeConfigs []gjson.Result) ([]Attribute, error) {
+	attributes := make([]Attribute, len(attributeConfigs))
+	for i, attributeConfig := range attributeConfigs {
+		attribute := Attribute{}
+		err := json.Unmarshal([]byte(attributeConfig.Raw), &attribute)
+		if err != nil {
+			log.Errorf("parse config failed, %v", err)
+			return nil, err
+		}
+		if attribute.Rule != "" && attribute.Rule != RuleFirst && attribute.Rule != RuleReplace && attribute.Rule != RuleAppend {
+			return nil, errors.New("value of rule must be one of [nil, first, replace, append]")
+		}
+		attributes[i] = attribute
+	}
+	return attributes, nil
+}
+
+// refreshBufferingFlags recalculates shouldBufferRequestBody/shouldBufferStreamingBody
+// based on the current attributes.
+func (config *AIStatisticsConfig) refreshBufferingFlags() {
+	config.shouldBufferRequestBody = false
+	config.shouldBufferStreamingBody = false
+	// Check if any attribute needs request body or streaming body buffering
+	for _, attribute := range config.attributes {
+		// Check for request body buffering
+		if attribute.ValueSource == RequestBody {
+			config.shouldBufferRequestBody = true
+		}
+		// Check for streaming body buffering (explicitly configured)
+		if attribute.ValueSource == ResponseStreamingBody {
+			config.shouldBufferStreamingBody = true
+		}
+		// For built-in attributes without explicit ValueSource, check default sources
+		if attribute.ValueSource == "" && isBuiltinAttribute(attribute.Key) {
+			defaultSources := getBuiltinAttributeDefaultSources(attribute.Key)
+			for _, src := range defaultSources {
+				if src == RequestBody {
+					config.shouldBufferRequestBody = true
+				}
+				// Only answer/reasoning/tool_calls need actual body buffering
+				// Token-related attributes are extracted from context, not from body
+				if src == ResponseStreamingBody && needsBodyBuffering(attribute.Key) {
+					config.shouldBufferStreamingBody = true
+				}
+			}
+		}
+	}
+}
+
+// parsePathSuffixes processes manually configured path suffixes,
+// where "*" means all paths are enabled (empty list).
+func parsePathSuffixes(pathSuffixes []gjson.Result) []string {
+	suffixes := make([]string, 0, len(pathSuffixes))
+	for _, suffix := range pathSuffixes {
+		suffixStr := suffix.String()
+		if suffixStr == "*" {
+			// Clear the suffixes list since * means all paths are enabled
+			return make([]string, 0)
+		}
+		suffixes = append(suffixes, suffixStr)
+	}
+	return suffixes
+}
+
+// parseContentTypes processes configured content types,
+// where "*" means all content types are enabled (empty list).
+func parseContentTypes(contentTypes []gjson.Result) []string {
+	types := make([]string, 0, len(contentTypes))
+	for _, contentType := range contentTypes {
+		contentTypeStr := contentType.String()
+		if contentTypeStr == "*" {
+			// Clear the content types list since * means all content types are enabled
+			return make([]string, 0)
+		}
+		types = append(types, contentTypeStr)
+	}
+	return types
+}
+
 func parseConfig(configJson gjson.Result, config *AIStatisticsConfig) error {
 	// Check if use_default_attributes is enabled
 	useDefaultAttributes := configJson.Get("use_default_attributes").Bool()
@@ -575,46 +655,16 @@ func parseConfig(configJson gjson.Result, config *AIStatisticsConfig) error {
 		}
 		log.Infof("Using default response attributes configuration (lightweight mode)")
 	} else {
-		config.attributes = make([]Attribute, len(attributeConfigs))
-		for i, attributeConfig := range attributeConfigs {
-			attribute := Attribute{}
-			err := json.Unmarshal([]byte(attributeConfig.Raw), &attribute)
-			if err != nil {
-				log.Errorf("parse config failed, %v", err)
-				return err
-			}
-			if attribute.Rule != "" && attribute.Rule != RuleFirst && attribute.Rule != RuleReplace && attribute.Rule != RuleAppend {
-				return errors.New("value of rule must be one of [nil, first, replace, append]")
-			}
-			config.attributes[i] = attribute
+		attributes, err := parseAttributeArray(attributeConfigs)
+		if err != nil {
+			return err
 		}
+		config.attributes = attributes
 	}
 
 	// Check if any attribute needs request body or streaming body buffering
-	for _, attribute := range config.attributes {
-		// Check for request body buffering
-		if attribute.ValueSource == RequestBody {
-			config.shouldBufferRequestBody = true
-		}
-		// Check for streaming body buffering (explicitly configured)
-		if attribute.ValueSource == ResponseStreamingBody {
-			config.shouldBufferStreamingBody = true
-		}
-		// For built-in attributes without explicit ValueSource, check default sources
-		if attribute.ValueSource == "" && isBuiltinAttribute(attribute.Key) {
-			defaultSources := getBuiltinAttributeDefaultSources(attribute.Key)
-			for _, src := range defaultSources {
-				if src == RequestBody {
-					config.shouldBufferRequestBody = true
-				}
-				// Only answer/reasoning/tool_calls need actual body buffering
-				// Token-related attributes are extracted from context, not from body
-				if src == ResponseStreamingBody && needsBodyBuffering(attribute.Key) {
-					config.shouldBufferStreamingBody = true
-				}
-			}
-		}
-	}
+	config.refreshBufferingFlags()
+
 	// Metric settings
 	config.counterMetrics = make(map[string]proxywasm.MetricCounter)
 
@@ -622,41 +672,75 @@ func parseConfig(configJson gjson.Result, config *AIStatisticsConfig) error {
 	config.disableOpenaiUsage = configJson.Get("disable_openai_usage").Bool()
 
 	// Parse path suffix configuration
-	pathSuffixes := configJson.Get("enable_path_suffixes").Array()
-	config.enablePathSuffixes = make([]string, 0, len(pathSuffixes))
-
 	// If use_default_attributes or use_default_response_attributes is enabled and enable_path_suffixes is not configured, use default path suffixes
 	if (useDefaultAttributes || useDefaultResponseAttributes) && !configJson.Get("enable_path_suffixes").Exists() {
 		config.enablePathSuffixes = []string{"/completions", "/messages"}
 		log.Infof("Using default path suffixes: /completions, /messages")
 	} else {
 		// Process manually configured path suffixes
-		for _, suffix := range pathSuffixes {
-			suffixStr := suffix.String()
-			if suffixStr == "*" {
-				// Clear the suffixes list since * means all paths are enabled
-				config.enablePathSuffixes = make([]string, 0)
-				break
-			}
-			config.enablePathSuffixes = append(config.enablePathSuffixes, suffixStr)
-		}
+		config.enablePathSuffixes = parsePathSuffixes(configJson.Get("enable_path_suffixes").Array())
 	}
 
 	// Parse content type configuration
-	contentTypes := configJson.Get("enable_content_types").Array()
-	config.enableContentTypes = make([]string, 0, len(contentTypes))
-
-	for _, contentType := range contentTypes {
-		contentTypeStr := contentType.String()
-		if contentTypeStr == "*" {
-			// Clear the content types list since * means all content types are enabled
-			config.enableContentTypes = make([]string, 0)
-			break
-		}
-		config.enableContentTypes = append(config.enableContentTypes, contentTypeStr)
-	}
+	config.enableContentTypes = parseContentTypes(configJson.Get("enable_content_types").Array())
 
 	// Parse session ID header configuration
+	if sessionIdHeader := configJson.Get("session_id_header"); sessionIdHeader.Exists() {
+		config.sessionIdHeader = sessionIdHeader.String()
+	}
+
+	return nil
+}
+
+// parseOverrideConfig parses a rule-level config that inherits from the global config.
+// Fields are only overridden when they are explicitly present in the rule-level JSON,
+// so that a matchRule config no longer silently drops the global (defaultConfig) attributes.
+func parseOverrideConfig(configJson gjson.Result, global AIStatisticsConfig, config *AIStatisticsConfig) error {
+	// Inherit everything from the global config first.
+	*config = global
+	// Metric counters must not be shared between rule-level configs.
+	config.counterMetrics = make(map[string]proxywasm.MetricCounter)
+
+	useDefaultAttributes := configJson.Get("use_default_attributes")
+	useDefaultResponseAttributes := configJson.Get("use_default_response_attributes")
+	attributesJson := configJson.Get("attributes")
+
+	// Redefine the attribute set only when the rule explicitly configures it.
+	// An explicit false without an attributes array keeps the inherited global attributes.
+	attributesChanged := false
+	if useDefaultAttributes.Exists() && useDefaultAttributes.Bool() {
+		config.attributes = getDefaultAttributes()
+		attributesChanged = true
+		log.Infof("Using default attributes configuration for rule-level config")
+	} else if useDefaultResponseAttributes.Exists() && useDefaultResponseAttributes.Bool() {
+		config.attributes = getDefaultResponseAttributes()
+		attributesChanged = true
+		log.Infof("Using default response attributes configuration (lightweight mode) for rule-level config")
+	} else if attributesJson.Exists() {
+		attributes, err := parseAttributeArray(attributesJson.Array())
+		if err != nil {
+			return err
+		}
+		config.attributes = attributes
+		attributesChanged = true
+	}
+	if attributesChanged {
+		config.refreshBufferingFlags()
+	}
+
+	// Scalar/list fields are overridden only when explicitly present in the rule-level JSON.
+	if valueLengthLimit := configJson.Get("value_length_limit"); valueLengthLimit.Exists() {
+		config.valueLengthLimit = int(valueLengthLimit.Int())
+	}
+	if disableOpenaiUsage := configJson.Get("disable_openai_usage"); disableOpenaiUsage.Exists() {
+		config.disableOpenaiUsage = disableOpenaiUsage.Bool()
+	}
+	if enablePathSuffixes := configJson.Get("enable_path_suffixes"); enablePathSuffixes.Exists() {
+		config.enablePathSuffixes = parsePathSuffixes(enablePathSuffixes.Array())
+	}
+	if enableContentTypes := configJson.Get("enable_content_types"); enableContentTypes.Exists() {
+		config.enableContentTypes = parseContentTypes(enableContentTypes.Array())
+	}
 	if sessionIdHeader := configJson.Get("session_id_header"); sessionIdHeader.Exists() {
 		config.sessionIdHeader = sessionIdHeader.String()
 	}

--- a/plugins/wasm-go/extensions/ai-statistics/main_extra_test.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main_extra_test.go
@@ -128,3 +128,125 @@ func TestConvertToUInt_NilAndSlice_FallToDefault(t *testing.T) {
 	require.False(t, ok)
 	require.Equal(t, uint64(0), v)
 }
+
+// === Module C — rule-level config inheritance (issue #4173) =============
+//
+// With matchRules configured, the SDK parses each rule independently. Before
+// the ParseOverrideConfig fix, a rule-level config that did not repeat the
+// attributes list silently dropped the global (defaultConfig) attributes.
+// The tests below pin the new inheritance contract implemented by
+// parseOverrideConfig. The test host's default route name is
+// "test-route-default", so `_match_route_: ["test-route-default"]` makes
+// GetMatchConfig return the rule-level config.
+
+// Reproduces the exact issue #4173 scenario: global config defines
+// attributes=[consumer] with use_default_attributes=false, and the matchRule
+// only sets `use_default_response_attributes: false`. The rule-level
+// effective config must inherit the global attributes instead of ending up
+// with an empty attribute list.
+func TestOverrideRuleInheritsGlobalAttributes(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost([]byte(`{
+			"use_default_attributes": false,
+			"attributes": [
+				{
+					"key": "consumer",
+					"value_source": "request_header",
+					"value": "x-mse-consumer",
+					"apply_to_log": true
+				}
+			],
+			"_rules_": [
+				{
+					"_match_route_": ["test-route-default"],
+					"use_default_response_attributes": false
+				}
+			]
+		}`))
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		conf, err := host.GetMatchConfig()
+		require.NoError(t, err)
+		c := conf.(*AIStatisticsConfig)
+		require.Len(t, c.attributes, 1)
+		require.Equal(t, "consumer", c.attributes[0].Key)
+		require.Equal(t, "x-mse-consumer", c.attributes[0].Value)
+	})
+}
+
+// A rule that explicitly configures its own attributes list must override
+// the inherited global attributes, and buffering flags must be recalculated
+// for the new attribute set.
+func TestOverrideRuleRedefinesAttributes(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost([]byte(`{
+			"attributes": [
+				{
+					"key": "consumer",
+					"value_source": "request_header",
+					"value": "x-mse-consumer",
+					"apply_to_log": true
+				}
+			],
+			"_rules_": [
+				{
+					"_match_route_": ["test-route-default"],
+					"attributes": [
+						{
+							"key": "model",
+							"value_source": "request_body",
+							"value": "model",
+							"apply_to_log": true
+						}
+					]
+				}
+			]
+		}`))
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		conf, err := host.GetMatchConfig()
+		require.NoError(t, err)
+		c := conf.(*AIStatisticsConfig)
+		require.Len(t, c.attributes, 1)
+		require.Equal(t, "model", c.attributes[0].Key)
+		// The new attribute set reads from the request body, so the
+		// buffering flag must be refreshed accordingly.
+		require.True(t, c.shouldBufferRequestBody)
+	})
+}
+
+// A rule that only overrides a scalar field (value_length_limit) must keep
+// the inherited global attributes while applying the new limit.
+func TestOverrideRuleOverridesScalar(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		host, status := test.NewTestHost([]byte(`{
+			"attributes": [
+				{
+					"key": "consumer",
+					"value_source": "request_header",
+					"value": "x-mse-consumer",
+					"apply_to_log": true
+				}
+			],
+			"_rules_": [
+				{
+					"_match_route_": ["test-route-default"],
+					"value_length_limit": 500
+				}
+			]
+		}`))
+		defer host.Reset()
+		require.Equal(t, types.OnPluginStartStatusOK, status)
+
+		conf, err := host.GetMatchConfig()
+		require.NoError(t, err)
+		c := conf.(*AIStatisticsConfig)
+		// Attributes inherited from the global config.
+		require.Len(t, c.attributes, 1)
+		require.Equal(t, "consumer", c.attributes[0].Key)
+		// Scalar overridden by the rule-level config.
+		require.Equal(t, 500, c.valueLengthLimit)
+	})
+}


### PR DESCRIPTION
Fixes #4173

## What this PR does

`ai-statistics` registered plain `wrapper.ParseConfig`, so each `matchRules` config was parsed independently and never inherited `defaultConfig` — `defaultConfig.attributes` silently stopped working once any matchRule matched (see root-cause analysis in #4173). This PR registers `wrapper.ParseOverrideConfig` (the same pattern already used by `ai-proxy` and `key-auth`) so rule-level configs are parsed **on top of** the global config.

Semantics:
- Rule-level entries inherit everything from `defaultConfig` and only override keys they explicitly set: the attribute set (`use_default_attributes` / `use_default_response_attributes` / `attributes`), `value_length_limit`, `disable_openai_usage`, `enable_path_suffixes`, `enable_content_types`, `session_id_header`.
- An explicit `use_default_*: false` without an `attributes` array keeps the inherited global attributes (this is exactly the reporter's config shape).
- Buffering flags (`shouldBufferRequestBody` / `shouldBufferStreamingBody`) are recalculated whenever the attribute set is redefined.
- Metric counter maps are freshly allocated per config and never shared.

`parseConfig` behavior is unchanged; shared logic is extracted into helpers (`parseAttributeArray`, `refreshBufferingFlags`, `parsePathSuffixes`, `parseContentTypes`).

## Tests

- `TestOverrideRuleInheritsGlobalAttributes` — reproduces the issue scenario: global `attributes` (consumer from request header) + rule-level `use_default_response_attributes: false` → consumer attribute is now inherited.
- `TestOverrideRuleRedefinesAttributes` — rule-level explicit `attributes` overrides global; buffering flags recalculated.
- `TestOverrideRuleOverridesScalar` — attributes inherited while `value_length_limit` is overridden.
- Full suite: `go vet ./...` clean, `go test ./...` green including all pre-existing cases.

## Behavior note

Rule-level configs that previously relied on fully independent parsing (i.e. expected an *empty* attribute set while `defaultConfig` had attributes) will now inherit the global attributes. This matches the documented mental model of `defaultConfig` + per-route overrides and the behavior of other plugins; explicitly setting `attributes: []` at the rule level still yields an empty set.