### PR TITLE
fix(ai-statistics): collect Responses API token metrics

### DIFF
--- a/plugins/wasm-go/extensions/ai-statistics/.gitignore
+++ b/plugins/wasm-go/extensions/ai-statistics/.gitignore
@@ -1,2 +1,4 @@
 main.wasm
 config.yaml
+wasm-unit-test.wasm
+plugin.wasm

--- a/plugins/wasm-go/extensions/ai-statistics/README.md
+++ b/plugins/wasm-go/extensions/ai-statistics/README.md
@@ -29,7 +29,7 @@ description: AI可观测配置参考
 | `attributes` | []Attribute | 非必填  | -   | 用户希望记录在log/span中的信息 |
 | `disable_openai_usage` | bool | 非必填  | false   | 非openai兼容协议时，model、token的支持非标，配置为true时可以避免报错 |
 | `value_length_limit` | int | 非必填  | 4000   | 记录的单个value的长度限制 |
-| `enable_path_suffixes` | []string    | 非必填   | []     | 只对这些特定路径后缀的请求生效，可以配置为 "\*" 以匹配所有路径（通配符检查会优先进行以提高性能）。如果为空数组，则对所有路径生效 |
+| `enable_path_suffixes` | []string    | 非必填   | []（未开启默认属性时对所有路径生效）；开启 `use_default_attributes` / `use_default_response_attributes` 且未显式配置时默认为 `["/completions", "/messages", "/responses"]` | 只对这些特定路径后缀的请求生效，可以配置为 "\*" 以匹配所有路径（通配符检查会优先进行以提高性能）。如果为空数组，则对所有路径生效。默认列表通过后缀匹配覆盖 `/v1/chat/completions`、`/v1/messages`、`/v1/responses` 等 |
 | `enable_content_types` | []string    | 非必填   | []     | 只对这些内容类型的响应进行缓冲处理。如果为空数组，则对所有内容类型生效                                                           |
 | `session_id_header` | string | 非必填  | -   | 指定读取 session ID 的 header 名称。如果不配置，将按以下优先级自动查找：`x-openclaw-session-key`、`x-clawdbot-session-key`、`x-moltbot-session-key`、`x-agent-session`。session ID 可用于追踪多轮 Agent 对话 |
 
@@ -406,6 +406,8 @@ data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\
 use_default_response_attributes: true
 ```
 
+开启该模式且未配置 `enable_path_suffixes` 时，插件默认只处理路径后缀为 `/completions`、`/messages`、`/responses` 的请求（覆盖 Chat Completions、Anthropic Messages、OpenAI Responses）。如需统计其他路径，请显式配置 `enable_path_suffixes`（或设为 `"*"`）。
+
 此配置是**推荐的生产环境配置**，特别适合高并发、高延迟的场景：
 
 | 字段 | 说明 |
@@ -447,6 +449,8 @@ LLM 请求有两个显著特点：**延迟高**（通常数秒到数十秒）和
 ```yaml
 use_default_attributes: true
 ```
+
+完整模式与轻量模式使用相同的默认路径后缀规则：未配置 `enable_path_suffixes` 时处理 `/completions`、`/messages`、`/responses`；显式配置空数组时处理所有路径。
 
 此配置会自动记录以下字段，**但会缓冲完整的请求体和流式响应体**：
 
@@ -581,8 +585,10 @@ print(result)
 
 ```yaml
 enable_path_suffixes:
-  - "/v1/chat/completions"
-  - "/v1/embeddings"
+  - "/completions"
+  - "/messages"
+  - "/responses"
+  - "/embeddings"
   - "/generateContent"
 ```
 

--- a/plugins/wasm-go/extensions/ai-statistics/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-statistics/README_EN.md
@@ -24,12 +24,16 @@ Users can also expand observable values ​​through configuration:
 
 | Name             | Type  | Required | Default | Description |
 |----------------|-------|------|-----|------------------------|
+| `use_default_attributes` | bool | optional | false | Enables the complete default attribute set, including messages, answer, and question. Intended for debugging and auditing scenarios. |
+| `use_default_response_attributes` | bool | optional | false | Enables the lightweight default attribute set containing model and token statistics without buffering streaming response bodies. Recommended for high-concurrency production environments. |
 | `attributes` | []Attribute | optional  | -   | Information that the user wants to record in log/span |
 | `disable_openai_usage` | bool | optional  | false   | When using a non-OpenAI-compatible protocol, the support for model and token is non-standard. Setting the configuration to true can prevent errors. |
 | `value_length_limit` | int | optional  | 4000   | length limit for each value |
-| `enable_path_suffixes`   | []string    | optional | ["/v1/chat/completions","/v1/completions","/v1/embeddings","/v1/models","/generateContent","/streamGenerateContent"] | Only effective for requests with these specific path suffixes, can be configured as "\*" to match all paths                                         |
+| `enable_path_suffixes`   | []string    | optional | `[]` (all paths when default attributes are off); when `use_default_attributes` / `use_default_response_attributes` is on and this field is omitted: `["/completions","/messages","/responses"]` | Only effective for requests with these path suffixes; `"*"` matches all paths. Empty list means all paths. Default suffixes cover Chat Completions, Anthropic Messages, and OpenAI Responses |
 | `enable_content_types` | []string    | optional | ["text/event-stream","application/json"]                                                                             | Only buffer response body for these content types                                                                                                   |
 | `session_id_header` | string | optional  | -   | Specify the header name to read session ID from. If not configured, it will automatically search in the following priority: `x-openclaw-session-key`, `x-clawdbot-session-key`, `x-moltbot-session-key`, `x-agent-session`. Session ID can be used to trace multi-turn Agent conversations |
+
+When either default-attribute mode is enabled and `enable_path_suffixes` is omitted, the plugin processes paths ending in `/completions`, `/messages`, and `/responses`. This covers Chat Completions, Anthropic Messages, and OpenAI Responses. Explicitly configure `enable_path_suffixes` (or use `"*"`) to process other paths. An explicitly configured empty list continues to process all paths.
 
 Attribute Configuration instructions:
 
@@ -353,8 +357,10 @@ The plugin automatically identifies each independent tool call by the `index` fi
 
 ```yaml
 enable_path_suffixes:
-  - "/v1/chat/completions"
-  - "/v1/embeddings"
+  - "/completions"
+  - "/messages"
+  - "/responses"
+  - "/embeddings"
   - "/generateContent"
 ```
 
@@ -377,8 +383,10 @@ enable_path_suffixes:
 
 ```yaml
 enable_path_suffixes:
-  - "/v1/chat/completions"
-  - "/v1/embeddings"
+  - "/completions"
+  - "/messages"
+  - "/responses"
+  - "/embeddings"
   - "/generateContent"
 enable_content_types:
   - "text/event-stream"

--- a/plugins/wasm-go/extensions/ai-statistics/main.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main.go
@@ -149,6 +149,12 @@ const (
 	CtxStreamingToolCallsBuffer = "streamingToolCallsBuffer"
 )
 
+var defaultEnabledPathSuffixes = []string{
+	"/completions",
+	"/messages",
+	"/responses",
+}
+
 // getDefaultAttributes returns the default attributes configuration for empty config
 // This includes all attributes but may consume significant memory for large conversations
 func getDefaultAttributes() []Attribute {
@@ -625,10 +631,11 @@ func parseConfig(configJson gjson.Result, config *AIStatisticsConfig) error {
 	pathSuffixes := configJson.Get("enable_path_suffixes").Array()
 	config.enablePathSuffixes = make([]string, 0, len(pathSuffixes))
 
-	// If use_default_attributes or use_default_response_attributes is enabled and enable_path_suffixes is not configured, use default path suffixes
+	// Preserve the all-paths behavior for an explicit empty list. Apply the
+	// constrained defaults only when the field is omitted in default-attribute modes.
 	if (useDefaultAttributes || useDefaultResponseAttributes) && !configJson.Get("enable_path_suffixes").Exists() {
-		config.enablePathSuffixes = []string{"/completions", "/messages"}
-		log.Infof("Using default path suffixes: /completions, /messages")
+		config.enablePathSuffixes = append([]string(nil), defaultEnabledPathSuffixes...)
+		log.Infof("Using default path suffixes: %s", strings.Join(defaultEnabledPathSuffixes, ", "))
 	} else {
 		// Process manually configured path suffixes
 		for _, suffix := range pathSuffixes {
@@ -1357,10 +1364,10 @@ func setSpanAttribute(key string, value interface{}) {
 
 // isErrorResponse checks whether the LLM response indicates an error.
 // Detects errors by:
-// 1. Response body contains non-null "error" field at root level (OpenAI/Anthropic format).
-//    Handles both raw JSON and SSE "data: " prefixed chunks, including multi-event
-//    streaming buffers.
-// 2. HTTP status code >= 400 as fallback when body is empty.
+//  1. Response body contains non-null "error" field at root level (OpenAI/Anthropic format).
+//     Handles both raw JSON and SSE "data: " prefixed chunks, including multi-event
+//     streaming buffers.
+//  2. HTTP status code >= 400 as fallback when body is empty.
 //
 // Note: some providers (e.g. Anthropic streaming responses) emit {"error":""}
 // even on success; an empty-string error is treated as not-an-error to avoid

--- a/plugins/wasm-go/extensions/ai-statistics/main_test.go
+++ b/plugins/wasm-go/extensions/ai-statistics/main_test.go
@@ -896,6 +896,103 @@ func TestMetrics(t *testing.T) {
 	})
 }
 
+func TestResponsesMetricsWithDefaultPathSuffixes(t *testing.T) {
+	defaultResponseAttributesConfig := []byte(`{
+		"use_default_response_attributes": true
+	}`)
+
+	test.RunTest(t, func(t *testing.T) {
+		t.Run("records non-streaming Responses API token metrics", func(t *testing.T) {
+			host, status := test.NewTestHost(defaultResponseAttributesConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.SetRouteName("responses-route")
+			host.SetClusterName("responses-cluster")
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/responses"},
+				{":method", "POST"},
+				{"x-mse-consumer", "responses-user"},
+			}))
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{
+				"model": "gpt-4o"
+			}`)))
+			require.Equal(t, types.ActionContinue, host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"content-type", "application/json"},
+			}))
+			require.Equal(t, types.ActionContinue, host.CallOnHttpResponseBody([]byte(`{
+				"model": "gpt-4o",
+				"usage": {
+					"input_tokens": 10,
+					"output_tokens": 20,
+					"total_tokens": 30
+				}
+			}`)))
+			host.CompleteHttp()
+
+			metricPrefix := "route.responses-route.upstream.responses-cluster.model.gpt-4o.consumer.responses-user.metric."
+			inputTokenValue, err := host.GetCounterMetric(metricPrefix + "input_token")
+			require.NoError(t, err)
+			require.Equal(t, uint64(10), inputTokenValue)
+			outputTokenValue, err := host.GetCounterMetric(metricPrefix + "output_token")
+			require.NoError(t, err)
+			require.Equal(t, uint64(20), outputTokenValue)
+			totalTokenValue, err := host.GetCounterMetric(metricPrefix + "total_token")
+			require.NoError(t, err)
+			require.Equal(t, uint64(30), totalTokenValue)
+		})
+
+		t.Run("records streaming Responses API token metrics", func(t *testing.T) {
+			host, status := test.NewTestHost(defaultResponseAttributesConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			host.SetRouteName("responses-stream-route")
+			host.SetClusterName("responses-stream-cluster")
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestHeaders([][2]string{
+				{":authority", "example.com"},
+				{":path", "/v1/responses"},
+				{":method", "POST"},
+				{"x-mse-consumer", "responses-stream-user"},
+			}))
+			require.Equal(t, types.ActionContinue, host.CallOnHttpRequestBody([]byte(`{
+				"model": "gpt-4o"
+			}`)))
+			require.Equal(t, types.ActionContinue, host.CallOnHttpResponseHeaders([][2]string{
+				{":status", "200"},
+				{"content-type", "text/event-stream"},
+			}))
+
+			completedEvent := []byte(`data: {
+				"type": "response.completed",
+				"response": {
+					"model": "gpt-4o",
+					"usage": {
+						"input_tokens": 11,
+						"output_tokens": 21,
+						"total_tokens": 32
+					}
+				}
+			}`)
+			require.Equal(t, types.ActionContinue, host.CallOnHttpStreamingResponseBody(completedEvent, true))
+			host.CompleteHttp()
+
+			metricPrefix := "route.responses-stream-route.upstream.responses-stream-cluster.model.gpt-4o.consumer.responses-stream-user.metric."
+			inputTokenValue, err := host.GetCounterMetric(metricPrefix + "input_token")
+			require.NoError(t, err)
+			require.Equal(t, uint64(11), inputTokenValue)
+			outputTokenValue, err := host.GetCounterMetric(metricPrefix + "output_token")
+			require.NoError(t, err)
+			require.Equal(t, uint64(21), outputTokenValue)
+			totalTokenValue, err := host.GetCounterMetric(metricPrefix + "total_token")
+			require.NoError(t, err)
+			require.Equal(t, uint64(32), totalTokenValue)
+		})
+	})
+}
+
 func TestCompleteFlow(t *testing.T) {
 	test.RunTest(t, func(t *testing.T) {
 		// 测试完整的统计流程
@@ -2146,8 +2243,20 @@ func TestExtractClaudeStreamingToolCalls(t *testing.T) {
 	})
 }
 
+// TestConfigWithDefaultAttributes uses RunGoTest because GetMatchConfig is only
+// available on the Go host path (same pattern as main_extra_test.go path-suffix tests).
 func TestConfigWithDefaultAttributes(t *testing.T) {
-	test.RunTest(t, func(t *testing.T) {
+	test.RunGoTest(t, func(t *testing.T) {
+		assertDefaultPathSuffixes := func(t *testing.T, conf *AIStatisticsConfig) {
+			t.Helper()
+			require.Equal(t, defaultEnabledPathSuffixes, conf.enablePathSuffixes)
+			// Suffix match: chat completions and Responses API must be enabled (#4183).
+			require.True(t, isPathEnabled("/v1/chat/completions", conf.enablePathSuffixes))
+			require.True(t, isPathEnabled("/v1/messages", conf.enablePathSuffixes))
+			require.True(t, isPathEnabled("/v1/responses", conf.enablePathSuffixes))
+			require.False(t, isPathEnabled("/v1/embeddings", conf.enablePathSuffixes))
+		}
+
 		t.Run("use default attributes config", func(t *testing.T) {
 			defaultConfig := []byte(`{
 				"use_default_attributes": true
@@ -2155,6 +2264,10 @@ func TestConfigWithDefaultAttributes(t *testing.T) {
 			host, status := test.NewTestHost(defaultConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			rawConf, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			assertDefaultPathSuffixes(t, rawConf.(*AIStatisticsConfig))
 		})
 
 		t.Run("use default response attributes config", func(t *testing.T) {
@@ -2164,8 +2277,54 @@ func TestConfigWithDefaultAttributes(t *testing.T) {
 			host, status := test.NewTestHost(defaultRespConfig)
 			defer host.Reset()
 			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			rawConf, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			assertDefaultPathSuffixes(t, rawConf.(*AIStatisticsConfig))
+		})
+
+		t.Run("explicit enable_path_suffixes overrides default list", func(t *testing.T) {
+			customConfig := []byte(`{
+				"use_default_response_attributes": true,
+				"enable_path_suffixes": ["/completions"]
+			}`)
+			host, status := test.NewTestHost(customConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			rawConf, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			conf := rawConf.(*AIStatisticsConfig)
+			require.Equal(t, []string{"/completions"}, conf.enablePathSuffixes)
+			require.True(t, isPathEnabled("/v1/chat/completions", conf.enablePathSuffixes))
+			require.False(t, isPathEnabled("/v1/responses", conf.enablePathSuffixes))
+		})
+
+		t.Run("explicit empty enable_path_suffixes enables all paths", func(t *testing.T) {
+			customConfig := []byte(`{
+				"use_default_response_attributes": true,
+				"enable_path_suffixes": []
+			}`)
+			host, status := test.NewTestHost(customConfig)
+			defer host.Reset()
+			require.Equal(t, types.OnPluginStartStatusOK, status)
+
+			rawConf, err := host.GetMatchConfig()
+			require.NoError(t, err)
+			conf := rawConf.(*AIStatisticsConfig)
+			require.Empty(t, conf.enablePathSuffixes)
+			require.True(t, isPathEnabled("/v1/embeddings", conf.enablePathSuffixes))
 		})
 	})
+}
+
+// TestIsPathEnabled_ResponsesSuffix pins the path gate used by onHttpRequestHeaders.
+// Without /responses in the default suffix list, Responses token metrics are skipped.
+func TestIsPathEnabled_ResponsesSuffix(t *testing.T) {
+	defaultSuffixes := defaultEnabledPathSuffixes
+	require.True(t, isPathEnabled("/v1/responses", defaultSuffixes))
+	require.True(t, isPathEnabled("/openai/v1/responses?api-version=2024-01-01", defaultSuffixes))
+	require.False(t, isPathEnabled("/v1/responses", []string{"/completions", "/messages"}))
 }
 
 func TestIsErrorResponse(t *testing.T) {


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

- Add `/responses` to the default `ai-statistics` path suffixes used by `use_default_attributes` and `use_default_response_attributes`.
- Preserve existing override semantics: an omitted field uses the constrained defaults, while an explicit empty list or `*` enables all paths.
- Add non-streaming and streaming OpenAI Responses API regression tests that assert input, output, and total token counters.
- Update the Chinese and English plugin documentation to describe the effective defaults and include `/responses` in copyable examples.
- Ignore local Wasm test/build artifacts generated while running plugin tests.

## Ⅱ. Does this pull request fix one issue?

fixes #4183

## Ⅲ. Why don't you add test cases (unit test/integration test)?

N/A. This PR adds focused unit/integration-style plugin host tests for both non-streaming and streaming Responses API token metrics, plus configuration-semantic coverage for explicit overrides.

## Ⅳ. Describe how to verify it

From `plugins/wasm-go/extensions/ai-statistics`:

```bash
go test ./... -count=1
```

Expected result:

```text
ok  ai-statistics
```

The added tests send requests to `/v1/responses` with `use_default_response_attributes: true` and verify the generated `input_token`, `output_token`, and `total_token` counters.

## Ⅴ. Special notes for reviews

- `tokenusage` already supports both Responses usage shapes (`usage.*` for non-streaming and `response.usage.*` for streaming). The bug was the default path gate skipping `/v1/responses` before token parsing.
- The `isErrorResponse` doc-comment indentation change is gofmt doc-comment normalization included while formatting the modified Go files; it is unrelated to the functional fix.
- `README_EN.md` adds the previously missing `use_default_attributes` and `use_default_response_attributes` rows because the updated `enable_path_suffixes` default depends on these options. This is an adjacent documentation-completeness improvement, not a new behavior change.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

- Investigate issue #4183 and verify why Responses API token metrics are missing from `/stats/prometheus`.
- Implement the fix according to project conventions, add regression tests, and update Chinese/English documentation.
- Review the generated changes with correctness and architecture hygiene as review dimensions, then address actionable findings.
- Note the gofmt doc-comment normalization and the adjacent English documentation additions in the PR description.

### AI Coding Summary

- **Key decisions:** Fixed the path gate rather than duplicating token parsing because the shared `tokenusage` package already handles Responses payloads. Kept explicit user overrides backward-compatible and consolidated the default suffixes into one list.
- **Major changes:** Added `/responses` to default suffixes; added non-streaming/streaming metric regression tests and explicit-empty-list coverage; synchronized CN/EN configuration documentation and examples.
- **Important considerations:** Explicit custom suffix lists still control behavior and must include `/responses` if Responses metrics are desired. The PR does not change token extraction formats or metric names.