### PR TITLE
fix(ai-proxy): map adaptive effort to sibling output_config in Bedrock

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock.go
@@ -963,10 +963,14 @@ func (b *bedrockProvider) buildBedrockTextGenerationRequest(origRequest *chatCom
 
 	thinking := bedrockThinkingFromClaudeConfig(origRequest.ClaudeThinking)
 	if thinking != nil {
-		if origRequest.ClaudeThinking.Type == "adaptive" && origRequest.ClaudeOutputConfig != nil && bedrockSupportsAdaptiveEffort(origRequest.ClaudeOutputConfig.Effort) {
-			thinking["effort"] = origRequest.ClaudeOutputConfig.Effort
-		}
 		request.AdditionalModelRequestFields["thinking"] = thinking
+		if origRequest.ClaudeThinking.Type == "adaptive" && origRequest.ClaudeOutputConfig != nil && bedrockSupportsAdaptiveEffort(origRequest.ClaudeOutputConfig.Effort) {
+			// Bedrock expects `thinking` and `output_config` to be sibling fields
+			// in additionalModelRequestFields, not `effort` nested inside `thinking`.
+			request.AdditionalModelRequestFields["output_config"] = map[string]interface{}{
+				"effort": origRequest.ClaudeOutputConfig.Effort,
+			}
+		}
 	} else if origRequest.ReasoningEffort != "" {
 		thinkingBudget := 1024 // default
 		switch origRequest.ReasoningEffort {

--- a/plugins/wasm-go/extensions/ai-proxy/provider/bedrock_thinking_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/bedrock_thinking_test.go
@@ -389,7 +389,7 @@ func TestBedrockRequestPreservesClaudeNativeThinkingBudget(t *testing.T) {
 	assert.Equal(t, float64(8192), request.AdditionalModelRequestFields["thinking"].(map[string]interface{})["budget_tokens"])
 }
 
-func TestBedrockRequestMapsAdaptiveOutputEffortIntoThinking(t *testing.T) {
+func TestBedrockRequestMapsAdaptiveOutputEffortToSiblingOutputConfig(t *testing.T) {
 	provider := &bedrockProvider{}
 	openaiBody, err := (&ClaudeToOpenAIConverter{}).ConvertClaudeRequestToOpenAI([]byte(`{
 		"model":"claude",
@@ -408,8 +408,11 @@ func TestBedrockRequestMapsAdaptiveOutputEffortIntoThinking(t *testing.T) {
 	require.NoError(t, json.Unmarshal(body, &request))
 	thinking := request.AdditionalModelRequestFields["thinking"].(map[string]interface{})
 	assert.Equal(t, "adaptive", thinking["type"])
-	assert.Equal(t, "high", thinking["effort"])
-	assert.NotContains(t, request.AdditionalModelRequestFields, "output_config")
+	// effort must NOT be nested inside thinking
+	assert.NotContains(t, thinking, "effort")
+	// effort must be a sibling output_config field
+	outputConfig := request.AdditionalModelRequestFields["output_config"].(map[string]interface{})
+	assert.Equal(t, "high", outputConfig["effort"])
 	assert.NotContains(t, request.AdditionalModelRequestFields, "anthropic_beta")
 }
 


### PR DESCRIPTION
## Ⅰ. Describe what this PR does

Fixes #4170

When `ai-proxy` converts a Claude request with adaptive thinking and an output effort level to an Amazon Bedrock Converse request, it placed `effort` inside the `thinking` object. Bedrock expects `thinking` and `output_config` to be **sibling** fields in `additionalModelRequestFields`.

## Ⅱ. Behavior

For a request containing:
```json
{ "thinking": { "type": "adaptive" }, "output_config": { "effort": "high" } }
```

**Before:**
```json
{ "thinking": { "type": "adaptive", "effort": "high" } }
```
(output_config lost, effort at wrong nesting level)

**After:**
```json
{ "thinking": { "type": "adaptive" }, "output_config": { "effort": "high" } }
```

## Ⅲ. Changes

- `provider/bedrock.go` — set `output_config.effort` as a sibling of `thinking` in `additionalModelRequestFields` instead of nesting `effort` inside `thinking`.
- `provider/bedrock_thinking_test.go` — updated the adaptive-effort test to assert the sibling structure (renamed `...IntoThinking` → `...ToSiblingOutputConfig`).

## Ⅳ. Scope

Supported effort values remain `low`/`medium`/`high`; unsupported values are still omitted. Manual extended thinking (`budget_tokens`) and requests without adaptive thinking are unaffected — covered by the existing `TestBedrockRequestDropsOutputEffortWithoutAdaptiveThinking` and `TestBedrockRequestDropsUnsupportedAdaptiveOutputEffort` tests which continue to pass.
