### PR TITLE
fix(ai-proxy): detect Cohere rerank API paths

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/cohere.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/cohere.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/alibaba/higress/plugins/wasm-go/extensions/ai-proxy/util"
-	"github.com/higress-group/wasm-go/pkg/wrapper"
 	"github.com/higress-group/proxy-wasm-go-sdk/proxywasm/types"
+	"github.com/higress-group/wasm-go/pkg/wrapper"
 )
 
 const (
@@ -119,6 +119,9 @@ func (m *cohereProvider) TransformRequestBody(ctx wrapper.HttpContext, apiName A
 func (m *cohereProvider) GetApiName(path string) ApiName {
 	if strings.Contains(path, cohereChatCompletionPath) {
 		return ApiNameChatCompletion
+	}
+	if strings.Contains(path, cohereRerankPath) {
+		return ApiNameCohereV1Rerank
 	}
 	return ""
 }

--- a/plugins/wasm-go/extensions/ai-proxy/provider/cohere_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/cohere_test.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCohereProviderGetApiName(t *testing.T) {
+	provider := &cohereProvider{}
+
+	tests := []struct {
+		name string
+		path string
+		want ApiName
+	}{
+		{
+			name: "chat",
+			path: cohereChatCompletionPath,
+			want: ApiNameChatCompletion,
+		},
+		{
+			name: "rerank",
+			path: cohereRerankPath,
+			want: ApiNameCohereV1Rerank,
+		},
+		{
+			name: "rerank with route prefix",
+			path: "/gateway" + cohereRerankPath,
+			want: ApiNameCohereV1Rerank,
+		},
+		{
+			name: "unknown",
+			path: "/v1/unknown",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, provider.GetApiName(tt.path))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- recognize Cohere's `/v1/rerank` endpoint in `GetApiName`
- add regression coverage for chat, rerank, prefixed rerank, and unknown paths

## Why

Cohere exposes rerank in its default capability map. In original-protocol mode, however, the provider-specific `GetApiName` hook replaces the generic path classification and previously returned an empty API name for `/v1/rerank`. The request could therefore bypass the provider's supported rerank path handling.

## Validation

- `go test ./provider`
- `git diff --check`
