### PR TITLE
fix(ai-proxy): clamp Claude thinking budget

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -16,9 +16,10 @@ import (
 
 // claudeProvider is the provider for Claude service.
 const (
-	claudeDomain           = "api.anthropic.com"
-	claudeDefaultVersion   = "2023-06-01"
-	claudeDefaultMaxTokens = 4096
+	claudeDomain                  = "api.anthropic.com"
+	claudeDefaultVersion          = "2023-06-01"
+	claudeDefaultMaxTokens        = 4096
+	claudeMinThinkingBudgetTokens = 1024
 
 	// Claude Code mode constants
 	claudeCodeUserAgent    = "claude-cli/2.1.2 (external, cli)"
@@ -486,13 +487,17 @@ func (c *claudeProvider) buildClaudeTextGenRequest(origRequest *chatCompletionRe
 				budgetTokens = 8192 // Default to medium
 			}
 		}
-		// Ensure minimum budget_tokens requirement
-		if budgetTokens < 1024 {
-			budgetTokens = 1024
+		if budgetTokens < claudeMinThinkingBudgetTokens {
+			budgetTokens = claudeMinThinkingBudgetTokens
 		}
-		claudeRequest.Thinking = &claudeThinkingConfig{
-			Type:         "enabled",
-			BudgetTokens: budgetTokens,
+		if budgetTokens >= claudeRequest.MaxTokens {
+			budgetTokens = claudeRequest.MaxTokens - 1
+		}
+		if budgetTokens >= claudeMinThinkingBudgetTokens {
+			claudeRequest.Thinking = &claudeThinkingConfig{
+				Type:         "enabled",
+				BudgetTokens: budgetTokens,
+			}
 		}
 	}
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_test.go
@@ -226,6 +226,58 @@ func TestClaudeProvider_BuildClaudeTextGenRequest_StandardMode(t *testing.T) {
 		assert.Equal(t, "answer", blocks[2].Text)
 	})
 
+	t.Run("drops_generated_thinking_when_max_tokens_cannot_fit_minimum_budget", func(t *testing.T) {
+		request := &chatCompletionRequest{
+			Model:           "claude-sonnet-4-5-20250929",
+			MaxTokens:       400,
+			ReasoningEffort: "low",
+			Messages: []chatMessage{
+				{Role: roleUser, Content: "Hello"},
+			},
+		}
+
+		claudeReq := provider.buildClaudeTextGenRequest(request)
+
+		assert.Equal(t, 400, claudeReq.MaxTokens)
+		assert.Nil(t, claudeReq.Thinking)
+	})
+
+	t.Run("clamps_generated_thinking_budget_below_max_tokens", func(t *testing.T) {
+		request := &chatCompletionRequest{
+			Model:           "claude-sonnet-4-5-20250929",
+			MaxTokens:       1200,
+			ReasoningEffort: "high",
+			Messages: []chatMessage{
+				{Role: roleUser, Content: "Hello"},
+			},
+		}
+
+		claudeReq := provider.buildClaudeTextGenRequest(request)
+
+		require.NotNil(t, claudeReq.Thinking)
+		assert.Equal(t, "enabled", claudeReq.Thinking.Type)
+		assert.Equal(t, 1199, claudeReq.Thinking.BudgetTokens)
+	})
+
+	t.Run("clamps_explicit_reasoning_max_tokens_below_max_tokens", func(t *testing.T) {
+		request := &chatCompletionRequest{
+			Model:     "claude-sonnet-4-5-20250929",
+			MaxTokens: 2000,
+			NonOpenAIStyleOptions: NonOpenAIStyleOptions{
+				ReasoningMaxTokens: 3000,
+			},
+			Messages: []chatMessage{
+				{Role: roleUser, Content: "Hello"},
+			},
+		}
+
+		claudeReq := provider.buildClaudeTextGenRequest(request)
+
+		require.NotNil(t, claudeReq.Thinking)
+		assert.Equal(t, "enabled", claudeReq.Thinking.Type)
+		assert.Equal(t, 1999, claudeReq.Thinking.BudgetTokens)
+	})
+
 	t.Run("maps_openai_function_tool_choice_to_claude_tool_choice", func(t *testing.T) {
 		request := &chatCompletionRequest{
 			Model:     "claude-sonnet-4-5-20250929",


### PR DESCRIPTION
﻿## What changed

Fixes #4107.

This is a minimal Claude provider fix for OpenAI-compatible reasoning parameters:

- keeps generated `thinking.budget_tokens` at Claude's minimum `1024` tokens
- clamps generated or explicit `reasoning_max_tokens` budgets below `max_tokens`
- skips auto-generated `thinking` when `max_tokens` is too small to satisfy `1024 <= budget_tokens < max_tokens`

This prevents requests such as `reasoning_effort=low` with `max_tokens=400` from being forwarded to Claude as `thinking.budget_tokens=1024`, which Anthropic rejects because `max_tokens` must be greater than `thinking.budget_tokens`.

## Scope note

There is another open attempt for the same issue in #4147. This PR intentionally keeps the change smaller: it only adjusts thinking generated from OpenAI-compatible `reasoning_effort` / `reasoning_max_tokens`, and does not clamp caller-supplied Claude native `claude_thinking`. That preserves Claude Code / interleaved thinking configurations where the native thinking budget can legitimately differ from the response `max_tokens` semantics.

## Validation

```bash
go test ./provider -count=1
git diff --check origin/main...HEAD
```
