### PR TITLE
security: avoid image request allocation overflows

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/image_request_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/image_request_test.go
@@ -1,0 +1,50 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageRequestsCollectAllURLs(t *testing.T) {
+	images := []imageInputURL{
+		{URL: "https://example.com/first.png"},
+		{ImageURL: &chatMessageContentImageUrl{Url: "https://example.com/second.png"}},
+	}
+	image := &imageInputURL{URL: "https://example.com/image.png"}
+	imageURL := &imageInputURL{URL: "https://example.com/image-url.png"}
+	expected := []string{
+		"https://example.com/first.png",
+		"https://example.com/second.png",
+		"https://example.com/image.png",
+		"https://example.com/image-url.png",
+	}
+
+	editRequest := &imageEditRequest{
+		Images:   images,
+		Image:    image,
+		ImageURL: imageURL,
+	}
+	require.Equal(t, expected, editRequest.GetImageURLs())
+
+	variationRequest := &imageVariationRequest{
+		Images:   images,
+		Image:    image,
+		ImageURL: imageURL,
+	}
+	require.Equal(t, expected, variationRequest.GetImageURLs())
+}
+
+func TestBuildVertexImageRequestKeepsImageAndPromptParts(t *testing.T) {
+	request, err := (&vertexProvider{}).buildVertexImageRequest(
+		"draw a gateway",
+		"1024x1024",
+		"png",
+		[]string{"https://example.com/input.jpg"},
+	)
+	require.NoError(t, err)
+	require.Len(t, request.Contents, 1)
+	require.Len(t, request.Contents[0].Parts, 2)
+	require.Equal(t, "https://example.com/input.jpg", request.Contents[0].Parts[0].FileData.FileUri)
+	require.Equal(t, "draw a gateway", request.Contents[0].Parts[1].Text)
+}

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -646,7 +646,7 @@ type imageEditRequest struct {
 }
 
 func (r *imageEditRequest) GetImageURLs() []string {
-	urls := make([]string, 0, len(r.Images)+2)
+	urls := make([]string, 0, len(r.Images))
 	for _, image := range r.Images {
 		if url := image.GetURL(); url != "" {
 			urls = append(urls, url)
@@ -690,7 +690,7 @@ type imageVariationRequest struct {
 }
 
 func (r *imageVariationRequest) GetImageURLs() []string {
-	urls := make([]string, 0, len(r.Images)+2)
+	urls := make([]string, 0, len(r.Images))
 	for _, image := range r.Images {
 		if url := image.GetURL(); url != "" {
 			urls = append(urls, url)

--- a/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/vertex.go
@@ -633,7 +633,7 @@ func (v *vertexProvider) buildVertexImageRequest(prompt string, size string, out
 		}
 	}
 
-	parts := make([]vertexPart, 0, len(imageURLs)+1)
+	parts := make([]vertexPart, 0, len(imageURLs))
 	for _, imageURL := range imageURLs {
 		part, err := convertMediaContent(imageURL)
 		if err != nil {


### PR DESCRIPTION
## Summary

- remove potentially overflowing len(slice) + constant capacity calculations from OpenAI image edit and variation URL collection
- remove the same pattern from Vertex image request part construction
- keep the existing slice length as the safe initial capacity and let append grow the slice for optional fields
- add regression tests for URL ordering and Vertex image-plus-prompt request structure

## CodeQL coverage

This addresses the three open High go/allocation-size-overflow alerts in Higress-owned AI Proxy code: alerts 81, 82, and 83. It does not dismiss or suppress the findings.

## Validation

- go test ./provider
- go test -timeout 10m ./...
- git diff --check

The complete AI Proxy test suite passed, including the main package in 343.654 seconds.