### PR TITLE
docs: refresh CNCF incubation readiness status

### DIFF
--- a/docs/cncf/general-technical-review.md
+++ b/docs/cncf/general-technical-review.md
@@ -3,10 +3,11 @@
 - **Project:** Higress
 - **Project version:** v2.2.3
 - **Website:** <https://higress.ai/en/>
-- **Date updated:** 2026-07-21
+- **Date updated:** 2026-08-04
 - **Template version:** CNCF General Technical Review v1.0
-- **Review state:** Project working draft; maintainer approval and CNCF Project
-  Reviews verification pending
+- **Review state:** Complete project self-assessment, approved in
+  [higress-group/higress#4177](https://github.com/higress-group/higress/pull/4177);
+  CNCF Project Reviews verification and dated TOC snapshot pending
 - **Evidence branch:**
   [`higress-group/higress@main`](https://github.com/higress-group/higress/tree/main)
 - **Intended TOC snapshot:** `projects/higress/tech-review/YYYY-MM-DD.md`
@@ -273,9 +274,10 @@ in ephemeral clusters and runs Gateway API and Higress conformance traffic.
 - **Explicit trust and boundaries:** Kubernetes administrators, xDS,
   certificate sources, plugins, registries, identity providers, and upstreams
   are separate trust boundaries described in the security self-assessment.
-- **Secure lifecycle:** public review, automated tests, license checks, weekly
-  CodeQL, private advisories, and coordinated disclosure are in place, with
-  SBOM/signing/dynamic-analysis gaps disclosed.
+- **Secure lifecycle:** public review, automated tests, license checks, CodeQL
+  on pull requests, pushes to `main`, and a weekly schedule, an OpenSSF Best
+  Practices Passing badge, private advisories, and coordinated disclosure are
+  in place, with SBOM/signing/dynamic-analysis gaps disclosed.
 
 Operators can loosen security by overriding pod/container security contexts,
 using privileged or host networking modes, expanding RBAC, exposing admin
@@ -287,11 +289,15 @@ threat model.
 maintained?**
 
 The project uses required review, build and unit tests with Go race detection,
-Gateway API/Higress conformance, plugin tests, license checks, weekly CodeQL,
+Gateway API/Higress conformance, plugin tests, license checks, CodeQL on pull
+requests, pushes to `main`, and a weekly schedule, a Go vet warning gate,
 versioned dependencies, Private Security Advisories, and coordinated
-disclosure. Certificate handling, RBAC reconciliation, xDS generation and
-validation, parsers/routing, authentication and authorization plugins, plugin
-loading, and release artifacts are treated as security-critical boundaries.
+disclosure. The OpenSSF Best Practices badge reached Passing on 2026-08-04,
+with the Critical/High CodeQL remediation and disposition recorded in
+[`#4207`](https://github.com/higress-group/higress/issues/4207). Certificate
+handling, RBAC reconciliation, xDS generation and validation, parsers/routing,
+authentication and authorization plugins, plugin loading, and release
+artifacts are treated as security-critical boundaries.
 
 **What privileges are required?**
 

--- a/docs/cncf/governance-review.md
+++ b/docs/cncf/governance-review.md
@@ -6,11 +6,12 @@ Incubation application. It follows the current CNCF TOC
 A CNCF Project Reviews reviewer may amend the assessment and findings during
 the public review.
 
-- **Review state:** Project working draft; maintainer approval and CNCF Project
-  Reviews verification pending
+- **Review state:** Project self-assessment approved in
+  [higress-group/higress#4177](https://github.com/higress-group/higress/pull/4177);
+  public-meeting Must-Fix and CNCF Project Reviews verification pending
 - **Evidence branch:**
   [`higress-group/higress@main`](https://github.com/higress-group/higress/tree/main)
-- **Template verified:** 2026-07-21 against `cncf/toc` `main`
+- **Template verified:** 2026-08-04 against `cncf/toc` `main`
 - **Intended TOC snapshot:**
   `projects/higress/governance-review/YYYY-MM-DD.md`
 
@@ -39,7 +40,7 @@ before asserting that the Governance Review has no remaining Must-Fix item.
 ### Executing the Assessment
 
 The self-assessment reviewed the following repository evidence as it exists on
-2026-07-21:
+2026-08-04:
 
 - [`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/main/GOVERNANCE.md)
 - [`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/main/MAINTAINERS.md)

--- a/docs/cncf/incubation-application.md
+++ b/docs/cncf/incubation-application.md
@@ -2,7 +2,7 @@
 
 This working draft follows the CNCF TOC
 [Project Incubation Application v1.6](https://github.com/cncf/toc/blob/main/.github/ISSUE_TEMPLATE/template-incubation-application.md),
-verified on 2026-07-21. It is not ready to file while any item labelled
+verified on 2026-08-04. It is not ready to file while any item labelled
 **BLOCKED** below remains unresolved.
 
 ## Review Project Moving Level Evaluation
@@ -12,8 +12,8 @@ verified on 2026-07-21. It is not ready to file while any item labelled
   will result in closure.
 
 This box remains unchecked because the public meeting, access-control evidence,
-OpenSSF Passing badge, adopter interviews/verification, and remaining
-vendor-neutral resource work are incomplete.
+adopter interviews/verification, and remaining vendor-neutral resource work are
+incomplete.
 
 ## Project information
 
@@ -39,8 +39,9 @@ vendor-neutral resource work are incomplete.
 
 ### Application Level Assertion
 
-- [x] Higress is currently Sandbox, accepted on 2026-03-15, and is applying to
-  Incubation.
+- [x] Higress is currently Sandbox. Its
+  [Sandbox vote passed on 2026-03-12](https://github.com/cncf/sandbox/issues/445#issuecomment-4044548879),
+  and it is applying to Incubation.
 - [ ] Higress is applying to join CNCF directly at Incubation level. Not
   applicable; remove this option from the filed issue.
 
@@ -67,7 +68,9 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
 
 - [x] Complete a General Technical Review. The project self-assessment is in
   [`general-technical-review.md`](https://github.com/higress-group/higress/blob/main/docs/cncf/general-technical-review.md);
-  maintainer approval and CNCF Project Reviews verification are requested.
+  the project copy was approved and merged in
+  [#4177](https://github.com/higress-group/higress/pull/4177), and CNCF Project
+  Reviews verification and the required dated TOC snapshot remain pending.
 - [ ] Complete a Governance Review. The self-assessment is in
   [`governance-review.md`](https://github.com/higress-group/higress/blob/main/docs/cncf/governance-review.md),
   but its public-meeting Must-Fix remains open.
@@ -81,7 +84,8 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
   application needs a maintainer/CNCF-reviewed compatibility and infrastructure
   plan.
 - [x] Review and acknowledgement of Sandbox expectations and maturity-level
-  requirements. Higress was accepted as a Sandbox project on 2026-03-15 and
+  requirements. The Higress Sandbox vote passed on 2026-03-12, onboarding was
+  [completed on 2026-06-17](https://github.com/cncf/sandbox/issues/481), and
   this application explicitly acknowledges the current requirements.
 - [ ] Due Diligence Review. This is completed through CNCF review, resolution
   of concerns, and public comment after a ready application is filed.
@@ -185,10 +189,15 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
   conflicts, report handling, and escalation are documented.
 - [x] The Security Self-Assessment is documented in
   [`security-self-assessment.md`](https://github.com/higress-group/higress/blob/main/docs/cncf/security-self-assessment.md).
-- [ ] **BLOCKED — OpenSSF Best Practices Passing badge.** The public entry is
-  currently 96%. Warning enforcement/remediation, static-analysis frequency,
-  confirmed CodeQL alert disposition, and project-level dynamic analysis remain
-  before the badge can be certified as Passing.
+- [x] Higress has achieved the
+  [OpenSSF Best Practices Passing badge](https://www.bestpractices.dev/projects/12667).
+  The result was verified on 2026-08-04. The supporting work includes CodeQL on
+  pull requests, pushes to `main`, and a weekly schedule
+  ([#4186](https://github.com/higress-group/higress/pull/4186)); an enforced Go
+  vet warning gate
+  ([#4193](https://github.com/higress-group/higress/pull/4193)); and an auditable
+  disposition for all tracked Critical/High CodeQL findings
+  ([#4207](https://github.com/higress-group/higress/issues/4207)).
 
 ## Ecosystem
 
@@ -211,8 +220,12 @@ the following required items remain open:
 
 1. a real public meeting scheduler and/or CNCF calendar integration;
 2. enforced repository access-control evidence;
-3. OpenSSF Best Practices Passing, including warning enforcement, analysis
-   frequency, alert disposition, and dynamic analysis;
-4. vendor-neutral resource/website remediation or an accepted migration plan;
-5. 5–7 adopter interview submissions and later TOC verification; and
-6. direct project point-of-contact emails confirmed for the issue.
+3. vendor-neutral resource/website remediation or an accepted migration plan;
+4. 5–7 adopter interview submissions and later TOC verification; and
+5. direct project point-of-contact emails confirmed for the issue.
+
+OpenSSF Best Practices is no longer a filing blocker. Before final filing, the
+project should also open the CNCF Project Reviews requests and coordinate the
+required vetted GTR, Governance Review, and Security Self-Assessment snapshots.
+CNCF reviewer availability should not be treated as a project-side blocker once
+all required project criteria and review requests are complete.

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -4,7 +4,7 @@
 
 | | |
 | --- | --- |
-| Assessment stage | Complete working draft, pending maintainer approval; updated 2026-07-21 |
+| Assessment stage | Complete project self-assessment, approved in [higress-group/higress#4177](https://github.com/higress-group/higress/pull/4177); updated 2026-08-04 |
 | Software | <https://github.com/higress-group/higress> |
 | Review state | Prepared from public project evidence; no independent security review or audit |
 | Evidence branch | [`higress-group/higress@main`](https://github.com/higress-group/higress/tree/main) |
@@ -21,7 +21,7 @@
 | Vulnerability reporting and response | [`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md) |
 | Architecture | [`docs/architecture.md`](https://github.com/higress-group/higress/blob/main/docs/architecture.md) |
 | Helm defaults | [`helm/core/values.yaml`](https://github.com/higress-group/higress/blob/main/helm/core/values.yaml) |
-| OpenSSF Best Practices | <https://www.bestpractices.dev/projects/12667> |
+| OpenSSF Best Practices | [Passing](https://www.bestpractices.dev/projects/12667), verified 2026-08-04 |
 
 This is the project-maintained working copy. For formal Due Diligence, a vetted
 snapshot must be archived at the path above in `cncf/toc`. The reviewer should
@@ -179,15 +179,15 @@ requests run license header and dependency-license checks.
 
 Pull requests are publicly reviewed and run build/unit tests with Go race
 detection, Gateway API and Higress conformance tests, plugin tests, and license
-checks. CodeQL is scheduled weekly; it is not currently a pull-request gate.
-The configured `golangci-lint` execution is commented out because of existing
-findings. Release tags trigger image and CLI/CRD artifact builds. Dependency
-inputs are versioned, but release artifacts do not currently have a
-project-generated SBOM, signature, or SLSA provenance. Not all workflow actions
-are pinned to immutable commits. The public repository does not prove a
-required reviewer count, signed-commit requirement, organization-wide 2FA, or
-branch-protection configuration; those controls require separate repository-
-settings evidence.
+checks. CodeQL runs on pull requests targeting `main`, pushes to `main`, and a
+weekly schedule; the project also enforces a Go vet warning gate. The configured
+`golangci-lint` execution is commented out because of existing findings.
+Release tags trigger image and CLI/CRD artifact builds. Dependency inputs are
+versioned, but release artifacts do not currently have a project-generated
+SBOM, signature, or SLSA provenance. Not all workflow actions are pinned to
+immutable commits. The public repository does not prove a required reviewer
+count, signed-commit requirement, organization-wide 2FA, or branch-protection
+configuration; those controls require separate repository-settings evidence.
 
 Ordinary project-team communication uses GitHub issues, pull requests,
 discussions, mailing, localized community channels, and Discord. Inbound users
@@ -228,10 +228,6 @@ Advisory and release information, and coordinate timing with the reporter.
 
 ### Known Gaps
 
-- OpenSSF Passing is not complete. Outstanding areas include compiler warning
-  enforcement, static-analysis alert remediation, and dynamic analysis.
-- There are unresolved critical/high CodeQL alerts requiring maintainer access,
-  triage, and either fixes or documented upstream/vendor dispositions.
 - Release SBOMs, signatures, and verifiable build provenance are absent.
 - The controller's ClusterRole is broad and its default container security
   context is empty. Gateway non-root defaults depend on Kubernetes/platform
@@ -255,13 +251,17 @@ aggregate vulnerability history or mean-time-to-remediation report.
 
 ### OpenSSF Best Practices
 
-The [Higress OpenSSF entry](https://www.bestpractices.dev/projects/12667) is at
-96% of the Passing badge as of this assessment. Seven criteria remain
-unanswered or unmet: compiler-warning enforcement, strict-warning enforcement,
-warning remediation, static-analysis remediation, static-analysis frequency,
-dynamic analysis, and enabling assertions or equivalent dynamic-analysis
-checks. Passing requires evidence and implementation for all seven, not merely
-updating the questionnaire.
+The [Higress OpenSSF entry](https://www.bestpractices.dev/projects/12667)
+reached **Passing** on 2026-08-04. Supporting evidence includes CodeQL coverage
+for pull requests, pushes to `main`, and weekly scans
+([#4186](https://github.com/higress-group/higress/pull/4186)); an enforced Go
+vet warning gate
+([#4193](https://github.com/higress-group/higress/pull/4193)); and the completed
+Critical/High CodeQL remediation tracker
+([#4207](https://github.com/higress-group/higress/issues/4207)), which records
+zero open Critical and High findings and the disposition of every finding in
+scope. Dedicated project fuzzing/DAST remains a defense-in-depth improvement,
+but it is not an unmet requirement for the achieved Passing badge.
 
 ### Example Use Cases
 


### PR DESCRIPTION
## Summary

- record the OpenSSF Best Practices Passing badge and link the completed CodeQL and Go vet evidence
- refresh the technical review and security self-assessment with the current scan cadence and Critical/High disposition
- correct the Sandbox vote and onboarding dates while keeping the remaining Incubation blockers explicit
- distinguish project-approved review copies from the CNCF-vetted snapshots that are still pending

## Validation

- git diff --check
- verified that the OpenSSF, remediation, pull request, Sandbox vote, and onboarding evidence links resolve successfully

Related: #4207