### PR TITLE
fix(ai-proxy): merge system messages in Claude->OpenAI conversion

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
@@ -275,6 +275,14 @@ func (c *ClaudeToOpenAIConverter) ConvertClaudeRequestToOpenAIWithOptions(body [
 		openaiRequest.Messages = append([]chatMessage{systemMsg}, openaiRequest.Messages...)
 	}
 
+	// Some clients (e.g. Claude Code) embed an extra system-role message inside the
+	// messages array in addition to Claude's top-level system field. After conversion
+	// this leaves more than one system message, and any system message that is not the
+	// first one makes strict OpenAI-compatible backends (such as vLLM) reject the request
+	// with "System message must be at the beginning.". Merge every system message into a
+	// single leading one so the output always has at most one system message at index 0.
+	openaiRequest.Messages = mergeSystemMessages(openaiRequest.Messages)
+
 	// Convert tools if present
 	for _, claudeTool := range claudeRequest.Tools {
 		openaiTool := tool{
@@ -351,6 +359,60 @@ func (c *ClaudeToOpenAIConverter) ConvertClaudeRequestToOpenAIWithOptions(body [
 
 	log.Debugf("[Claude->OpenAI] Converted OpenAI request body: %s", string(result))
 	return result, nil
+}
+
+// mergeSystemMessages collapses every system-role message into a single leading
+// system message. Strict OpenAI-compatible backends (e.g. vLLM) reject a request
+// when a system message appears anywhere other than the first position. This can
+// happen when the client embeds a system-role message inside the messages array
+// on top of Claude's top-level system field.
+//
+// - No system message: the messages are returned unchanged.
+// - Exactly one system message: its content is preserved as-is and it is moved to
+//   the front (a no-op when it already leads).
+// - Multiple system messages: their contents are concatenated into a single block
+//   array and emitted as one leading system message.
+func mergeSystemMessages(messages []chatMessage) []chatMessage {
+	var systemMessages []chatMessage
+	others := make([]chatMessage, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Role == roleSystem {
+			systemMessages = append(systemMessages, msg)
+		} else {
+			others = append(others, msg)
+		}
+	}
+
+	switch len(systemMessages) {
+	case 0:
+		return messages
+	case 1:
+		return append([]chatMessage{systemMessages[0]}, others...)
+	default:
+		var mergedContent []chatMessageContent
+		for _, msg := range systemMessages {
+			mergedContent = append(mergedContent, systemContentBlocks(msg.Content)...)
+		}
+		merged := chatMessage{Role: roleSystem, Content: mergedContent}
+		return append([]chatMessage{merged}, others...)
+	}
+}
+
+// systemContentBlocks normalizes a system message's content into a list of content
+// blocks so multiple system messages can be concatenated. String content becomes a
+// single text block; an existing block array (preserving any cache_control) is kept.
+func systemContentBlocks(content any) []chatMessageContent {
+	switch v := content.(type) {
+	case string:
+		if v == "" {
+			return nil
+		}
+		return []chatMessageContent{{Type: contentTypeText, Text: v}}
+	case []chatMessageContent:
+		return v
+	default:
+		return nil
+	}
 }
 
 // computeClaudeInputTokens computes Claude-compatible input_tokens from OpenAI usage.

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
@@ -95,6 +95,76 @@ func TestClaudeToOpenAIConverter_ConvertClaudeRequestToOpenAI(t *testing.T) {
 		require.Contains(t, string(result), `"parallel_tool_calls":false`)
 	})
 
+	t.Run("merge_top_level_system_with_inline_system_message", func(t *testing.T) {
+		// Regression test for gpustack/gpustack#5934: Claude Code sends a system-role
+		// message inside the messages array on top of the top-level system field. The
+		// naive conversion produced [system, user, system], and strict OpenAI backends
+		// (e.g. vLLM) reject it with "System message must be at the beginning.".
+		// The converter must merge both system messages into a single leading one.
+		claudeRequest := `{
+			"model": "qwen3.6-35b-a3b",
+			"max_tokens": 1000,
+			"system": "You are Claude Code.",
+			"messages": [
+				{"role": "user", "content": "hello"},
+				{"role": "system", "content": "Available agent types for the Agent tool: ..."}
+			]
+		}`
+
+		result, err := converter.ConvertClaudeRequestToOpenAI([]byte(claudeRequest))
+		require.NoError(t, err)
+
+		var openaiRequest chatCompletionRequest
+		err = json.Unmarshal(result, &openaiRequest)
+		require.NoError(t, err)
+
+		// Exactly one system message, and it must be the first message.
+		require.Len(t, openaiRequest.Messages, 2)
+		assert.Equal(t, roleSystem, openaiRequest.Messages[0].Role)
+		assert.Equal(t, "user", openaiRequest.Messages[1].Role)
+		for i, msg := range openaiRequest.Messages {
+			if i != 0 {
+				assert.NotEqual(t, roleSystem, msg.Role, "no system message allowed after index 0")
+			}
+		}
+
+		// Merged system content should contain both the top-level and inline system text,
+		// in order, as a content-block array.
+		systemContentArray, ok := openaiRequest.Messages[0].Content.([]interface{})
+		require.True(t, ok, "merged system content should be a block array")
+		require.Len(t, systemContentArray, 2)
+		firstBlock := systemContentArray[0].(map[string]interface{})
+		secondBlock := systemContentArray[1].(map[string]interface{})
+		assert.Equal(t, "You are Claude Code.", firstBlock["text"])
+		assert.Equal(t, "Available agent types for the Agent tool: ...", secondBlock["text"])
+	})
+
+	t.Run("move_inline_system_message_to_front_without_top_level_system", func(t *testing.T) {
+		// A system-role message inside messages with no top-level system field must
+		// still be relocated to the beginning so the request is accepted.
+		claudeRequest := `{
+			"model": "qwen3.6-35b-a3b",
+			"max_tokens": 1000,
+			"messages": [
+				{"role": "user", "content": "hello"},
+				{"role": "system", "content": "You are a helpful assistant."}
+			]
+		}`
+
+		result, err := converter.ConvertClaudeRequestToOpenAI([]byte(claudeRequest))
+		require.NoError(t, err)
+
+		var openaiRequest chatCompletionRequest
+		err = json.Unmarshal(result, &openaiRequest)
+		require.NoError(t, err)
+
+		require.Len(t, openaiRequest.Messages, 2)
+		assert.Equal(t, roleSystem, openaiRequest.Messages[0].Role)
+		// Single system message keeps its original (string) content untouched.
+		assert.Equal(t, "You are a helpful assistant.", openaiRequest.Messages[0].Content)
+		assert.Equal(t, "user", openaiRequest.Messages[1].Role)
+	})
+
 	t.Run("convert_multiple_text_content_blocks", func(t *testing.T) {
 		// Test case: multiple text content blocks should remain as separate array elements with cache control support
 		// Both system and user messages should handle array content format


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Fix the Claude→OpenAI protocol conversion in `ai-proxy` so it never emits more than one `system` message.

Previously, [`claude_to_openai.go` L264-276](https://github.com/higress-group/higress/blob/main/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go#L264-L276) only **prepended** Claude's top-level `system` field to the message list and passed any `role: system` message already inside `messages` (as Claude Code sends) through verbatim. The result could be `[system, user, system]`, i.e. a `system` message not at index 0. Strict OpenAI-compatible backends (e.g. vLLM) reject this with:

```
API Error: 400 System message must be at the beginning.
```

This PR adds a `mergeSystemMessages` step after conversion that collapses the top-level `system` and every `role: system` message into a **single leading** `system` message:

- **0 system messages** → messages unchanged.
- **1 system message** → content preserved as-is, moved to the front (no-op when already leading).
- **≥2 system messages** → contents concatenated into one block array (preserving `cache_control`) as a single leading system message.

Non-system messages keep their original order.

## Ⅱ. Does this pull request fix one issue?

fixes #4214


## Ⅲ. Why don't you add test cases (unit test/integration test)?

Test cases are added in `claude_to_openai_test.go`:

- `merge_top_level_system_with_inline_system_message` — top-level `system` + an inline `role: system` message → asserts exactly one leading `system`, no `system` after index 0, and that the merged content contains both parts in order.
- `move_inline_system_message_to_front_without_top_level_system` — an inline `role: system` with no top-level `system` → asserts it is relocated to the front with its content untouched.

## Ⅳ. Describe how to verify it

```bash
cd plugins/wasm-go/extensions/ai-proxy
go test ./provider/ -run TestClaudeToOpenAIConverter_ConvertClaudeRequestToOpenAI -v
```

End-to-end: send a request through `ai-proxy` (Claude/Anthropic protocol in, OpenAI backend out) with both a top-level `system` field and a `role: system` message inside `messages`. Before this change the strict backend returns `400 System message must be at the beginning.`; after it, the request is accepted.

**Input (Claude / Anthropic):**

```json
{
  "system": "You are Claude Code.",
  "messages": [
    { "role": "user", "content": "hello" },
    { "role": "system", "content": "Available agent types for the Agent tool: ..." }
  ]
}
```

**Output before the fix — roles `[system, user, system]` (rejected):**

```json
{
  "messages": [
    { "role": "system", "content": "You are Claude Code." },
    { "role": "user", "content": "hello" },
    { "role": "system", "content": "Available agent types for the Agent tool: ..." }
  ]
}
```

**Output after the fix — roles `[system, user]` (accepted):**

```json
{
  "messages": [
    { "role": "system", "content": [
      { "type": "text", "text": "You are Claude Code." },
      { "type": "text", "text": "Available agent types for the Agent tool: ..." }
    ] },
    { "role": "user", "content": "hello" }
  ]
}
```

## Ⅴ. Special notes for reviews

- The direct vLLM endpoint works today because it hits vLLM's native Anthropic route `/v1/messages` and never goes through this conversion; the bug only surfaces on the OpenAI Chat Completions path.
- Single-system requests are intentionally left byte-for-byte unchanged (string content stays a string) to avoid altering existing behavior; merging into a block array only happens when 2+ system messages are present.
- Reproduced with: Claude Code `2.1.206` → Higress `ai-proxy` (commit `c8b82797c51a`) → upstream vLLM serving Qwen3.


## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Tool: Claude Code (Opus 4.8).

- "Analyze this ai-proxy debug log and extract the before/after JSON of the Claude→OpenAI conversion."
- "Confirm whether the current ai-proxy plugin handles this problem" (multiple system messages).
- "Write the fix and add a test case for this scenario."

### AI Coding Summary

- **Key decisions:** Fix at the conversion layer by merging all `system` messages into a single leading one, rather than restructuring the `chatMessageContent`/message model. Preserve existing single-system output verbatim to minimize behavioral change and keep `cache_control` when concatenating into a block array.
- **Major changes:** Added `mergeSystemMessages` + `systemContentBlocks` helpers in `claude_to_openai.go`, invoked right after the top-level system handling; added two regression sub-tests.
- **Considerations / limitations:** Relocating a non-leading inline `system` to the front is the only way to satisfy strict backends and slightly changes conversational position of that block; this matches the Claude Code usage that triggers the issue. Verified with `go test ./provider/` (all passing) and both host and `GOOS=wasip1 GOARCH=wasm` builds.
