### PR TITLE
ci: define CodeQL Go build targets

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -45,29 +45,19 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
+          build-mode: manual
+          source-root: .
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       # step 3
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: "Autobuild"
-        uses: github/codeql-action/autobuild@v4
+      - name: "Build Go binaries"
+        run: |
+          make build
+          make build-hgctl
 
       # step 4
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
-      #- run: |
-      #   make bootstrap
-      #   make release
-
-      # step 5
       - name: "Perform CodeQL Analysis"
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

- switch CodeQL for Go from autobuild to manual build mode
- set an explicit source root for incremental pull-request analysis
- build both shipped Go binaries: the Higress controller and the standalone `hgctl` CLI

This does not add an `hgctl` runtime dependency to the controller. The two binaries are built separately so CodeQL can trace both of them.

## Why

CodeQL autobuild discovers `hgctl` as a nested Go module, but its standalone extraction fails while resolving the module graph. This leaves the configuration page with both "Go files were found but not processed" and "Unable to extract some Go projects: hgctl", even though the workflow itself is green.

Adding the reported checksum entries did not fix the extractor, so this PR gives CodeQL the supported repository build commands instead.

## Validation

- `make build-hgctl` passes in the Linux CodeQL runner
- [full non-PR CodeQL run](https://github.com/EndlessSeeker/higress/actions/runs/30885102100) completed successfully
- that full run no longer reported either extraction diagnostic
- the full run completed in 13m50s

## Trade-off

Manual mode analyzes code reached by the controller and `hgctl` production builds. In the full comparison run, CodeQL tracked 276/989 source files (493,527 Go LOC), versus 646/989 files (569,419 Go LOC) with autobuild. This is a narrower, production-build-oriented database, but it removes the incomplete-extraction state and includes the separately shipped `hgctl` binary.