### PR TITLE
test: verify conformance TLS certificates

### DIFF
--- a/test/e2e/conformance/tests/configmap-https.go
+++ b/test/e2e/conformance/tests/configmap-https.go
@@ -15,8 +15,13 @@
 package tests
 
 import (
+	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/cert"
 	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/http"
 	"github.com/alibaba/higress/v2/test/e2e/conformance/utils/suite"
 )
@@ -31,6 +36,39 @@ var ConfigmapHttps = suite.ConformanceTest{
 	Manifests:   []string{"tests/configmap-https.yaml"},
 	Features:    []suite.SupportedFeature{suite.HTTPConformanceFeature},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
+		fooCAOut, _, fooCA, fooCAKey := cert.MustGenerateCaCert(t)
+		fooCertOut, fooKeyOut := cert.MustGenerateCertWithCA(t, cert.ServerCertType, fooCA, fooCAKey, []string{"foo.com", "*.foo.com"})
+		barCAOut, _, barCA, barCAKey := cert.MustGenerateCaCert(t)
+		barCertOut, barKeyOut := cert.MustGenerateCertWithCA(t, cert.ServerCertType, barCA, barCAKey, []string{"bar.com"})
+
+		testContext := context.Background()
+		for _, secretUpdate := range []struct {
+			objectKey  client.ObjectKey
+			cert       []byte
+			privateKey []byte
+		}{
+			{
+				objectKey:  client.ObjectKey{Namespace: "higress-system", Name: "foo-com-secret"},
+				cert:       fooCertOut.Bytes(),
+				privateKey: fooKeyOut.Bytes(),
+			},
+			{
+				objectKey:  client.ObjectKey{Namespace: "higress-conformance-infra", Name: "bar-com-secret"},
+				cert:       barCertOut.Bytes(),
+				privateKey: barKeyOut.Bytes(),
+			},
+		} {
+			secret := &corev1.Secret{}
+			if err := suite.Client.Get(testContext, secretUpdate.objectKey, secret); err != nil {
+				t.Fatalf("failed to get TLS secret %s: %v", secretUpdate.objectKey, err)
+			}
+			secret.Data[corev1.TLSCertKey] = secretUpdate.cert
+			secret.Data[corev1.TLSPrivateKeyKey] = secretUpdate.privateKey
+			if err := suite.Client.Update(testContext, secret); err != nil {
+				t.Fatalf("failed to update TLS secret %s: %v", secretUpdate.objectKey, err)
+			}
+		}
+
 		testCases := []struct {
 			httpAssert http.Assertion
 		}{
@@ -47,6 +85,9 @@ var ConfigmapHttps = suite.ConformanceTest{
 							Host: "bar.com",
 							TLSConfig: &http.TLSConfig{
 								SNI: "bar.com",
+								Certificates: http.Certificates{
+									CACerts: [][]byte{barCAOut.Bytes()},
+								},
 							},
 						},
 						ExpectedRequest: &http.ExpectedRequest{
@@ -76,6 +117,9 @@ var ConfigmapHttps = suite.ConformanceTest{
 							Host: "a.foo.com",
 							TLSConfig: &http.TLSConfig{
 								SNI: "a.foo.com",
+								Certificates: http.Certificates{
+									CACerts: [][]byte{fooCAOut.Bytes()},
+								},
 							},
 						},
 						ExpectedRequest: &http.ExpectedRequest{
@@ -105,6 +149,9 @@ var ConfigmapHttps = suite.ConformanceTest{
 							Host: "b.foo.com",
 							TLSConfig: &http.TLSConfig{
 								SNI: "b.foo.com",
+								Certificates: http.Certificates{
+									CACerts: [][]byte{fooCAOut.Bytes()},
+								},
 							},
 						},
 						ExpectedRequest: &http.ExpectedRequest{

--- a/test/e2e/conformance/tests/httproute-downstream-encryption.go
+++ b/test/e2e/conformance/tests/httproute-downstream-encryption.go
@@ -38,7 +38,12 @@ var HTTPRouteDownstreamEncryption = suite.ConformanceTest{
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		// Prepare certificates and secrets for testcases
 		caCertOut, _, caCert, caKey := cert.MustGenerateCaCert(t)
-		svcCertOut, svcKeyOut := cert.MustGenerateCertWithCA(t, cert.ServerCertType, caCert, caKey, []string{"foo.com"})
+		svcCertOut, svcKeyOut := cert.MustGenerateCertWithCA(t, cert.ServerCertType, caCert, caKey, []string{
+			"foo.com",
+			"foo1.com",
+			"foo2.com",
+			"foo3.com",
+		})
 		cliCertOut, cliKeyOut := cert.MustGenerateCertWithCA(t, cert.ClientCertType, caCert, caKey, nil)
 		fooSecret := kubernetes.ConstructTLSSecret("higress-conformance-infra", "foo-secret", svcCertOut.Bytes(), svcKeyOut.Bytes())
 		fooSecretCACert := kubernetes.ConstructCASecret("higress-conformance-infra", "foo-secret-cacert", caCertOut.Bytes())

--- a/test/e2e/conformance/tests/httproute-https-without-sni.go
+++ b/test/e2e/conformance/tests/httproute-https-without-sni.go
@@ -36,7 +36,7 @@ var HTTPHttpsWithoutSni = suite.ConformanceTest{
 	Features:    []suite.SupportedFeature{suite.HTTPConformanceFeature},
 	Test: func(t *testing.T, suite *suite.ConformanceTestSuite) {
 		// Prepare secrets for testcases
-		_, _, caCert, caKey := cert.MustGenerateCaCert(t)
+		caCertOut, _, caCert, caKey := cert.MustGenerateCaCert(t)
 		svcCertOut, svcKeyOut := cert.MustGenerateCertWithCA(t, cert.ServerCertType, caCert, caKey, []string{"foo.com"})
 		fooSecret := kubernetes.ConstructTLSSecret("higress-conformance-infra", "foo-secret", svcCertOut.Bytes(), svcKeyOut.Bytes())
 		suite.Applier.MustApplyObjectsWithCleanup(t, suite.Client, suite.TimeoutConfig, []client.Object{fooSecret}, suite.Cleanup)
@@ -54,6 +54,9 @@ var HTTPHttpsWithoutSni = suite.ConformanceTest{
 						Host: "foo.com",
 						TLSConfig: &http.TLSConfig{
 							SNI: "foo.com",
+							Certificates: http.Certificates{
+								CACerts: [][]byte{caCertOut.Bytes()},
+							},
 						},
 					},
 					ExpectedRequest: &http.ExpectedRequest{
@@ -77,9 +80,13 @@ var HTTPHttpsWithoutSni = suite.ConformanceTest{
 				},
 				Request: http.AssertionRequest{
 					ActualRequest: http.Request{
-						Path:      "/foo",
-						Host:      "foo.com",
-						TLSConfig: &http.TLSConfig{},
+						Path: "/foo",
+						Host: "foo.com",
+						TLSConfig: &http.TLSConfig{
+							Certificates: http.Certificates{
+								CACerts: [][]byte{caCertOut.Bytes()},
+							},
+						},
 					},
 					ExpectedRequest: &http.ExpectedRequest{
 						Request: http.Request{

--- a/test/e2e/conformance/utils/roundtripper/roundtripper.go
+++ b/test/e2e/conformance/utils/roundtripper/roundtripper.go
@@ -128,13 +128,12 @@ func (d *DefaultRoundTripper) initTransport(client *http.Client, protocol string
 		}
 
 		tlsClientConfig = &tls.Config{
-			MinVersion:         tlsConfig.MinVersion,
-			MaxVersion:         tlsConfig.MaxVersion,
-			ServerName:         tlsConfig.SNI,
-			CipherSuites:       tlsConfig.CipherSuites,
-			RootCAs:            pool,
-			Certificates:       clientCerts,
-			InsecureSkipVerify: true,
+			MinVersion:   tlsConfig.MinVersion,
+			MaxVersion:   tlsConfig.MaxVersion,
+			ServerName:   tlsConfig.SNI,
+			CipherSuites: tlsConfig.CipherSuites,
+			RootCAs:      pool,
+			Certificates: clientCerts,
 		}
 	}
 
@@ -190,13 +189,12 @@ func (d *DefaultRoundTripper) CaptureRoundTrip(request Request) (*CapturedReques
 			TLSHandshakeTimeout: d.TimeoutConfig.TLSHandshakeTimeout,
 			DisableKeepAlives:   true,
 			TLSClientConfig: &tls.Config{
-				MinVersion:         request.TLSConfig.MinVersion,
-				MaxVersion:         request.TLSConfig.MaxVersion,
-				ServerName:         request.TLSConfig.SNI,
-				CipherSuites:       request.TLSConfig.CipherSuites,
-				RootCAs:            pool,
-				Certificates:       clientCerts,
-				InsecureSkipVerify: true,
+				MinVersion:   request.TLSConfig.MinVersion,
+				MaxVersion:   request.TLSConfig.MaxVersion,
+				ServerName:   request.TLSConfig.SNI,
+				CipherSuites: request.TLSConfig.CipherSuites,
+				RootCAs:      pool,
+				Certificates: clientCerts,
 			},
 		}
 	}

--- a/test/e2e/conformance/utils/roundtripper/roundtripper_test.go
+++ b/test/e2e/conformance/utils/roundtripper/roundtripper_test.go
@@ -58,9 +58,8 @@ func TestTransport(t *testing.T) {
 			},
 			transport: &http2.Transport{
 				TLSClientConfig: &tls.Config{
-					RootCAs:            x509.NewCertPool(),
-					ServerName:         "www.example.com",
-					InsecureSkipVerify: true,
+					RootCAs:    x509.NewCertPool(),
+					ServerName: "www.example.com",
 				},
 			},
 		},


### PR DESCRIPTION
## What this fixes

Addresses CodeQL High alerts #36 and #37 (`go/disabled-certificate-check`) in the conformance test round tripper. TLS clients now verify the gateway certificate against the CA supplied by each test instead of setting `InsecureSkipVerify`.

The ConfigMap HTTPS test replaces its expired fixture certificates at runtime with short-lived test certificates and trusts their generated CAs. The HTTPS-without-SNI test likewise supplies the CA it already generates.

## Validation

- `go test ./test/e2e/conformance/utils/roundtripper`
- Verified there are no remaining `InsecureSkipVerify` uses in the conformance round tripper
- Full conformance coverage is delegated to the repository CI because the local generated `external/istio` workspace requires Go 1.26 while the repository toolchain is Go 1.24.4

This PR fixes certificate authentication directly and does not suppress or dismiss either alert.