### PR TITLE
bugfix: fix unsafe type assertions in ai-quota and ai-cache plugins

### DIFF
--- a/plugins/wasm-go/extensions/ai-cache/util.go
+++ b/plugins/wasm-go/extensions/ai-cache/util.go
@@ -17,7 +17,11 @@ func handleNonStreamChunk(ctx wrapper.HttpContext, c config.PluginConfig, chunk 
 		ctx.SetContext(CACHE_CONTENT_CONTEXT_KEY, chunk)
 		return nil
 	}
-	tempContent := tempContentI.([]byte)
+	tempContent, ok := tempContentI.([]byte)
+	if !ok {
+		ctx.SetContext(CACHE_CONTENT_CONTEXT_KEY, chunk)
+		return nil
+	}
 	tempContent = append(tempContent, chunk...)
 	ctx.SetContext(CACHE_CONTENT_CONTEXT_KEY, tempContent)
 	return nil
@@ -34,7 +38,12 @@ func handleStreamChunk(ctx wrapper.HttpContext, c config.PluginConfig, chunk []b
 	partialMessageI := ctx.GetContext(PARTIAL_MESSAGE_CONTEXT_KEY)
 	log.Debugf("[handleStreamChunk] cache content: %v", ctx.GetContext(CACHE_CONTENT_CONTEXT_KEY))
 	if partialMessageI != nil {
-		partialMessage = append(partialMessageI.([]byte), chunk...)
+		pm, ok := partialMessageI.([]byte)
+		if !ok {
+			partialMessage = chunk
+		} else {
+			partialMessage = append(pm, chunk...)
+		}
 	} else {
 		partialMessage = chunk
 	}
@@ -59,7 +68,12 @@ func processNonStreamLastChunk(ctx wrapper.HttpContext, c config.PluginConfig, c
 	var body []byte
 	tempContentI := ctx.GetContext(CACHE_CONTENT_CONTEXT_KEY)
 	if tempContentI != nil {
-		body = append(tempContentI.([]byte), chunk...)
+		tc, ok := tempContentI.([]byte)
+		if ok {
+			body = append(tc, chunk...)
+		} else {
+			body = chunk
+		}
 	} else {
 		body = chunk
 	}
@@ -76,7 +90,12 @@ func processStreamLastChunk(ctx wrapper.HttpContext, c config.PluginConfig, chun
 		var lastMessage []byte
 		partialMessageI := ctx.GetContext(PARTIAL_MESSAGE_CONTEXT_KEY)
 		if partialMessageI != nil {
-			lastMessage = append(partialMessageI.([]byte), chunk...)
+			pm, ok := partialMessageI.([]byte)
+			if ok {
+				lastMessage = append(pm, chunk...)
+			} else {
+				lastMessage = chunk
+			}
 		} else {
 			lastMessage = chunk
 		}
@@ -92,7 +111,9 @@ func processStreamLastChunk(ctx wrapper.HttpContext, c config.PluginConfig, chun
 		// 此时从 ctx 取已累积的缓存内容，避免缓存写空。
 		if value == "" {
 			if tempContentI := ctx.GetContext(CACHE_CONTENT_CONTEXT_KEY); tempContentI != nil {
-				value = tempContentI.(string)
+				if s, ok := tempContentI.(string); ok {
+					value = s
+				}
 			}
 		}
 		return value, nil
@@ -101,7 +122,11 @@ func processStreamLastChunk(ctx wrapper.HttpContext, c config.PluginConfig, chun
 	if tempContentI == nil {
 		return "", nil
 	}
-	return tempContentI.(string), nil
+	s, ok := tempContentI.(string)
+	if !ok {
+		return "", nil
+	}
+	return s, nil
 }
 
 func processSSEMessage(ctx wrapper.HttpContext, c config.PluginConfig, sseMessage string, log log.Log) (string, error) {
@@ -158,15 +183,17 @@ func processSSEMessage(ctx wrapper.HttpContext, c config.PluginConfig, sseMessag
 	if content != "" {
 		if v := ctx.GetContext(CACHE_CONTENT_CONTEXT_KEY); v == nil {
 			ctx.SetContext(CACHE_CONTENT_CONTEXT_KEY, content)
-		} else {
-			ctx.SetContext(CACHE_CONTENT_CONTEXT_KEY, v.(string)+content)
+		} else if s, ok := v.(string); ok {
+			ctx.SetContext(CACHE_CONTENT_CONTEXT_KEY, s+content)
 		}
 	}
 
 	// handleStreamChunk 不使用返回值；processStreamLastChunk 把它作为 cacheResponse 的
 	// SET value，必须是完整累积值（避免最后一段 content 因 [DONE] 早 return 被丢）。
 	if v := ctx.GetContext(CACHE_CONTENT_CONTEXT_KEY); v != nil {
-		return v.(string), nil
+		if s, ok := v.(string); ok {
+			return s, nil
+		}
 	}
 	return "", nil
 }

--- a/plugins/wasm-go/extensions/ai-quota/main.go
+++ b/plugins/wasm-go/extensions/ai-quota/main.go
@@ -258,9 +258,18 @@ func onHttpStreamingResponseBody(ctx wrapper.HttpContext, config QuotaConfig, da
 		return data
 	}
 
-	inputToken := ctx.GetContext(tokenusage.CtxKeyInputToken).(int64)
-	outputToken := ctx.GetContext(tokenusage.CtxKeyOutputToken).(int64)
-	consumer := ctx.GetContext("consumer").(string)
+	inputToken, ok := ctx.GetContext(tokenusage.CtxKeyInputToken).(int64)
+	if !ok {
+		return data
+	}
+	outputToken, ok := ctx.GetContext(tokenusage.CtxKeyOutputToken).(int64)
+	if !ok {
+		return data
+	}
+	consumer, ok := ctx.GetContext("consumer").(string)
+	if !ok {
+		return data
+	}
 	totalToken := int(inputToken + outputToken)
 	log.Debugf("update consumer:%s, totalToken:%d", consumer, totalToken)
 	config.redisClient.DecrBy(config.RedisKeyPrefix+consumer, totalToken, nil)


### PR DESCRIPTION
## I. What does this PR do

Fixes unsafe type assertions in the ai-quota and ai-cache plugins that could panic if context values contain unexpected types.

### Root Cause

Both plugins use bare type assertions on `ctx.GetContext()` values. While nil checks exist in most locations, type checks are missing — if a context key is set to a different type (e.g. by a plugin interaction or race condition), the bare assertion panics.

### Fix

**ai-quota/main.go** (3 assertions in `onHttpStreamingResponseBody`):
- `inputToken.(int64)` → comma-ok pattern, return `data` if not int64
- `outputToken.(int64)` → comma-ok pattern, return `data` if not int64
- `consumer.(string)` → comma-ok pattern, return `data` if not string

**ai-cache/util.go** (8 assertions across 5 functions):
- `handleNonStreamChunk`: type check for `tempContentI.([]byte)`
- `handleStreamChunk`: type check for `partialMessageI.([]byte)`
- `processNonStreamLastChunk`: type check for `tempContentI.([]byte)`
- `processStreamLastChunk`: type checks for `partialMessageI.([]byte)` and `tempContentI.(string)`
- `processSSEMessage`: type checks for cache content string assertions (2 locations)

## II. Fixes Issue

Related to general stability improvements for ai-quota and ai-cache plugins.

## III. Why no test cases

Both plugins require Wasm runtime and Redis/cache infrastructure to test. The fix follows the same defensive pattern approved in #4226.

## IV. How to verify

- `cd plugins/wasm-go/extensions/ai-quota && GOOS=wasip1 GOARCH=wasm go build ./...` — compiles
- `cd plugins/wasm-go/extensions/ai-cache && GOOS=wasip1 GOARCH=wasm go build ./...` — compiles

## V. Special notes for reviewers

- Same pattern as #4226 (WAF plugin, approved by @johnlanni) and #4255 (SSE proxy)
- When context types don't match, functions return early with safe defaults instead of panicking
- ai-quota: returns `data` (passing through the streaming body unchanged)
- ai-cache: falls back to treating the chunk as the initial content or returns empty string

## VI. AI Coding Tool Usage Checklist

- [x] Used AI coding tools: Yes (AI-assisted code analysis and fix generation)
- [ ] New standalone plugin scenario: N/A (bug fix in existing code)
- [x] Regular modification scenario: AI analyzed the ai-quota and ai-cache plugin context usage to identify all unsafe type assertions