### PR TITLE
fix(ai-proxy): detect Groq Responses API paths

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/groq.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/groq.go
@@ -73,5 +73,8 @@ func (g *groqProvider) GetApiName(path string) ApiName {
 	if strings.Contains(path, groqChatCompletionPath) {
 		return ApiNameChatCompletion
 	}
+	if strings.Contains(path, groqResponsesPath) {
+		return ApiNameResponses
+	}
 	return ""
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/groq_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/groq_test.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroqProviderGetApiName(t *testing.T) {
+	provider := &groqProvider{}
+
+	tests := []struct {
+		name string
+		path string
+		want ApiName
+	}{
+		{
+			name: "chat completions",
+			path: groqChatCompletionPath,
+			want: ApiNameChatCompletion,
+		},
+		{
+			name: "responses",
+			path: groqResponsesPath,
+			want: ApiNameResponses,
+		},
+		{
+			name: "responses with route prefix",
+			path: "/gateway" + groqResponsesPath,
+			want: ApiNameResponses,
+		},
+		{
+			name: "unknown",
+			path: "/openai/v1/unknown",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, provider.GetApiName(tt.path))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- recognize Groq's `/openai/v1/responses` endpoint in `GetApiName`
- add regression coverage for chat, Responses, prefixed Responses, and unknown paths

## Why

Groq advertises the Responses API in its default capabilities, but original-protocol requests are classified through the provider-specific `GetApiName` hook. That hook only recognized chat completions, so a request sent directly to Groq's Responses path was downgraded to an unknown API.

## Validation

- `go test ./provider`
- `GOPROXY=https://goproxy.cn,direct go test ./...`
- `git diff --check`
