### PR TITLE
security: validate core integer bounds

### DIFF
--- a/pkg/ingress/kube/annotations/local_rate_limit.go
+++ b/pkg/ingress/kube/annotations/local_rate_limit.go
@@ -15,6 +15,8 @@
 package annotations
 
 import (
+	"fmt"
+
 	"github.com/golang/protobuf/ptypes/duration"
 	networking "istio.io/api/networking/v1alpha3"
 	//"istio.io/istio/pilot/pkg/networking/core/v1alpha3/mseingress"
@@ -60,26 +62,53 @@ func (l localRateLimit) Parse(annotations Annotations, config *Ingress, _ *Globa
 		config.localRateLimit = local
 	}()
 
-	multiplier := defaultBurstMultiplier
-	if m, err := annotations.ParseIntForHigress(limitBurstMultiplier); err == nil {
+	multiplier := uint32(defaultBurstMultiplier)
+	if annotations.HasHigress(limitBurstMultiplier) {
+		m, err := annotations.ParseUint32ForHigress(limitBurstMultiplier)
+		if err != nil || m == 0 {
+			return fmt.Errorf("invalid %s annotation", limitBurstMultiplier)
+		}
 		multiplier = m
 	}
 
-	if rpm, err := annotations.ParseIntForHigress(limitRPM); err == nil {
-		local = &localRateLimitConfig{
-			MaxTokens:     uint32(rpm * multiplier),
-			TokensPerFill: uint32(rpm),
-			FillInterval:  minute,
+	if annotations.HasHigress(limitRPM) {
+		rpm, err := annotations.ParseUint32ForHigress(limitRPM)
+		if err != nil {
+			return fmt.Errorf("invalid %s annotation", limitRPM)
 		}
-	} else if rps, err := annotations.ParseIntForHigress(limitRPS); err == nil {
-		local = &localRateLimitConfig{
-			MaxTokens:     uint32(rps * multiplier),
-			TokensPerFill: uint32(rps),
-			FillInterval:  second,
+		local, err = buildLocalRateLimitConfig(rpm, multiplier, minute)
+		if err != nil {
+			return err
+		}
+	} else {
+		rps, err := annotations.ParseUint32ForHigress(limitRPS)
+		if err != nil {
+			return fmt.Errorf("invalid %s annotation", limitRPS)
+		}
+		local, err = buildLocalRateLimitConfig(rps, multiplier, second)
+		if err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+func buildLocalRateLimitConfig(rate, multiplier uint32, interval *duration.Duration) (*localRateLimitConfig, error) {
+	if rate == 0 {
+		return nil, fmt.Errorf("local rate limit must be greater than zero")
+	}
+	if multiplier == 0 {
+		return nil, fmt.Errorf("local rate limit burst multiplier must be greater than zero")
+	}
+	if rate > ^uint32(0)/multiplier {
+		return nil, fmt.Errorf("local rate limit burst exceeds uint32")
+	}
+	return &localRateLimitConfig{
+		MaxTokens:     rate * multiplier,
+		TokensPerFill: rate,
+		FillInterval:  interval,
+	}, nil
 }
 
 func (l localRateLimit) ApplyRoute(route *networking.HTTPRoute, config *Ingress) {

--- a/pkg/ingress/kube/annotations/local_rate_limit_test.go
+++ b/pkg/ingress/kube/annotations/local_rate_limit_test.go
@@ -24,8 +24,9 @@ import (
 func TestLocalRateLimitParse(t *testing.T) {
 	localRateLimit := localRateLimit{}
 	inputCases := []struct {
-		input  map[string]string
-		expect *localRateLimitConfig
+		input   map[string]string
+		expect  *localRateLimitConfig
+		wantErr bool
 	}{
 		{},
 		{
@@ -61,12 +62,41 @@ func TestLocalRateLimitParse(t *testing.T) {
 				FillInterval:  second,
 			},
 		},
+		{
+			input: map[string]string{
+				buildHigressAnnotationKey(limitRPM): "-1",
+			},
+			wantErr: true,
+		},
+		{
+			input: map[string]string{
+				buildHigressAnnotationKey(limitRPM): "4294967296",
+			},
+			wantErr: true,
+		},
+		{
+			input: map[string]string{
+				buildHigressAnnotationKey(limitRPM):             "4294967295",
+				buildHigressAnnotationKey(limitBurstMultiplier): "2",
+			},
+			wantErr: true,
+		},
+		{
+			input: map[string]string{
+				buildHigressAnnotationKey(limitRPS):             "1",
+				buildHigressAnnotationKey(limitBurstMultiplier): "0",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, inputCase := range inputCases {
 		t.Run("", func(t *testing.T) {
 			config := &Ingress{}
-			_ = localRateLimit.Parse(inputCase.input, config, nil)
+			err := localRateLimit.Parse(inputCase.input, config, nil)
+			if (err != nil) != inputCase.wantErr {
+				t.Fatalf("Parse() error = %v, wantErr %v", err, inputCase.wantErr)
+			}
 			if !reflect.DeepEqual(inputCase.expect, config.localRateLimit) {
 				t.Fatal("Should be equal")
 			}

--- a/registry/zookeeper/watcher.go
+++ b/registry/zookeeper/watcher.go
@@ -634,7 +634,11 @@ func (w *watcher) generateServiceEntry(config InterfaceConfig) *v1alpha3.Service
 		if service.Metadata != nil && service.Metadata[PROTOCOL] != "" {
 			protocol = common.ParseProtocol(service.Metadata[PROTOCOL])
 		}
-		portNumber, _ := strconv.Atoi(service.Port)
+		portNumber, err := strconv.ParseUint(service.Port, 10, 16)
+		if err != nil || portNumber == 0 {
+			log.Warnf("skip zookeeper endpoint %s with invalid port %q", service.Ip, service.Port)
+			continue
+		}
 		port := &v1alpha3.ServicePort{
 			Name:     protocol.String(),
 			Number:   uint32(portNumber),

--- a/registry/zookeeper/watcher_test.go
+++ b/registry/zookeeper/watcher_test.go
@@ -128,3 +128,23 @@ func TestGetDubboConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateServiceEntryRejectsInvalidPorts(t *testing.T) {
+	w := &watcher{}
+	serviceEntry := w.generateServiceEntry(InterfaceConfig{
+		Host: "example.service",
+		Endpoints: []Endpoint{
+			{Ip: "10.0.0.1", Port: "8080"},
+			{Ip: "10.0.0.2", Port: "-1"},
+			{Ip: "10.0.0.3", Port: "0"},
+			{Ip: "10.0.0.4", Port: "65536"},
+			{Ip: "10.0.0.5", Port: "4294967296"},
+			{Ip: "10.0.0.6", Port: "invalid"},
+		},
+	})
+
+	assert.Len(t, serviceEntry.Ports, 1)
+	assert.Equal(t, uint32(8080), serviceEntry.Ports[0].Number)
+	assert.Len(t, serviceEntry.Endpoints, 1)
+	assert.Equal(t, "10.0.0.1", serviceEntry.Endpoints[0].Address)
+}


### PR DESCRIPTION
## Summary

- parse local rate-limit annotations directly as uint32 values
- reject zero rates, zero burst multipliers, negative/overflowing annotations, and burst multiplication overflow
- parse ZooKeeper endpoint ports with a 16-bit bound and skip invalid, zero, or out-of-range endpoints instead of emitting wrapped port values
- add boundary regression tests for annotation parsing, burst overflow, and invalid ZooKeeper ports

## CodeQL coverage

This addresses three open High go/incorrect-integer-conversion alerts in Higress-owned core code: alerts 29, 30, and 5. No finding is dismissed or suppressed.

## Validation

- gofmt completed for all changed Go files
- git diff --check passed
- targeted tests were added for both code paths

A local targeted go test invocation was blocked before compilation because the existing generated external/istio tree in this workspace requires Go 1.26 while the repository and CI select Go 1.24. No dependency or generated tree was changed to bypass that mismatch; the clean GitHub CI run is the authoritative test for this PR.