### PR TITLE
test: add continuous annotation fuzzing

### DIFF
--- a/.github/workflows/dynamic-analysis.yaml
+++ b/.github/workflows/dynamic-analysis.yaml
@@ -10,6 +10,7 @@ on:
       - "**/*.go"
       - "go.mod"
       - "go.sum"
+      - "Makefile.core.mk"
       - ".github/workflows/dynamic-analysis.yaml"
   schedule:
     - cron: "17 3 * * 1"

--- a/.github/workflows/dynamic-analysis.yaml
+++ b/.github/workflows/dynamic-analysis.yaml
@@ -1,0 +1,54 @@
+name: "Dynamic Analysis"
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    branches: ["*"]
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/dynamic-analysis.yaml"
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch: ~
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dynamic-analysis-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: 1.24
+  FUZZ_TIME: ${{ github.event_name == 'schedule' && '5m' || '30s' }}
+
+jobs:
+  fuzz:
+    name: fuzz ingress annotations
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run dynamic analysis
+        run: >-
+          GOPROXY="https://proxy.golang.org,direct"
+          make dynamic-analysis
+          FUZZ_TIME="${FUZZ_TIME}"
+
+      - name: Upload failing fuzz inputs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-failures
+          path: pkg/ingress/kube/annotations/testdata/fuzz/
+          if-no-files-found: ignore

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -90,6 +90,12 @@ default: build
 go.test.coverage: prebuild
 	go test ./cmd/... ./pkg/... -race -coverprofile=coverage.xml -covermode=atomic
 
+FUZZ_TIME ?= 30s
+.PHONY: dynamic-analysis
+dynamic-analysis: prebuild
+	go test ./pkg/ingress/kube/annotations -run=^$$ -fuzz=^FuzzRewriteAnnotation$$ -fuzztime=$(FUZZ_TIME)
+	go test ./pkg/ingress/kube/annotations -run=^$$ -fuzz=^FuzzHeaderControlAnnotation$$ -fuzztime=$(FUZZ_TIME)
+
 .PHONY: build
 build: prebuild $(OUT)
 	GOPROXY="$(GOPROXY)" GOOS=$(GOOS_LOCAL) GOARCH=$(GOARCH_LOCAL) LDFLAGS=$(RELEASE_LDFLAGS) tools/hack/gobuild.sh $(OUT)/ $(HIGRESS_BINARIES)

--- a/pkg/ingress/kube/annotations/annotations_fuzz_test.go
+++ b/pkg/ingress/kube/annotations/annotations_fuzz_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotations
+
+import (
+	"testing"
+
+	networking "istio.io/api/networking/v1alpha3"
+)
+
+func FuzzRewriteAnnotation(f *testing.F) {
+	f.Add("/$1", "/api", uint8(0))
+	f.Add(`/${2}/$1`, `/users/(.*)`, uint8(2))
+	f.Add("", "/", uint8(1))
+
+	f.Fuzz(func(t *testing.T, target, path string, matchKind uint8) {
+		if len(target) > 4096 || len(path) > 4096 {
+			t.Skip()
+		}
+
+		config := &Ingress{}
+		input := Annotations{
+			buildNginxAnnotationKey(rewriteTarget): target,
+			buildNginxAnnotationKey(useRegex):      "true",
+		}
+		if err := (rewrite{}).Parse(input, config, nil); err != nil {
+			t.Fatalf("parse rewrite annotation: %v", err)
+		}
+
+		match := &networking.StringMatch{}
+		switch matchKind % 3 {
+		case 0:
+			match.MatchType = &networking.StringMatch_Exact{Exact: path}
+		case 1:
+			match.MatchType = &networking.StringMatch_Prefix{Prefix: path}
+		default:
+			match.MatchType = &networking.StringMatch_Regex{Regex: path}
+		}
+		route := &networking.HTTPRoute{
+			Match: []*networking.HTTPMatchRequest{{Uri: match}},
+		}
+		(rewrite{}).ApplyRoute(route, config)
+
+		converted := convertToRE2(target)
+		if convertToRE2(converted) != converted {
+			t.Fatalf("rewrite conversion is not idempotent: %q", target)
+		}
+	})
+}
+
+func FuzzHeaderControlAnnotation(f *testing.F) {
+	f.Add("x-request-id request-id")
+	f.Add("\"x quoted\" 'value with spaces'")
+	f.Add("x-first one\nx-second two")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, value string) {
+		if len(value) > 8192 {
+			t.Skip()
+		}
+
+		config := &Ingress{}
+		input := Annotations{
+			buildHigressAnnotationKey(requestHeaderAdd):     value,
+			buildHigressAnnotationKey(responseHeaderUpdate): value,
+		}
+		if err := (headerControl{}).Parse(input, config, nil); err != nil {
+			t.Fatalf("parse header-control annotation: %v", err)
+		}
+
+		route := &networking.HTTPRoute{}
+		(headerControl{}).ApplyRoute(route, config)
+	})
+}


### PR DESCRIPTION
## What this changes

- adds Go-native fuzz targets for ingress rewrite and header-control annotation parsing and translation
- adds make dynamic-analysis as the documented local/CI entry point
- runs fuzzing for every Go pull request, main update, release tag, weekly schedule, and manual dispatch
- retains failing fuzz inputs as CI artifacts

PR and main runs use 30 seconds per target; the weekly run uses 5 minutes per target. This continuously varies untrusted annotation inputs and establishes repository-level dynamic analysis evidence for the OpenSSF Best Practices dynamic_analysis criterion.

## Verification

- go test ./pkg/ingress/kube/annotations
- 10-second FuzzRewriteAnnotation run: 47,670 executions, pass
- 10-second FuzzHeaderControlAnnotation run: 59,450 executions, pass
- make dynamic-analysis FUZZ_TIME=1s
- workflow YAML parse
- git diff --check