### PR TITLE
feat: improve rate limit plugin configuration guidance

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -1,0 +1,6 @@
+# Higress FAQ
+
+本目录汇总可复用的故障排查与二次开发说明。中文文档是内容基准，英文版本保持同步。
+
+- [限流插件 FAQ](rate-limit-plugin-faq.md)：`ai-token-ratelimit` 与 `cluster-key-rate-limit` 的配置、Redis 和数据面排查
+- [English index](README_EN.md)

--- a/docs/faq/README_EN.md
+++ b/docs/faq/README_EN.md
@@ -1,0 +1,6 @@
+# Higress FAQ
+
+This directory collects reusable troubleshooting and development notes. Chinese is the canonical source; English documents are synchronized translations.
+
+- [Rate-limit Plugin FAQ](rate-limit-plugin-faq-en.md): configuration, Redis, and data-plane diagnosis for `ai-token-ratelimit` and `cluster-key-rate-limit`
+- [中文索引](README.md)

--- a/docs/faq/rate-limit-plugin-faq-en.md
+++ b/docs/faq/rate-limit-plugin-faq-en.md
@@ -1,0 +1,208 @@
+# Higress Rate-limit Plugin FAQ
+
+> Chinese is the canonical source; this document is its synchronized English translation. It applies to both `ai-token-ratelimit` and `cluster-key-rate-limit`; plugin-specific fields are called out explicitly.
+
+## Contents
+
+1. [Rate limit not taking effect](#rate-limit-not-taking-effect)
+2. [Configuration rejected: literal name under `limit_by_per_*`](#literal-name-in-per-rule)
+3. [Configuration rejected: missing `limit_keys`](#missing-limit-keys)
+4. [Redis connection issues](#redis-connection-issues)
+5. [Diagnostic command cheat sheet](#diagnostic-command-cheat-sheet)
+6. [Developer notes](#developer-notes)
+
+<a id="rate-limit-not-taking-effect"></a>
+## 1. Rate limit not taking effect
+
+### 1.1 Requests always return 200, never 429
+
+**Symptom:** Requests keep succeeding and the configured threshold appears ineffective.
+
+**Root cause:** In order of investigation: route or match conditions did not match; parsing failed and the new rule was not loaded; the configured dimension differs from the request value; or no Redis call occurred.
+
+**Diagnostic steps:**
+
+1. Search gateway logs for the plugin name, `limit_by_per_`, `missing limit_keys`, and `must start with`.
+2. Check `/stats` for increasing Wasm configuration-rejection counters.
+3. Confirm the target Redis cluster in `/clusters`, then inspect its connection counters.
+4. Finally use Redis `SCAN` for rate-limit keys. No key alone does not prove a Redis failure.
+
+**Fix:** Correct the earliest parsing or matching error before debugging connectivity. Do not blame Redis until the rule is known to be loaded.
+
+**See also:** [#4067](https://github.com/higress-group/higress/issues/4067), [#2646](https://github.com/higress-group/higress/issues/2646).
+
+### 1.2 Redis always has no rate-limit keys
+
+**Symptom:** `SCAN` finds no Higress rate-limit key.
+
+**Root cause:** The rule may not match, data-plane parsing may reject it, or no request requiring a counter has occurred. A key appears only after rule execution reaches Redis.
+
+**Diagnostic steps:** Confirm that plugin logs contain no parse error, send a request known to match, and correlate `/stats`, `/clusters`, and short-lived Redis `MONITOR` output in a test environment.
+
+**Fix:** Align request values with `limit_by_*` and `limit_keys`. If connection attempts occur and fail, then inspect port, credentials, and network.
+
+**See also:** [Section 2](#literal-name-in-per-rule), [Section 3](#missing-limit-keys).
+
+### 1.3 `cx_total=0` and `cx_connect_fail=0`
+
+**Symptom:** The Redis cluster reports neither successful nor failed connection attempts.
+
+**Root cause:** Usually the data plane never tried to connect: the rule was not loaded or matched, or the wrong cluster name is being inspected. This is different from a connection failure.
+
+**Diagnostic steps:** Derive `outbound|<port>||<service_name>` from `service_name` and `service_port`, locate that exact entry in `/clusters`, and inspect Wasm rejection logs.
+
+**Fix:** Correct loading or matching first; changing Redis credentials cannot fix zero connection attempts.
+
+**See also:** [#4067](https://github.com/higress-group/higress/issues/4067).
+
+### 1.4 `update_rejected` / `config_fail` keeps increasing
+
+**Symptom:** Rejection counters increase after each control-plane push.
+
+**Root cause:** The plugin parser returned an error, commonly a literal key under `limit_by_per_*`, missing `limit_keys`, or an invalid IP-source format.
+
+**Diagnostic steps:** Correlate the counter timestamp with the complete gateway log error; do not rely only on control-plane object state.
+
+**Fix:** Correct the field, rejected value, or migration target named by the error, then verify that the counter stops increasing.
+
+**See also:** [Section 2](#literal-name-in-per-rule), [Section 3](#missing-limit-keys).
+
+### 1.5 `config_dump` does not mean loaded by the data plane
+
+**Symptom:** Configuration appears in `config_dump`, but rate limiting is inactive.
+
+**Root cause:** `config_dump` proves delivery, not that the Wasm plugin accepted and activated the configuration.
+
+**Diagnostic steps:** Correlate plugin logs, Wasm rejection counters, the target cluster, and Redis calls.
+
+**Fix:** Use data-plane load results as authority and re-observe the current configuration after fixing parse errors.
+
+**See also:** [#2464](https://github.com/higress-group/higress/issues/2464).
+
+<a id="literal-name-in-per-rule"></a>
+## 2. Configuration rejected: literal name under `limit_by_per_*`
+
+### 2.1 What the error looks like
+
+```text
+the "limit_by_per_consumer" restriction must start with 'regexp:' or be exactly '*' (got "alice"); to match an exact name, use the non-per variant "limit_by_consumer" instead (limit_keys stay the same)
+```
+
+`per_` means “create a separate bucket for each actual value,” so its `limit_keys` are selectors and accept only `*` or `regexp:...`. Exact literals belong to the non-`per_` variant.
+
+### 2.2 Choosing `per_*` or non-`per_*`
+
+| Goal | Field | `limit_keys[].key` |
+| --- | --- | --- |
+| Limit one exact header value | `limit_by_header` | Literal |
+| Limit each header value separately | `limit_by_per_header` | `*` or `regexp:...` |
+| Limit one exact parameter value | `limit_by_param` | Literal |
+| Limit each parameter value separately | `limit_by_per_param` | `*` or `regexp:...` |
+| Limit one exact consumer | `limit_by_consumer` | Consumer literal |
+| Limit each consumer separately | `limit_by_per_consumer` | `*` or `regexp:...` |
+| Limit one exact Cookie value | `limit_by_cookie` | Literal |
+| Limit each Cookie value separately | `limit_by_per_cookie` | `*` or `regexp:...` |
+
+### 2.3 Migration map
+
+Change `limit_by_per_header/param/consumer/cookie` to the corresponding `limit_by_header/param/consumer/cookie`, keeping `limit_keys` and threshold fields. `limit_by_per_ip` is different: it selects the IP source, while CIDRs remain in `limit_keys`.
+
+<a id="missing-limit-keys"></a>
+## 3. Configuration rejected: missing `limit_keys`
+
+### 3.1 What the error looks like
+
+```text
+missing limit_keys in config for limit_by_per_ip; add at least one entry, e.g. key: "0.0.0.0/0"
+```
+
+An empty array carries the same type and example, with the prefix `config limit_keys cannot be empty`.
+
+### 3.2 Minimal valid key by type
+
+| Type | Minimal `limit_keys` entry |
+| --- | --- |
+| `limit_by_header/param/cookie` | `- key: "<exact-value>"` |
+| `limit_by_consumer` | `- key: "<consumer-name>"` |
+| `limit_by_per_header/param/consumer/cookie` | `- key: "*"` |
+| `limit_by_per_ip` | `- key: "0.0.0.0/0"` |
+
+Each entry also needs a positive plugin-specific threshold: `token_per_*` for AI Token rate limiting, or `query_per_*` for cluster key rate limiting.
+
+<a id="redis-connection-issues"></a>
+## 4. Redis connection issues
+
+### 4.1 `cx_connect_fail > 0`
+
+**Symptom:** Connection failures increase for the target Redis cluster.
+
+**Root cause:** Common causes are a wrong port, authentication failure, unreachable DNS/route, or network policy.
+
+**Diagnostic steps:** Confirm the exact cluster name and port in `/clusters`; verify DNS/TCP from the gateway container; inspect Redis authentication logs.
+
+**Fix:** Correct `service_name`, `service_port`, credentials, or network policy. A connection failure is distinct from `cx_total=0`.
+
+**See also:** [#2000](https://github.com/higress-group/higress/issues/2000).
+
+### 4.2 `service_port` and the cluster port
+
+Both plugins use `FQDNCluster` to generate `outbound|<service_port>||<service_name>`. If the port is omitted, `.static` services default to 80 and others default to 6379. If a console-generated static service points to Redis on 6379, set `service_port: 6379` explicitly.
+
+### 4.3 About `.static` services
+
+`.static` is a fixed-address naming convention; it does not mean Redis listens on port 80. The cluster name uses the logical port and must match the control-plane-generated cluster. After changing an McpBridge port, re-check the cluster, credentials, and plugin state.
+
+### 4.4 Historical authentication loss after an McpBridge port change
+
+[#2000](https://github.com/higress-group/higress/issues/2000) reported Redis commands losing AUTH after a port edit and recovering after plugin restart. The current Redis wrapper retries `RedisInit` while not ready, but upgrade investigations should still verify the actual version, cluster transition, and authentication logs.
+
+<a id="diagnostic-command-cheat-sheet"></a>
+## 5. Diagnostic command cheat sheet
+
+```bash
+# Wasm configuration and Redis connection metrics
+kubectl -n higress-system exec <gateway-pod> -- \
+  curl -s '127.0.0.1:15000/stats?filter=wasm|redis|update_rejected|config_fail|cx_'
+
+# Locate the target Redis cluster
+kubectl -n higress-system exec <gateway-pod> -- \
+  curl -s '127.0.0.1:15000/clusters' | grep -A8 'outbound|<port>||<service_name>'
+
+# Configuration parsing logs
+kubectl -n higress-system logs <gateway-pod> --tail=2000 \
+  | grep -Ei 'ai-token-ratelimit|cluster-key-rate-limit|limit_by_per_|missing limit_keys|must start with|redis'
+
+# Redis: use SCAN in production, not blocking KEYS
+redis-cli -h <host> -p <port> --scan --pattern '*ratelimit*'
+```
+
+<a id="developer-notes"></a>
+## 6. Developer notes
+
+### 6.1 Semantic contract for `per_*` and non-`per_*`
+
+Non-`per_` types treat `limit_keys` as exact values; non-IP `per_*` types treat them as `*`/regexp selectors; `limit_by_per_ip` treats the field as the IP source and `limit_keys` as IP/CIDR values. A new type must update parsing, error examples, tests, and bilingual docs together.
+
+### 6.2 `FQDNCluster` to Envoy cluster name
+
+The current dependency's `wrapper.FQDNCluster.ClusterName()` generates `outbound|<port>||<fqdn>`. The plugins use `service_name` as the FQDN and `service_port` as the port; a control-plane port change therefore changes the lookup target.
+
+### 6.3 `RedisClient.Init` / `Ready` lifecycle
+
+`Init` installs a retry closure and calls `RedisInit`. On initial failure, the client remains `ready=false`, logs a warning, and lets a later `Command`/`Eval` retry authentication. `Ready()` is a current-state snapshot, not a permanent health guarantee. Do not treat one `Init` return as proof of sustained connectivity.
+
+### 6.4 Adding a `limit_by_*` type
+
+1. Add the `LimitRuleItemType` constant and field parsing.
+2. Define whether keys are exact, `*`/regexp, or IP/CIDR.
+3. Update `exampleLimitKeyForType` and actionable errors.
+4. Add unit tests for valid input, invalid input, and migration guidance.
+5. Keep `token_per_*` / `query_per_*` distinct and update all four READMEs plus this FAQ.
+
+### 6.5 What not to do
+
+- Do not add a cross-plugin dependency for a small shared error helper; the plugins are separate Go modules.
+- Do not silently accept literals for non-IP `per_*`; that changes the established configuration contract.
+- Do not put CIDRs in the `limit_by_per_ip` field.
+- Do not use `config_dump`, one `Ready()` result, or “no Redis key” alone to prove root cause.
+- Do not use Redis `KEYS` for routine production diagnosis.

--- a/docs/faq/rate-limit-plugin-faq.md
+++ b/docs/faq/rate-limit-plugin-faq.md
@@ -1,0 +1,208 @@
+# Higress 限流插件 FAQ
+
+> 中文版本是内容基准；[英文版本](rate-limit-plugin-faq-en.md)为同步翻译。本文同时适用于 `ai-token-ratelimit` 和 `cluster-key-rate-limit`，字段差异会显式标注。
+
+## 目录
+
+1. [限流不生效](#rate-limit-not-taking-effect)
+2. [配置被拒：`limit_by_per_*` 写了字面名](#literal-name-in-per-rule)
+3. [配置被拒：缺少 `limit_keys`](#missing-limit-keys)
+4. [Redis 连接异常](#redis-connection-issues)
+5. [诊断命令速查](#diagnostic-command-cheat-sheet)
+6. [二次开发说明](#developer-notes)
+
+<a id="rate-limit-not-taking-effect"></a>
+## 1. 限流不生效
+
+### 1.1 请求始终 200，从不返回 429
+
+**现象：** 请求持续成功，配置的阈值似乎没有生效。
+
+**根因：** 常见原因依次是：路由/匹配条件未命中；配置解析失败，插件保留旧配置或未加载新规则；计数维度与实际请求值不一致；Redis 调用没有发生。
+
+**诊断步骤：**
+
+1. 在网关日志中搜索插件名、`limit_by_per_`、`missing limit_keys` 和 `must start with`。
+2. 查看 `/stats` 中 Wasm 配置拒绝类计数是否增长。
+3. 查看 `/clusters` 中目标 Redis cluster 是否存在，再检查其连接计数。
+4. 最后用 Redis `SCAN` 检查限流 key；没有 key 不等于 Redis 故障。
+
+**修复：** 先修复最早出现的配置解析或匹配错误，再处理 Redis 连接。不要在尚未确认规则加载时直接归因于 Redis。
+
+**参考：** [#4067](https://github.com/higress-group/higress/issues/4067)、[#2646](https://github.com/higress-group/higress/issues/2646)。
+
+### 1.2 Redis 中始终没有限流 key
+
+**现象：** `SCAN` 找不到 Higress 限流 key。
+
+**根因：** 规则可能未命中、配置可能在数据面被拒绝，或者尚未发生需要计数的请求。只有规则执行到 Redis 调用后才会产生 key。
+
+**诊断步骤：** 先确认插件日志无解析错误，再发起确定能命中的请求，同时观察 `/stats`、`/clusters` 和 Redis `MONITOR`（仅限短时测试环境）。
+
+**修复：** 让请求值与 `limit_by_*`/`limit_keys` 语义一致；若连接计数增长但调用失败，再检查端口、认证和网络。
+
+**参考：** [第 2 节](#literal-name-in-per-rule)、[第 3 节](#missing-limit-keys)。
+
+### 1.3 `cx_total=0` 且 `cx_connect_fail=0`
+
+**现象：** Redis cluster 没有连接成功或失败计数。
+
+**根因：** 通常表示数据面没有尝试连接：规则没有加载/命中，或查看的 cluster 名不正确。这不同于连接失败。
+
+**诊断步骤：** 从 `service_name` 和 `service_port` 推导 `outbound|<port>||<service_name>`，在 `/clusters` 中确认对应条目；再查看 Wasm 配置拒绝日志。
+
+**修复：** 修复加载或匹配问题；不要仅通过修改 Redis 密码来处理零连接计数。
+
+**参考：** [#4067](https://github.com/higress-group/higress/issues/4067)。
+
+### 1.4 `update_rejected` / `config_fail` 持续上涨
+
+**现象：** 每次控制面推送后拒绝计数增加。
+
+**根因：** 插件解析器返回了错误，例如 `limit_by_per_*` 使用字面 key、缺少 `limit_keys`，或 IP 来源格式不合法。
+
+**诊断步骤：** 按时间关联拒绝计数与网关日志中的完整错误；不要只看控制面对象状态。
+
+**修复：** 按错误中的字段名、错误值和迁移建议修正配置，然后确认计数停止增长。
+
+**参考：** [第 2 节](#literal-name-in-per-rule)、[第 3 节](#missing-limit-keys)。
+
+### 1.5 `config_dump` 不等于数据面已加载
+
+**现象：** `config_dump` 能看到配置，但限流仍不生效。
+
+**根因：** `config_dump` 证明配置已下发，不证明 Wasm 插件接受并激活了它。
+
+**诊断步骤：** 同时检查插件日志、Wasm 拒绝计数、目标 cluster 和 Redis 调用。
+
+**修复：** 以数据面加载结果为准，修复解析错误后重新观察 exact-current 配置。
+
+**参考：** [#2464](https://github.com/higress-group/higress/issues/2464)。
+
+<a id="literal-name-in-per-rule"></a>
+## 2. 配置被拒：`limit_by_per_*` 写了字面名
+
+### 2.1 错误信息长什么样
+
+```text
+the "limit_by_per_consumer" restriction must start with 'regexp:' or be exactly '*' (got "alice"); to match an exact name, use the non-per variant "limit_by_consumer" instead (limit_keys stay the same)
+```
+
+`per_` 表示“按每一个实际值分别建桶”，因此其 `limit_keys` 是选择器，只接受 `*` 或 `regexp:...`。精确字面值属于非 `per_` 变体。
+
+### 2.2 `per_*` 与非 `per_*` 选择表
+
+| 需求 | 使用字段 | `limit_keys[].key` |
+| --- | --- | --- |
+| 只限制精确请求头值 | `limit_by_header` | 字面值 |
+| 每个请求头值分别限流 | `limit_by_per_header` | `*` 或 `regexp:...` |
+| 只限制精确参数值 | `limit_by_param` | 字面值 |
+| 每个参数值分别限流 | `limit_by_per_param` | `*` 或 `regexp:...` |
+| 只限制精确 consumer | `limit_by_consumer` | consumer 字面名 |
+| 每个 consumer 分别限流 | `limit_by_per_consumer` | `*` 或 `regexp:...` |
+| 只限制精确 Cookie 值 | `limit_by_cookie` | 字面值 |
+| 每个 Cookie 值分别限流 | `limit_by_per_cookie` | `*` 或 `regexp:...` |
+
+### 2.3 迁移对照
+
+将 `limit_by_per_header/param/consumer/cookie` 改为对应的 `limit_by_header/param/consumer/cookie`，保留原 `limit_keys` 和阈值字段。`limit_by_per_ip` 是例外：它选择 IP 来源，CIDR 仍写在 `limit_keys`。
+
+<a id="missing-limit-keys"></a>
+## 3. 配置被拒：缺少 `limit_keys`
+
+### 3.1 错误信息长什么样
+
+```text
+missing limit_keys in config for limit_by_per_ip; add at least one entry, e.g. key: "0.0.0.0/0"
+```
+
+空数组会得到相同的类型和示例提示，但错误前缀是 `config limit_keys cannot be empty`。
+
+### 3.2 各类型最小合法 key
+
+| 类型 | 最小 `limit_keys` 示例 |
+| --- | --- |
+| `limit_by_header/param/cookie` | `- key: "<exact-value>"` |
+| `limit_by_consumer` | `- key: "<consumer-name>"` |
+| `limit_by_per_header/param/consumer/cookie` | `- key: "*"` |
+| `limit_by_per_ip` | `- key: "0.0.0.0/0"` |
+
+每项还必须包含插件对应的正数阈值：AI Token 插件使用 `token_per_*`，集群 Key 限流使用 `query_per_*`。
+
+<a id="redis-connection-issues"></a>
+## 4. Redis 连接异常
+
+### 4.1 `cx_connect_fail > 0`
+
+**现象：** 目标 Redis cluster 的连接失败计数增长。
+
+**根因：** 常见于端口错误、认证失败、DNS/路由不可达或网络策略拒绝。
+
+**诊断步骤：** 在 `/clusters` 中确认准确 cluster 名和端口；从网关容器验证 DNS/TCP；检查 Redis 认证日志。
+
+**修复：** 修正 `service_name`、`service_port`、认证或网络策略。连接失败与 `cx_total=0` 是两类问题。
+
+**参考：** [#2000](https://github.com/higress-group/higress/issues/2000)。
+
+### 4.2 `service_port` 与 cluster 端口
+
+两个插件都通过 `FQDNCluster` 生成 `outbound|<service_port>||<service_name>`。省略端口时，`.static` 服务默认使用 80，其他服务默认使用 6379。控制台生成的固定地址若实际 Redis 监听 6379，应显式填写 `service_port: 6379`。
+
+### 4.3 关于 `.static` 服务
+
+`.static` 是固定地址服务命名约定，不代表 Redis 必然监听 80。cluster 名使用逻辑端口；它必须与控制面生成的 cluster 一致。修改 McpBridge 端口后应重新检查 cluster、认证和插件状态。
+
+### 4.4 历史问题：修改 McpBridge 端口后认证丢失
+
+[#2000](https://github.com/higress-group/higress/issues/2000) 记录过修改端口后 Redis 命令不再带 AUTH、重启插件后恢复的现象。当前 Redis wrapper 会在未 ready 时重新调用 `RedisInit`，但排查升级/兼容问题时仍应核对实际版本、cluster 变化和认证日志。
+
+<a id="diagnostic-command-cheat-sheet"></a>
+## 5. 诊断命令速查
+
+```bash
+# Wasm 配置与 Redis 连接相关指标
+kubectl -n higress-system exec <gateway-pod> -- \
+  curl -s '127.0.0.1:15000/stats?filter=wasm|redis|update_rejected|config_fail|cx_'
+
+# 查找目标 Redis cluster
+kubectl -n higress-system exec <gateway-pod> -- \
+  curl -s '127.0.0.1:15000/clusters' | grep -A8 'outbound|<port>||<service_name>'
+
+# 配置解析日志
+kubectl -n higress-system logs <gateway-pod> --tail=2000 \
+  | grep -Ei 'ai-token-ratelimit|cluster-key-rate-limit|limit_by_per_|missing limit_keys|must start with|redis'
+
+# Redis：生产环境使用 SCAN，不要使用阻塞式 KEYS
+redis-cli -h <host> -p <port> --scan --pattern '*ratelimit*'
+```
+
+<a id="developer-notes"></a>
+## 6. 二次开发说明
+
+### 6.1 `per_*` 与非 `per_*` 的语义契约
+
+非 `per_` 类型把 `limit_keys` 当精确值；非 IP 的 `per_*` 类型把它当 `*`/regexp 选择器；`limit_by_per_ip` 把字段值当 IP 来源、把 `limit_keys` 当 IP/CIDR。新增类型时必须同时更新解析、错误示例、测试和双语文档。
+
+### 6.2 `FQDNCluster` 到 Envoy cluster 名
+
+当前依赖中的 `wrapper.FQDNCluster.ClusterName()` 固定生成 `outbound|<port>||<fqdn>`。插件用 `service_name` 作为 FQDN、`service_port` 作为端口；任何控制面端口变化都会改变查找目标。
+
+### 6.3 `RedisClient.Init` / `Ready` 生命周期
+
+`Init` 设置重试闭包并调用 `RedisInit`。首次初始化失败时 client 保持 `ready=false`、记录告警，并允许后续 `Command`/`Eval` 再认证；`Ready()` 只是当前状态快照，不是永久健康承诺。不要把一次 `Init` 返回当成持续连接证明。
+
+### 6.4 如何新增 `limit_by_*` 类型
+
+1. 新增 `LimitRuleItemType` 常量和字段解析。
+2. 定义它使用精确、`*`/regexp 还是 IP/CIDR key。
+3. 更新 `exampleLimitKeyForType` 和可操作错误。
+4. 为合法输入、非法输入和迁移建议补单元测试。
+5. 同步两个插件时分别使用 `token_per_*` / `query_per_*`，并更新四份 README 与本 FAQ。
+
+### 6.5 不要做什么
+
+- 不要为共享错误 helper 引入跨插件依赖；两个插件是独立 Go module。
+- 不要接受字面值作为非 IP `per_*` 的隐式精确匹配，这会改变既有配置语义。
+- 不要把 CIDR 放进 `limit_by_per_ip` 字段。
+- 不要用 `config_dump`、单次 `Ready()` 或“Redis 中没有 key”单独证明根因。
+- 不要在生产 Redis 上用 `KEYS` 做常规诊断。

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/README.md
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/README.md
@@ -55,11 +55,11 @@ description: AI Token限流插件配置参考
 | limit_by_param        | string          | 否，`limit_by_*`中选填一项 | -      | 配置获取限流键值的来源 URL 参数名称                          |
 | limit_by_consumer     | string          | 否，`limit_by_*`中选填一项 | -      | 根据 consumer 名称进行限流，无需添加实际值                   |
 | limit_by_cookie       | string          | 否，`limit_by_*`中选填一项 | -      | 配置获取限流键值的来源 Cookie中 key 名称                     |
-| limit_by_per_header   | string          | 否，`limit_by_*`中选填一项 | -      | 按规则匹配特定 HTTP 请求头，并对每个请求头分别计算限流，配置获取限流键值的来源 HTTP 请求头名称，配置`limit_keys`时支持正则表达式或`*` |
-| limit_by_per_param    | string          | 否，`limit_by_*`中选填一项 | -      | 按规则匹配特定 URL 参数，并对每个参数分别计算限流，配置获取限流键值的来源 URL 参数名称，配置`limit_keys`时支持正则表达式或`*` |
-| limit_by_per_consumer | string          | 否，`limit_by_*`中选填一项 | -      | 按规则匹配特定 consumer，并对每个 consumer 分别计算限流，根据 consumer 名称进行限流，无需添加实际值，配置`limit_keys`时支持正则表达式或`*` |
-| limit_by_per_cookie   | string          | 否，`limit_by_*`中选填一项 | -      | 按规则匹配特定 Cookie，并对每个 Cookie 分别计算限流，配置获取限流键值的来源 Cookie中 key 名称，配置`limit_keys`时支持正则表达式或`*` |
-| limit_by_per_ip       | string          | 否，`limit_by_*`中选填一项 | -      | 按规则匹配特定 IP，并对每个 IP 分别计算限流，配置获取限流键值的来源 IP 参数名称，从请求头获取，以`from-header-对应的header名`，示例：`from-header-x-forwarded-for`，直接获取对端socket ip，配置为`from-remote-addr` |
+| limit_by_per_header   | string          | 否，`limit_by_*`中选填一项 | -      | 按请求头值分别计算限流；`limit_keys` **不可填字面名，仅接受 `*` 或 `regexp:...`**。精确匹配请改用 `limit_by_header`（去掉 `per_`） |
+| limit_by_per_param    | string          | 否，`limit_by_*`中选填一项 | -      | 按 URL 参数值分别计算限流；`limit_keys` **不可填字面名，仅接受 `*` 或 `regexp:...`**。精确匹配请改用 `limit_by_param`（去掉 `per_`） |
+| limit_by_per_consumer | string          | 否，`limit_by_*`中选填一项 | -      | 按 consumer 分别计算限流；`limit_keys` **不可填字面名，仅接受 `*` 或 `regexp:...`**。精确匹配请改用 `limit_by_consumer`（去掉 `per_`） |
+| limit_by_per_cookie   | string          | 否，`limit_by_*`中选填一项 | -      | 按 Cookie 值分别计算限流；`limit_keys` **不可填字面名，仅接受 `*` 或 `regexp:...`**。精确匹配请改用 `limit_by_cookie`（去掉 `per_`） |
+| limit_by_per_ip       | string          | 否，`limit_by_*`中选填一项 | -      | 选择客户端 IP 来源：`from-header-<header名>` 或 `from-remote-addr`；IP/CIDR 必须写在 `limit_keys[].key` 中 |
 | limit_keys            | array of object | 是                         | -      | 配置匹配键值后的限流次数                                     |
 
 #### `rule_items` 多规则匹配语义
@@ -74,7 +74,7 @@ description: AI Token限流插件配置参考
 
 | 配置项           | 类型   | 必填                                                         | 默认值 | 说明                                                         |
 | ---------------- | ------ | ------------------------------------------------------------ | ------ | ------------------------------------------------------------ |
-| key              | string | 是                                                           | -      | 匹配的键值，`limit_by_per_header`,`limit_by_per_param`,`limit_by_per_consumer`,`limit_by_per_cookie` 类型支持配置正则表达式（以regexp:开头后面跟正则表达式）或者*（代表所有），正则表达式示例：`regexp:^d.*`（以d开头的所有字符串）；`limit_by_per_ip`支持配置 IP 地址或 IP 段 |
+| key              | string | 是                                                           | -      | 非 `per_` 类型接受精确字面值；`limit_by_per_header`、`limit_by_per_param`、`limit_by_per_consumer`、`limit_by_per_cookie` 仅接受 `regexp:...` 或 `*`；`limit_by_per_ip` 接受 IP 地址或 CIDR |
 | token_per_second | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每秒请求token数                                             |
 | token_per_minute | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每分钟请求token数                                           |
 | token_per_hour   | int    | 否，`token_per_second`,`token_per_minute`,`token_per_hour`,`token_per_day` 中选填一项 | -      | 允许每小时请求token数                                           |
@@ -229,6 +229,73 @@ rejected_msg: '{"code":-1,"msg":"Too many requests"}'
 redis:
   service_name: redis.static
 ```
+
+## 常见错误
+
+### `limit_by_per_consumer` 中填写字面 consumer 名称
+
+```yaml
+# ❌ 错误：per_consumer 的 limit_keys 仅接受 * 或 regexp:...
+rule_items:
+  - limit_by_per_consumer: ""
+    limit_keys:
+      - key: "alice"
+        token_per_day: 100
+
+# ✅ 正确：精确匹配名称时去掉 per_
+rule_items:
+  - limit_by_consumer: ""
+    limit_keys:
+      - key: "alice"
+        token_per_day: 100
+```
+
+### 把 CIDR 填到 `limit_by_per_ip`
+
+```yaml
+# ❌ 错误：limit_by_per_ip 选择 IP 来源，不接受 CIDR
+rule_items:
+  - limit_by_per_ip: "0.0.0.0/0"
+
+# ✅ 正确：CIDR 写入 limit_keys
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+    limit_keys:
+      - key: "0.0.0.0/0"
+        token_per_day: 1000
+```
+
+### 遗漏 `limit_keys`
+
+```yaml
+# ❌ 错误：整个 rule_item 会被拒绝
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+
+# ✅ 正确：至少提供一个 key 和 token 阈值
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+    limit_keys:
+      - key: "0.0.0.0/0"
+        token_per_day: 1000
+```
+
+## 诊断
+
+完整排查步骤见[限流插件 FAQ](../../../../docs/faq/rate-limit-plugin-faq.md#rate-limit-not-taking-effect)。
+
+| 现象 | 优先判断 |
+| --- | --- |
+| 请求始终返回 200，Redis 中没有限流 key | 规则未匹配，或配置解析失败导致规则未加载 |
+| Redis cluster 的 `cx_connect_fail` 大于 0 | 端口、认证或网络连接异常 |
+| Wasm `update_rejected` / `config_fail` 持续增长 | 新配置被解析器拒绝；先检查网关日志中的具体错误 |
+
+```bash
+kubectl -n higress-system logs <gateway-pod> --tail=2000 \
+  | grep -Ei 'ai-token-ratelimit|limit_by_per_|missing limit_keys|must start with'
+```
+
+`config_dump` 中能看到配置只说明控制面已下发，不能证明数据面插件已成功加载；需要结合 `/stats`、`/clusters` 和网关日志判断。
 
 ## 完整示例
 

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/README_EN.md
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/README_EN.md
@@ -59,11 +59,11 @@ Plugin execution priority: `600`
 | limit_by_param              | string          | No, one of `limit_by_*` is required | - | Configures the source of the rate limiting key value as the URL parameter name                                                                                                                              |
 | limit_by_consumer           | string          | No, one of `limit_by_*` is required | - | Performs rate limiting based on the consumer name; no actual value needs to be added                                                                                                                         |
 | limit_by_cookie             | string          | No, one of `limit_by_*` is required | - | Configures the source of the rate limiting key value as the key name in the Cookie                                                                                                                           |
-| limit_by_per_header         | string          | No, one of `limit_by_*` is required | - | Matches specific HTTP request headers by rule and calculates rate limits for each header separately. Configures the source of the rate limiting key value as the HTTP request header name. Regular expressions or `*` are supported when configuring `limit_keys`. |
-| limit_by_per_param          | string          | No, one of `limit_by_*` is required | - | Matches specific URL parameters by rule and calculates rate limits for each parameter separately. Configures the source of the rate limiting key value as the URL parameter name. Regular expressions or `*` are supported when configuring `limit_keys`.       |
-| limit_by_per_consumer       | string          | No, one of `limit_by_*` is required | - | Matches specific consumers by rule and calculates rate limits for each consumer separately. Performs rate limiting based on the consumer name; no actual value needs to be added. Regular expressions or `*` are supported when configuring `limit_keys`.      |
-| limit_by_per_cookie         | string          | No, one of `limit_by_*` is required | - | Matches specific Cookies by rule and calculates rate limits for each Cookie separately. Configures the source of the rate limiting key value as the key name in the Cookie. Regular expressions or `*` are supported when configuring `limit_keys`.             |
-| limit_by_per_ip             | string          | No, one of `limit_by_*` is required | - | Matches specific IPs by rule and calculates rate limits for each IP separately. Configures the source of the rate limiting key value as the IP parameter name, obtained from the request header in the format `from-header-corresponding_header_name` (e.g., `from-header-x-forwarded-for`), or directly obtains the peer socket IP by configuring `from-remote-addr`. |
+| limit_by_per_header         | string          | No, one of `limit_by_*` is required | - | Calculates a separate limit per header value. `limit_keys` **MUST NOT be a literal name; only `*` or `regexp:...` is accepted**. For an exact match, use `limit_by_header` (drop `per_`). |
+| limit_by_per_param          | string          | No, one of `limit_by_*` is required | - | Calculates a separate limit per parameter value. `limit_keys` **MUST NOT be a literal name; only `*` or `regexp:...` is accepted**. For an exact match, use `limit_by_param` (drop `per_`). |
+| limit_by_per_consumer       | string          | No, one of `limit_by_*` is required | - | Calculates a separate limit per consumer. `limit_keys` **MUST NOT be a literal name; only `*` or `regexp:...` is accepted**. For an exact match, use `limit_by_consumer` (drop `per_`). |
+| limit_by_per_cookie         | string          | No, one of `limit_by_*` is required | - | Calculates a separate limit per Cookie value. `limit_keys` **MUST NOT be a literal name; only `*` or `regexp:...` is accepted**. For an exact match, use `limit_by_cookie` (drop `per_`). |
+| limit_by_per_ip             | string          | No, one of `limit_by_*` is required | - | Selects the client-IP source: `from-header-<header_name>` or `from-remote-addr`. Put IP/CIDR values in `limit_keys[].key`. |
 | limit_keys                  | array of object | Yes      | -             | Configures the rate limiting count after matching the key value                                                                                                                                             |
 
 #### `rule_items` Multi-Rule Matching Semantics
@@ -79,7 +79,7 @@ Plugin execution priority: `600`
 
 | Configuration Item    | Type   | Required | Default Value | Description                                                                                                                                                                                                 |
 |-----------------------|--------|----------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| key                   | string | Yes      | -             | The matched key value. For types `limit_by_per_header`, `limit_by_per_param`, `limit_by_per_consumer`, and `limit_by_per_cookie`, regular expressions (starting with `regexp:` followed by the regular expression, e.g., `regexp:^d.*` for all strings starting with "d") or `*` (representing all) are supported. For `limit_by_per_ip`, IP addresses or IP segments are supported. |
+| key                   | string | Yes      | -             | Non-`per_` types accept exact literals. `limit_by_per_header`, `limit_by_per_param`, `limit_by_per_consumer`, and `limit_by_per_cookie` accept only `regexp:...` or `*`. `limit_by_per_ip` accepts IP addresses or CIDR blocks. |
 | token_per_second      | int    | No, one of `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` is required | - | Allowed number of request tokens per second   |
 | token_per_minute      | int    | No, one of `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` is required | - | Allowed number of request tokens per minute   |
 | token_per_hour        | int    | No, one of `token_per_second`, `token_per_minute`, `token_per_hour`, `token_per_day` is required | - | Allowed number of request tokens per hour     |
@@ -226,6 +226,73 @@ rejected_msg: '{"code":-1,"msg":"Too many requests"}'
 redis:
   service_name: redis.static
 ```
+
+## Common Pitfalls
+
+### Literal consumer name under `limit_by_per_consumer`
+
+```yaml
+# ❌ Wrong: per_consumer limit_keys accepts only * or regexp:...
+rule_items:
+  - limit_by_per_consumer: ""
+    limit_keys:
+      - key: "alice"
+        token_per_day: 100
+
+# ✅ Right: drop per_ for an exact-name match
+rule_items:
+  - limit_by_consumer: ""
+    limit_keys:
+      - key: "alice"
+        token_per_day: 100
+```
+
+### CIDR placed in `limit_by_per_ip`
+
+```yaml
+# ❌ Wrong: limit_by_per_ip selects the IP source; it is not a CIDR field
+rule_items:
+  - limit_by_per_ip: "0.0.0.0/0"
+
+# ✅ Right: put the CIDR in limit_keys
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+    limit_keys:
+      - key: "0.0.0.0/0"
+        token_per_day: 1000
+```
+
+### Missing `limit_keys`
+
+```yaml
+# ❌ Wrong: the entire rule_item is rejected
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+
+# ✅ Right: provide at least one key and token threshold
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+    limit_keys:
+      - key: "0.0.0.0/0"
+        token_per_day: 1000
+```
+
+## Diagnosing
+
+See the [Rate-limit Plugin FAQ](../../../../docs/faq/rate-limit-plugin-faq-en.md#rate-limit-not-taking-effect) for complete diagnosis recipes.
+
+| Symptom | Check first |
+| --- | --- |
+| Requests always return 200 and Redis has no rate-limit keys | No rule matched, or configuration parsing prevented the rule from loading |
+| Redis cluster `cx_connect_fail` is greater than 0 | Port, credentials, or network connectivity |
+| Wasm `update_rejected` / `config_fail` keeps increasing | The parser rejected the pushed configuration; inspect the concrete gateway log error |
+
+```bash
+kubectl -n higress-system logs <gateway-pod> --tail=2000 \
+  | grep -Ei 'ai-token-ratelimit|limit_by_per_|missing limit_keys|must start with'
+```
+
+Seeing configuration in `config_dump` proves only that the control plane delivered it; it does not prove that the data-plane plugin loaded it. Correlate `/stats`, `/clusters`, and gateway logs.
 
 ## Example
 

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/config/config.go
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/config/config.go
@@ -320,10 +320,12 @@ func parseLimitRuleItem(item gjson.Result) (*LimitRuleItem, error) {
 func initConfigItems(json gjson.Result, rule *LimitRuleItem) error {
 	limitKeys := json.Get("limit_keys")
 	if !limitKeys.Exists() {
-		return errors.New("missing limit_keys in config")
+		return fmt.Errorf("missing limit_keys in config for %s; add at least one entry, e.g. %s",
+			rule.LimitType, exampleLimitKeyForType(rule.LimitType))
 	}
 	if len(limitKeys.Array()) == 0 {
-		return errors.New("config limit_keys cannot be empty")
+		return fmt.Errorf("config limit_keys cannot be empty for %s; add at least one entry, e.g. %s",
+			rule.LimitType, exampleLimitKeyForType(rule.LimitType))
 	}
 	var configItems []LimitConfigItem
 	for _, item := range limitKeys.Array() {
@@ -360,7 +362,12 @@ func initConfigItems(json gjson.Result, rule *LimitRuleItem) error {
 				}
 				itemType = RegexpType
 			} else {
-				return fmt.Errorf("the '%s' restriction must start with 'regexp:' or be exactly '*'", rule.LimitType)
+				return fmt.Errorf(
+					"the %q restriction must start with 'regexp:' or be exactly '*' (got %q); "+
+						"to match an exact name, use the non-per variant %q instead (limit_keys stay the same)",
+					string(rule.LimitType), itemKey,
+					"limit_by_"+strings.TrimPrefix(string(rule.LimitType), "limit_by_per_"),
+				)
 			}
 		} else {
 			itemType = ExactType
@@ -374,6 +381,21 @@ func initConfigItems(json gjson.Result, rule *LimitRuleItem) error {
 	}
 	rule.ConfigItems = configItems
 	return nil
+}
+
+func exampleLimitKeyForType(limitType LimitRuleItemType) string {
+	switch limitType {
+	case LimitByPerIpType:
+		return `key: "0.0.0.0/0"`
+	case LimitByConsumerType:
+		return `key: "<consumer-name>"`
+	case LimitByHeaderType, LimitByParamType, LimitByCookieType:
+		return `key: "<exact-value>"`
+	case LimitByPerConsumerType, LimitByPerHeaderType, LimitByPerParamType, LimitByPerCookieType:
+		return `key: "*"`
+	default:
+		return `key: "<value>"`
+	}
 }
 
 func createConfigItemFromRate(item gjson.Result, itemType LimitConfigItemType, key string, ipNet *iptree.IPTree, regexp *re.Regexp) (*LimitConfigItem, error) {

--- a/plugins/wasm-go/extensions/ai-token-ratelimit/config/config_test.go
+++ b/plugins/wasm-go/extensions/ai-token-ratelimit/config/config_test.go
@@ -284,3 +284,69 @@ func TestParseAiTokenRateLimitConfig_RuleItemsLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAiTokenRateLimitConfig_ActionableLimitKeyErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		json       string
+		wantErrors []string
+	}{
+		{
+			name: "LiteralPerConsumerSuggestsExactVariant",
+			json: `{
+				"rule_name": "literal-per-consumer",
+				"rule_items": [{
+					"limit_by_per_consumer": "",
+					"limit_keys": [{"key": "alice", "token_per_day": 100}]
+				}]
+			}`,
+			wantErrors: []string{`"limit_by_per_consumer"`, `got "alice"`, `"limit_by_consumer"`, "limit_keys stay the same"},
+		},
+		{
+			name: "MissingPerIpKeysIncludesCIDRExample",
+			json: `{
+				"rule_name": "missing-keys",
+				"rule_items": [{"limit_by_per_ip": "from-remote-addr"}]
+			}`,
+			wantErrors: []string{"missing limit_keys", "limit_by_per_ip", `key: "0.0.0.0/0"`},
+		},
+		{
+			name: "EmptyExactKeysIncludesLiteralExample",
+			json: `{
+				"rule_name": "empty-keys",
+				"rule_items": [{"limit_by_header": "x-user", "limit_keys": []}]
+			}`,
+			wantErrors: []string{"limit_keys cannot be empty", "limit_by_header", `key: "<exact-value>"`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config AiTokenRateLimitConfig
+			err := ParseAiTokenRateLimitConfig(gjson.Parse(tt.json), &config)
+			if assert.Error(t, err) {
+				for _, want := range tt.wantErrors {
+					assert.Contains(t, err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseAiTokenRateLimitConfig_AcceptsSupportedLimitKeyForms(t *testing.T) {
+	tests := []struct {
+		name string
+		item string
+	}{
+		{name: "Exact", item: `{"limit_by_header":"x-user","limit_keys":[{"key":"alice","token_per_second":1}]}`},
+		{name: "Wildcard", item: `{"limit_by_per_header":"x-user","limit_keys":[{"key":"*","token_per_second":1}]}`},
+		{name: "Regexp", item: `{"limit_by_per_consumer":"","limit_keys":[{"key":"regexp:^team-","token_per_second":1}]}`},
+		{name: "CIDR", item: `{"limit_by_per_ip":"from-remote-addr","limit_keys":[{"key":"0.0.0.0/0","token_per_second":1}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config AiTokenRateLimitConfig
+			raw := fmt.Sprintf(`{"rule_name":"valid-key","rule_items":[%s]}`, tt.item)
+			assert.NoError(t, ParseAiTokenRateLimitConfig(gjson.Parse(raw), &config))
+		})
+	}
+}

--- a/plugins/wasm-go/extensions/cluster-key-rate-limit/README.md
+++ b/plugins/wasm-go/extensions/cluster-key-rate-limit/README.md
@@ -58,11 +58,11 @@ description: 基于 Key 集群限流插件配置参考
 | limit_by_param        | string          | 否，`limit_by_*` 中选填一项 | -      | 配置获取限流键值的来源 URL 参数名称                                                                                                                                     |
 | limit_by_consumer     | string          | 否，`limit_by_*` 中选填一项 | -      | 根据 consumer 名称进行限流，无需添加实际值                                                                                                                               |
 | limit_by_cookie       | string          | 否，`limit_by_*` 中选填一项 | -      | 配置获取限流键值的来源 Cookie中 key 名称                                                                                                                               |
-| limit_by_per_header   | string          | 否，`limit_by_*` 中选填一项 | -      | 按规则匹配特定 HTTP 请求头，并对每个请求头分别计算限流，配置获取限流键值的来源 HTTP 请求头名称，配置 `limit_keys` 时支持正则表达式或 `*`                                                                      |
-| limit_by_per_param    | string          | 否，`limit_by_*` 中选填一项 | -      | 按规则匹配特定 URL 参数，并对每个参数分别计算限流，配置获取限流键值的来源 URL 参数名称，配置 `limit_keys` 时支持正则表达式或 `*`                                                                           |
-| limit_by_per_consumer | string          | 否，`limit_by_*` 中选填一项 | -      | 按规则匹配特定 consumer，并对每个 consumer 分别计算限流，根据 consumer 名称进行限流，无需添加实际值，配置 `limit_keys` 时支持正则表达式或 `*`                                                           |
-| limit_by_per_cookie   | string          | 否，`limit_by_*` 中选填一项 | -      | 按规则匹配特定 Cookie，并对每个 Cookie 分别计算限流，配置获取限流键值的来源 Cookie中 key 名称，配置 `limit_keys` 时支持正则表达式或 `*`                                                               |
-| limit_by_per_ip       | string          | 否，`limit_by_*` 中选填一项 | -      | 按规则匹配特定 IP，并对每个 IP 分别计算限流，配置获取限流键值的来源 IP 参数名称，从请求头获取，以 `from-header-对应的header名`，示例：`from-header-x-forwarded-for`，直接获取对端 socket ip，配置为 `from-remote-addr` |
+| limit_by_per_header   | string          | 否，`limit_by_*` 中选填一项 | -      | 按请求头值分别计算限流；`limit_keys` **不可填字面名，仅接受 `*` 或 `regexp:...`**。精确匹配请改用 `limit_by_header`（去掉 `per_`） |
+| limit_by_per_param    | string          | 否，`limit_by_*` 中选填一项 | -      | 按 URL 参数值分别计算限流；`limit_keys` **不可填字面名，仅接受 `*` 或 `regexp:...`**。精确匹配请改用 `limit_by_param`（去掉 `per_`） |
+| limit_by_per_consumer | string          | 否，`limit_by_*` 中选填一项 | -      | 按 consumer 分别计算限流；`limit_keys` **不可填字面名，仅接受 `*` 或 `regexp:...`**。精确匹配请改用 `limit_by_consumer`（去掉 `per_`） |
+| limit_by_per_cookie   | string          | 否，`limit_by_*` 中选填一项 | -      | 按 Cookie 值分别计算限流；`limit_keys` **不可填字面名，仅接受 `*` 或 `regexp:...`**。精确匹配请改用 `limit_by_cookie`（去掉 `per_`） |
+| limit_by_per_ip       | string          | 否，`limit_by_*` 中选填一项 | -      | 选择客户端 IP 来源：`from-header-<header名>` 或 `from-remote-addr`；IP/CIDR 必须写在 `limit_keys[].key` 中 |
 | limit_keys            | array of object | 是                    | -      | 配置匹配键值后的限流次数                                                                                                                                             |
 
 #### `rule_items` 多规则匹配语义
@@ -81,7 +81,7 @@ description: 基于 Key 集群限流插件配置参考
 
 | 配置项           | 类型   | 必填                                                         | 默认值 | 说明                                                         |
 | ---------------- | ------ | ------------------------------------------------------------ | ------ | ------------------------------------------------------------ |
-| key              | string | 是                                                           | -      | 匹配的键值，`limit_by_per_header`,`limit_by_per_param`,`limit_by_per_consumer`,`limit_by_per_cookie` 类型支持配置正则表达式（以regexp:开头后面跟正则表达式）或者*（代表所有），正则表达式示例：`regexp:^d.*`（以d开头的所有字符串）；`limit_by_per_ip`支持配置 IP 地址或 IP 段 |
+| key              | string | 是                                                           | -      | 非 `per_` 类型接受精确字面值；`limit_by_per_header`、`limit_by_per_param`、`limit_by_per_consumer`、`limit_by_per_cookie` 仅接受 `regexp:...` 或 `*`；`limit_by_per_ip` 接受 IP 地址或 CIDR |
 | query_per_second | int    | 否，`query_per_second`,`query_per_minute`,`query_per_hour`,`query_per_day` 中选填一项 | -      | 允许每秒请求次数                                             |
 | query_per_minute | int    | 否，`query_per_second`,`query_per_minute`,`query_per_hour`,`query_per_day` 中选填一项 | -      | 允许每分钟请求次数                                           |
 | query_per_hour   | int    | 否，`query_per_second`,`query_per_minute`,`query_per_hour`,`query_per_day` 中选填一项 | -      | 允许每小时请求次数                                           |
@@ -137,6 +137,75 @@ redis:
   service_name: redis.static
 show_limit_quota_header: true
 ```
+
+## 常见错误
+
+### `limit_by_per_consumer` 中填写字面 consumer 名称
+
+```yaml
+# ❌ 错误：per_consumer 的 limit_keys 仅接受 * 或 regexp:...
+rule_items:
+  - limit_by_per_consumer: ""
+    limit_keys:
+      - key: "alice"
+        query_per_day: 100
+
+# ✅ 正确：精确匹配名称时去掉 per_
+rule_items:
+  - limit_by_consumer: ""
+    limit_keys:
+      - key: "alice"
+        query_per_day: 100
+```
+
+### 把 CIDR 填到 `limit_by_per_ip`
+
+```yaml
+# ❌ 错误：limit_by_per_ip 选择 IP 来源，不接受 CIDR
+rule_items:
+  - limit_by_per_ip: "0.0.0.0/0"
+
+# ✅ 正确：CIDR 写入 limit_keys
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+    limit_keys:
+      - key: "0.0.0.0/0"
+        query_per_day: 1000
+```
+
+### 遗漏 `limit_keys`
+
+```yaml
+# ❌ 错误：整个 rule_item 会被拒绝
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+
+# ✅ 正确：至少提供一个 key 和请求阈值
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+    limit_keys:
+      - key: "0.0.0.0/0"
+        query_per_day: 1000
+```
+
+## 诊断
+
+完整排查步骤见[限流插件 FAQ](../../../../docs/faq/rate-limit-plugin-faq.md#rate-limit-not-taking-effect)。
+
+| 现象 | 优先判断 |
+| --- | --- |
+| 请求始终返回 200，Redis 中没有限流 key | 规则未匹配，或配置解析失败导致规则未加载 |
+| Redis cluster 的 `cx_connect_fail` 大于 0 | 端口、认证或网络连接异常 |
+| Wasm `update_rejected` / `config_fail` 持续增长 | 新配置被解析器拒绝；先检查网关日志中的具体错误 |
+
+```bash
+kubectl -n higress-system logs <gateway-pod> --tail=2000 \
+  | grep -Ei 'cluster-key-rate-limit|limit_by_per_|missing limit_keys|must start with'
+```
+
+`config_dump` 中能看到配置只说明控制面已下发，不能证明数据面插件已成功加载；需要结合 `/stats`、`/clusters` 和网关日志判断。
+
+## 配置示例（续）
 
 ### 识别请求头 x-ca-key，进行区别限流
 

--- a/plugins/wasm-go/extensions/cluster-key-rate-limit/README_EN.md
+++ b/plugins/wasm-go/extensions/cluster-key-rate-limit/README_EN.md
@@ -60,11 +60,11 @@ It supports three rate limiting modes:
 | limit_by_param                | string        | No (choose one of `limit_by_*` fields) | -           | Configures the URL parameter name to extract the rate limiting key.        |  
 | limit_by_consumer             | string        | No (choose one of `limit_by_*` fields) | -           | Rate limits based on the consumer name (no need to add a specific value).   |  
 | limit_by_cookie               | string        | No (choose one of `limit_by_*` fields) | -           | Configures the Cookie key name to extract the rate limiting key.           |  
-| limit_by_per_header           | string        | No (choose one of `limit_by_*` fields) | -           | Matches specific HTTP headers by rule and calculates rate limits for each header. Supports regular expressions (starting with `regexp:`) or `*` for the `limit_keys` configuration. |  
-| limit_by_per_param            | string        | No (choose one of `limit_by_*` fields) | -           | Matches specific URL parameters by rule and calculates rate limits for each parameter. Supports regular expressions (starting with `regexp:`) or `*` for the `limit_keys` configuration. |  
-| limit_by_per_consumer         | string        | No (choose one of `limit_by_*` fields) | -           | Matches specific consumers by rule and calculates rate limits for each consumer. Supports regular expressions (starting with `regexp:`) or `*` for the `limit_keys` configuration (no need to add a specific value for the consumer name). |  
-| limit_by_per_cookie           | string        | No (choose one of `limit_by_*` fields) | -           | Matches specific Cookies by rule and calculates rate limits for each Cookie value. Supports regular expressions (starting with `regexp:`) or `*` for the `limit_keys` configuration. |  
-| limit_by_per_ip               | string        | No (choose one of `limit_by_*` fields) | -           | Matches specific IPs by rule and calculates rate limits for each IP. The IP can be extracted from a request header (formatted as `from-header-<header_name>`, e.g., `from-header-x-forwarded-for`) or directly from the peer socket IP (configured as `from-remote-addr`). |  
+| limit_by_per_header           | string        | No (choose one of `limit_by_*` fields) | -           | Calculates a separate limit per header value. `limit_keys` **MUST NOT be a literal name; only `*` or `regexp:...` is accepted**. For an exact match, use `limit_by_header` (drop `per_`). |
+| limit_by_per_param            | string        | No (choose one of `limit_by_*` fields) | -           | Calculates a separate limit per parameter value. `limit_keys` **MUST NOT be a literal name; only `*` or `regexp:...` is accepted**. For an exact match, use `limit_by_param` (drop `per_`). |
+| limit_by_per_consumer         | string        | No (choose one of `limit_by_*` fields) | -           | Calculates a separate limit per consumer. `limit_keys` **MUST NOT be a literal name; only `*` or `regexp:...` is accepted**. For an exact match, use `limit_by_consumer` (drop `per_`). |
+| limit_by_per_cookie           | string        | No (choose one of `limit_by_*` fields) | -           | Calculates a separate limit per Cookie value. `limit_keys` **MUST NOT be a literal name; only `*` or `regexp:...` is accepted**. For an exact match, use `limit_by_cookie` (drop `per_`). |
+| limit_by_per_ip               | string        | No (choose one of `limit_by_*` fields) | -           | Selects the client-IP source: `from-header-<header_name>` or `from-remote-addr`. Put IP/CIDR values in `limit_keys[].key`. |
 | limit_keys                    | array of object | Yes                               | -           | Configures the rate limits for matched key values.                          |  
 
 #### `rule_items` Multi-Rule Matching Semantics
@@ -83,7 +83,7 @@ When multiple rules are matched and none trigger (with `show_limit_quota_header:
 
 | Configuration Item       | Type   | Required                                 | Default Value | Description                                                                 |  
 |--------------------------|--------|------------------------------------------|---------------|-----------------------------------------------------------------------------|  
-| key                      | string | Yes                                      | -             | The matched key value. For `limit_by_per_header`, `limit_by_per_param`, `limit_by_per_consumer`, and `limit_by_per_cookie` types, supports regular expressions (prefixed with `regexp:`) or `*` (wildcard for all). Example regular expression: `regexp:^d.*` (matches all strings starting with `d`). For `limit_by_per_ip`, supports IP addresses or CIDR blocks. |  
+| key                      | string | Yes                                      | -             | Non-`per_` types accept exact literals. `limit_by_per_header`, `limit_by_per_param`, `limit_by_per_consumer`, and `limit_by_per_cookie` accept only `regexp:...` or `*`. `limit_by_per_ip` accepts IP addresses or CIDR blocks. |
 | query_per_second         | int    | No (choose one of `query_per_second`, `query_per_minute`, `query_per_hour`, `query_per_day`) | -           | Allowed requests per second.                                                |  
 | query_per_minute         | int    | No (choose one of `query_per_second`, `query_per_minute`, `query_per_hour`, `query_per_day`) | -           | Allowed requests per minute.                                                |  
 | query_per_hour           | int    | No (choose one of `query_per_second`, `query_per_minute`, `query_per_hour`, `query_per_day`) | -           | Allowed requests per hour.                                                  |  
@@ -139,6 +139,75 @@ redis:
   service_name: redis.static
 show_limit_quota_header: true
 ```
+
+## Common Pitfalls
+
+### Literal consumer name under `limit_by_per_consumer`
+
+```yaml
+# ❌ Wrong: per_consumer limit_keys accepts only * or regexp:...
+rule_items:
+  - limit_by_per_consumer: ""
+    limit_keys:
+      - key: "alice"
+        query_per_day: 100
+
+# ✅ Right: drop per_ for an exact-name match
+rule_items:
+  - limit_by_consumer: ""
+    limit_keys:
+      - key: "alice"
+        query_per_day: 100
+```
+
+### CIDR placed in `limit_by_per_ip`
+
+```yaml
+# ❌ Wrong: limit_by_per_ip selects the IP source; it is not a CIDR field
+rule_items:
+  - limit_by_per_ip: "0.0.0.0/0"
+
+# ✅ Right: put the CIDR in limit_keys
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+    limit_keys:
+      - key: "0.0.0.0/0"
+        query_per_day: 1000
+```
+
+### Missing `limit_keys`
+
+```yaml
+# ❌ Wrong: the entire rule_item is rejected
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+
+# ✅ Right: provide at least one key and request threshold
+rule_items:
+  - limit_by_per_ip: "from-remote-addr"
+    limit_keys:
+      - key: "0.0.0.0/0"
+        query_per_day: 1000
+```
+
+## Diagnosing
+
+See the [Rate-limit Plugin FAQ](../../../../docs/faq/rate-limit-plugin-faq-en.md#rate-limit-not-taking-effect) for complete diagnosis recipes.
+
+| Symptom | Check first |
+| --- | --- |
+| Requests always return 200 and Redis has no rate-limit keys | No rule matched, or configuration parsing prevented the rule from loading |
+| Redis cluster `cx_connect_fail` is greater than 0 | Port, credentials, or network connectivity |
+| Wasm `update_rejected` / `config_fail` keeps increasing | The parser rejected the pushed configuration; inspect the concrete gateway log error |
+
+```bash
+kubectl -n higress-system logs <gateway-pod> --tail=2000 \
+  | grep -Ei 'cluster-key-rate-limit|limit_by_per_|missing limit_keys|must start with'
+```
+
+Seeing configuration in `config_dump` proves only that the control plane delivered it; it does not prove that the data-plane plugin loaded it. Correlate `/stats`, `/clusters`, and gateway logs.
+
+## Configuration Examples (continued)
 
 ### Rate Limiting by Request Header `x-ca-key`
 

--- a/plugins/wasm-go/extensions/cluster-key-rate-limit/config/config.go
+++ b/plugins/wasm-go/extensions/cluster-key-rate-limit/config/config.go
@@ -308,10 +308,12 @@ func parseLimitRuleItem(item gjson.Result) (*LimitRuleItem, error) {
 func initConfigItems(json gjson.Result, rule *LimitRuleItem) error {
 	limitKeys := json.Get("limit_keys")
 	if !limitKeys.Exists() {
-		return errors.New("missing limit_keys in config")
+		return fmt.Errorf("missing limit_keys in config for %s; add at least one entry, e.g. %s",
+			rule.LimitType, exampleLimitKeyForType(rule.LimitType))
 	}
 	if len(limitKeys.Array()) == 0 {
-		return errors.New("config limit_keys cannot be empty")
+		return fmt.Errorf("config limit_keys cannot be empty for %s; add at least one entry, e.g. %s",
+			rule.LimitType, exampleLimitKeyForType(rule.LimitType))
 	}
 	var configItems []LimitConfigItem
 	for _, item := range limitKeys.Array() {
@@ -348,7 +350,12 @@ func initConfigItems(json gjson.Result, rule *LimitRuleItem) error {
 				}
 				itemType = RegexpType
 			} else {
-				return fmt.Errorf("the '%s' restriction must start with 'regexp:' or be exactly '*'", rule.LimitType)
+				return fmt.Errorf(
+					"the %q restriction must start with 'regexp:' or be exactly '*' (got %q); "+
+						"to match an exact name, use the non-per variant %q instead (limit_keys stay the same)",
+					string(rule.LimitType), itemKey,
+					"limit_by_"+strings.TrimPrefix(string(rule.LimitType), "limit_by_per_"),
+				)
 			}
 		} else {
 			itemType = ExactType
@@ -362,6 +369,21 @@ func initConfigItems(json gjson.Result, rule *LimitRuleItem) error {
 	}
 	rule.ConfigItems = configItems
 	return nil
+}
+
+func exampleLimitKeyForType(limitType LimitRuleItemType) string {
+	switch limitType {
+	case LimitByPerIpType:
+		return `key: "0.0.0.0/0"`
+	case LimitByConsumerType:
+		return `key: "<consumer-name>"`
+	case LimitByHeaderType, LimitByParamType, LimitByCookieType:
+		return `key: "<exact-value>"`
+	case LimitByPerConsumerType, LimitByPerHeaderType, LimitByPerParamType, LimitByPerCookieType:
+		return `key: "*"`
+	default:
+		return `key: "<value>"`
+	}
 }
 
 func createConfigItemFromRate(item gjson.Result, itemType LimitConfigItemType, key string, ipNet *iptree.IPTree, regexp *re.Regexp) (*LimitConfigItem, error) {

--- a/plugins/wasm-go/extensions/cluster-key-rate-limit/config/config_test.go
+++ b/plugins/wasm-go/extensions/cluster-key-rate-limit/config/config_test.go
@@ -303,3 +303,69 @@ func TestParseClusterKeyRateLimitConfig_RuleItemsLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestParseClusterKeyRateLimitConfig_ActionableLimitKeyErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		json       string
+		wantErrors []string
+	}{
+		{
+			name: "LiteralPerConsumerSuggestsExactVariant",
+			json: `{
+				"rule_name": "literal-per-consumer",
+				"rule_items": [{
+					"limit_by_per_consumer": "",
+					"limit_keys": [{"key": "alice", "query_per_day": 100}]
+				}]
+			}`,
+			wantErrors: []string{`"limit_by_per_consumer"`, `got "alice"`, `"limit_by_consumer"`, "limit_keys stay the same"},
+		},
+		{
+			name: "MissingPerIpKeysIncludesCIDRExample",
+			json: `{
+				"rule_name": "missing-keys",
+				"rule_items": [{"limit_by_per_ip": "from-remote-addr"}]
+			}`,
+			wantErrors: []string{"missing limit_keys", "limit_by_per_ip", `key: "0.0.0.0/0"`},
+		},
+		{
+			name: "EmptyExactKeysIncludesLiteralExample",
+			json: `{
+				"rule_name": "empty-keys",
+				"rule_items": [{"limit_by_header": "x-user", "limit_keys": []}]
+			}`,
+			wantErrors: []string{"limit_keys cannot be empty", "limit_by_header", `key: "<exact-value>"`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config ClusterKeyRateLimitConfig
+			err := ParseClusterKeyRateLimitConfig(gjson.Parse(tt.json), &config)
+			if assert.Error(t, err) {
+				for _, want := range tt.wantErrors {
+					assert.Contains(t, err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseClusterKeyRateLimitConfig_AcceptsSupportedLimitKeyForms(t *testing.T) {
+	tests := []struct {
+		name string
+		item string
+	}{
+		{name: "Exact", item: `{"limit_by_header":"x-user","limit_keys":[{"key":"alice","query_per_second":1}]}`},
+		{name: "Wildcard", item: `{"limit_by_per_header":"x-user","limit_keys":[{"key":"*","query_per_second":1}]}`},
+		{name: "Regexp", item: `{"limit_by_per_consumer":"","limit_keys":[{"key":"regexp:^team-","query_per_second":1}]}`},
+		{name: "CIDR", item: `{"limit_by_per_ip":"from-remote-addr","limit_keys":[{"key":"0.0.0.0/0","query_per_second":1}]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config ClusterKeyRateLimitConfig
+			raw := fmt.Sprintf(`{"rule_name":"valid-key","rule_items":[%s]}`, tt.item)
+			assert.NoError(t, ParseClusterKeyRateLimitConfig(gjson.Parse(raw), &config))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did

- Make invalid `limit_keys` errors actionable in both `cluster-key-rate-limit` and `ai-token-ratelimit`: errors now name the active rule type, show the rejected value, and suggest the exact non-`per` alternative when a literal is used.
- Add parser tests for the new diagnostics and for all accepted key forms (`exact`, `*`, `regexp:`, and CIDR).
- Clarify the configuration contract in the Chinese and English plugin READMEs, including `limit_by_per_ip` source-vs-CIDR semantics and wrong/right examples.
- Add a shared bilingual FAQ covering configuration diagnosis and Redis/FQDNCluster startup behavior.

Implements the replacement issue-spec Implement #4251 for Design #4079.

## Ⅱ. Does this pull request fix one issue?

fixes #4079

## Ⅲ. Why don't you add test cases (unit test/integration test)?

Unit tests are included in both independent plugin modules. A standalone documentation grep CI job was intentionally not added because it would only duplicate static string checks without exercising runtime behavior; documentation structure, anchors, and local links were validated locally instead.

## Ⅳ. Describe how to verify it

Run in each plugin module:

```bash
go test ./...
go vet ./...
GOOS=wasip1 GOARCH=wasm go build -buildvcs=false -buildmode=c-shared -o /tmp/plugin.wasm .
```

The commands above pass for:

- `plugins/wasm-go/extensions/cluster-key-rate-limit`
- `plugins/wasm-go/extensions/ai-token-ratelimit`

Also verified:

- `git diff --check`
- balanced Markdown code fences in all eight touched documentation files
- README-to-FAQ links, required FAQ anchors, and synchronized Chinese/English FAQ section counts

## Ⅴ. Special notes for reviews

- The accepted configuration grammar and runtime matching behavior are unchanged; this PR changes diagnostics, tests, and documentation only.
- The two plugins are separate Go modules, so the small diagnostic helper is intentionally local to each module rather than introducing a new cross-module dependency.
- `limit_by_per_ip` continues to select the client-IP source; CIDRs continue to belong in `limit_keys`.
- Workflow lineage: Proposal #4072 → Design #4079 → replacement Implement #4251. The superseded Implement #4095 is retained as historical context.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Implement Design #4079 from a fresh replacement Implement using the latest issue-spec CLI. Improve the two rate-limit plugins' configuration errors, tests, bilingual READMEs, and FAQ while preserving accepted runtime behavior. Keep the workflow minimal: use direct single-writer implementation, create no managed PROCESS unless a concrete concurrency or handoff need appears, and do not add low-value mechanical CI checks.

### AI Coding Summary

- Kept the parser grammar unchanged and improved only error context and repair guidance.
- Derived the non-`per` alternative from the existing naming invariant to keep diagnostics aligned as rule types evolve.
- Added type-aware examples for missing/empty `limit_keys` and regression coverage for every accepted key class.
- Updated both plugin modules and both languages together; added shared FAQ anchors for stable deep links.
- Avoided a standalone documentation grep workflow because local structural validation provides the same signal without adding a new delivery gate.
