### PR TITLE
security: validate plugin integer conversions

### DIFF
--- a/plugins/wasm-go/extensions/custom-response/main.go
+++ b/plugins/wasm-go/extensions/custom-response/main.go
@@ -125,8 +125,8 @@ func parseRuleItem(gjson gjson.Result, rule *CustomResponseRule) error {
 	rule.statusCode = 200
 	if gjson.Get("status_code").Exists() {
 		statusCode := gjson.Get("status_code")
-		parsedStatusCode, err := strconv.Atoi(statusCode.String())
-		if err != nil {
+		parsedStatusCode, err := strconv.ParseUint(statusCode.String(), 10, 32)
+		if err != nil || parsedStatusCode < 100 || parsedStatusCode > 599 {
 			return fmt.Errorf("invalid status code value: %s", statusCode.String())
 		}
 		rule.statusCode = uint32(parsedStatusCode)

--- a/plugins/wasm-go/extensions/custom-response/main_extra_test.go
+++ b/plugins/wasm-go/extensions/custom-response/main_extra_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
@@ -144,6 +145,22 @@ func TestParseRuleItem_InvalidStatusCode_StartFails(t *testing.T) {
 		defer host.Reset()
 		require.Equal(t, types.OnPluginStartStatusFailed, status)
 	})
+}
+
+func TestParseRuleItem_OutOfRangeStatusCode_StartFails(t *testing.T) {
+	for _, statusCode := range []any{-1, 99, 600, "4294967296"} {
+		t.Run(fmt.Sprint(statusCode), func(t *testing.T) {
+			test.RunGoTest(t, func(t *testing.T) {
+				cfg := mustConfigBytes(t, map[string]interface{}{
+					"status_code": statusCode,
+					"body":        "x",
+				})
+				host, status := test.NewTestHost(cfg)
+				defer host.Reset()
+				require.Equal(t, types.OnPluginStartStatusFailed, status)
+			})
+		})
+	}
 }
 
 // === Module C — parseConfig error paths =================================

--- a/plugins/wasm-go/extensions/response-cache/main.go
+++ b/plugins/wasm-go/extensions/response-cache/main.go
@@ -141,15 +141,7 @@ func onHttpResponseHeaders(ctx wrapper.HttpContext, c config.PluginConfig) types
 	}
 
 	// 状态码判断
-	found := false
-	respCode, _ := strconv.Atoi(status)
-	for _, element := range c.CacheResponseCode {
-		if element == int32(respCode) {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if !isCacheableResponseStatus(status, c.CacheResponseCode) {
 		log.Infof("[onHttpResponseBody] status not allow to cached: %s", status)
 		proxywasm.AddHttpResponseHeader("x-cache-status", "skip")
 		ctx.DontReadResponseBody()
@@ -167,6 +159,19 @@ func onHttpResponseHeaders(ctx wrapper.HttpContext, c config.PluginConfig) types
 	}
 	ctx.SetResponseBodyBufferLimit(DEFAULT_MAX_BODY_BYTES)
 	return types.ActionContinue
+}
+
+func isCacheableResponseStatus(status string, allowed []int32) bool {
+	code, err := strconv.ParseInt(status, 10, 32)
+	if err != nil || code < 100 || code > 599 {
+		return false
+	}
+	for _, allowedCode := range allowed {
+		if allowedCode == int32(code) {
+			return true
+		}
+	}
+	return false
 }
 
 func onHttpResponseBody(ctx wrapper.HttpContext, c config.PluginConfig, body []byte) types.Action {

--- a/plugins/wasm-go/extensions/response-cache/main_test.go
+++ b/plugins/wasm-go/extensions/response-cache/main_test.go
@@ -437,6 +437,27 @@ func TestOnHttpResponseHeaders(t *testing.T) {
 	})
 }
 
+func TestIsCacheableResponseStatus(t *testing.T) {
+	allowed := []int32{200, 204}
+	for _, tc := range []struct {
+		name   string
+		status string
+		want   bool
+	}{
+		{name: "allowed", status: "200", want: true},
+		{name: "valid but not allowed", status: "500", want: false},
+		{name: "negative", status: "-1", want: false},
+		{name: "below HTTP range", status: "99", want: false},
+		{name: "above HTTP range", status: "600", want: false},
+		{name: "int32 overflow", status: "2147483648", want: false},
+		{name: "not a number", status: "invalid", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isCacheableResponseStatus(tc.status, allowed))
+		})
+	}
+}
+
 func TestOnHttpResponseBody(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
 		// 测试响应体处理 - 提取特定字段

--- a/plugins/wasm-go/extensions/waf/magefiles/magefile.go
+++ b/plugins/wasm-go/extensions/waf/magefiles/magefile.go
@@ -17,6 +17,11 @@ var minGoVersion = "1.19"
 var tinygoMinorVersion = "0.28"
 var Default = Build
 
+const (
+	defaultInitialPages = uint32(2100)
+	maxWasmMemoryPages  = uint64(65536)
+)
+
 func init() {
 	for _, check := range []func() error{
 		checkTinygoVersion,
@@ -100,13 +105,13 @@ func Build() error {
 	buildTagArg := fmt.Sprintf("-tags='%s'", strings.Join(buildTags, " "))
 
 	// ~100MB initial heap
-	initialPages := 2100
+	initialPages := defaultInitialPages
 	if ipEnv := os.Getenv("INITIAL_PAGES"); ipEnv != "" {
-		if ip, err := strconv.Atoi(ipEnv); err != nil {
-			return err
-		} else {
-			initialPages = ip
+		ip, err := strconv.ParseUint(ipEnv, 10, 32)
+		if err != nil || ip == 0 || ip > maxWasmMemoryPages {
+			return fmt.Errorf("invalid INITIAL_PAGES %q: must be between 1 and %d", ipEnv, maxWasmMemoryPages)
 		}
+		initialPages = uint32(ip)
 	}
 
 	if err := sh.RunV("tinygo", "build", "-gc=custom", "-opt=2", "-o", filepath.Join("local", "mainraw.wasm"), "-scheduler=none", "-target=wasi", buildTagArg); err != nil {
@@ -124,7 +129,7 @@ func Build() error {
 	return nil
 }
 
-func patchWasm(inPath, outPath string, initialPages int) error {
+func patchWasm(inPath, outPath string, initialPages uint32) error {
 	raw, err := os.ReadFile(inPath)
 	if err != nil {
 		return err
@@ -134,7 +139,7 @@ func patchWasm(inPath, outPath string, initialPages int) error {
 		return err
 	}
 
-	mod.MemorySection.Min = uint32(initialPages)
+	mod.MemorySection.Min = initialPages
 
 	for _, imp := range mod.ImportSection {
 		switch {


### PR DESCRIPTION
## Summary

- parse response-cache HTTP status values with an explicit 32-bit bound and only cache valid 100-599 responses
- parse custom-response status_code as uint32 and reject negative, overflowing, or non-HTTP values
- parse WAF INITIAL_PAGES as uint32, enforce the WebAssembly 1-65536 page range, and pass the checked type through to the module patcher
- add regression coverage for malformed, negative, out-of-range, and overflowing status values

## CodeQL coverage

This addresses three open High go/incorrect-integer-conversion alerts in Higress-owned plugin code: alerts 78, 60, and 40. No finding is dismissed or suppressed.

## Validation

- go test ./... in plugins/wasm-go/extensions/response-cache
- go test ./... in plugins/wasm-go/extensions/custom-response
- go test -c -o /tmp/higress-waf-magefiles.test . in plugins/wasm-go/extensions/waf/magefiles
- git diff --check

The WAF magefiles package has build-tool checks in init, so it was compiled without executing the build-tool initialization; response-cache and custom-response ran their complete test suites.