### PR TITLE
ci: run CodeQL on main and pull requests

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -12,6 +12,10 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [ 'main' ]
+  pull_request:
+    branches: [ 'main' ]
   schedule:
     - cron: '36 19 * * 6'
 
@@ -38,7 +42,7 @@ jobs:
 
       # step 2: Initializes the CodeQL tools for scanning.
       - name: "Initialize CodeQL"
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: "Autobuild"
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       # step 4
       # ℹ️ Command-line programs to run using the OS shell.
@@ -66,4 +70,4 @@ jobs:
 
       # step 5
       - name: "Perform CodeQL Analysis"
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- run CodeQL on pull requests targeting `main`
- run CodeQL on pushes to `main`
- retain the existing weekly scheduled scan
- upgrade `github/codeql-action` from v2 to v4

## Why

Previously, the CodeQL workflow only ran on its weekly schedule. This change adds continuous scanning for pull requests and the default branch so security findings can be detected before or immediately after merge.

## Scope

This is a workflow-only change. It does not modify Higress production code or runtime behavior.

## Validation

- the PR diff contains only `.github/workflows/codeql-analysis.yaml`
- the new `pull_request` trigger ran successfully on this PR
- CodeQL, build, tests, conformance, license, DCO, and security checks all passed