### PR TITLE
docs: publish Higress community meeting

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -12,8 +12,8 @@ discussions, pull requests, or published meeting notes.
 | [GitHub Issues](https://github.com/higress-group/higress/issues) | Bug reports, feature requests, and work tracking for the primary repository |
 | [GitHub Pull Requests](https://github.com/higress-group/higress/pulls) | Public change proposals, reviews, and decision records |
 | [GitHub Discussions](https://github.com/higress-group/higress/discussions) | User questions, ideas, announcements, and longer-form community discussion |
+| [Higress Community Meeting](./MEETINGS.md) | Monthly public project updates, technical discussions, roadmap planning, and community questions; schedule and joining details are published on the [LFX public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/higress) |
 | [Discord](https://discord.gg/tSbww9VDaM) | Public real-time user and contributor chat; decisions arising there must be recorded on GitHub |
-| [Higress mailing list](mailto:higress@googlegroups.com) | Community questions and contributor contact by email |
 | [Chinese-language community group](./README_ZH.md#%E4%BA%A4%E6%B5%81%E7%BE%A4) | Publicly advertised Chinese-language user and contributor chat |
 | [Higress WeChat Official Account](./README_ZH.md#%E6%8A%80%E6%9C%AF%E5%88%86%E4%BA%AB) | Chinese-language technical articles and project announcements; broadcast rather than a decision channel |
 | [Higress website and documentation](https://higress.cn/en/) | Published user and contributor documentation and project announcements |
@@ -49,16 +49,12 @@ non-sensitive decision and rationale must be recorded publicly.
 
 ## Community meetings
 
-Higress does not currently run a recurring public community meeting and does
-not yet have a CNCF calendar entry. Establishing an up-to-date public meeting
-scheduler and/or CNCF calendar integration is tracked as an Incubation
-readiness item in
-[`docs/cncf/governance-review.md`](./docs/cncf/governance-review.md).
-
-When a recurring meeting is established, its schedule and joining information
-will be published here and on the CNCF calendar. Agendas, notes, recordings,
-and decisions will be public, with confidential security and Code of Conduct
-matters excluded.
+The [Higress Community Meeting](./MEETINGS.md) is held on the third Thursday of
+each month from 20:00 to 21:00 Asia/Shanghai (UTC+8). Its current schedule and
+public joining information are published on the
+[LFX public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/higress).
+The meeting document also defines the public agenda, notes, decisions, action
+items, recordings, and transcripts process.
 
 ## Contributor activity and recruitment
 

--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -1,0 +1,52 @@
+# Higress Community Meetings
+
+Higress community meetings are public and open to users, contributors, and
+anyone interested in the project. Meetings are used for project updates,
+technical discussions, roadmap planning, and community questions.
+
+## Schedule and joining
+
+| Item | Details |
+| --- | --- |
+| Meeting | Higress Community Meeting |
+| Schedule | Third Thursday of every month |
+| Time | 20:00–21:00 Asia/Shanghai (UTC+8) |
+| First meeting | 2026-08-20 |
+| Public calendar | [Higress meetings on the LFX platform](https://zoom-lfx.platform.linuxfoundation.org/meetings/higress) |
+| Join or register | [Higress Community Meeting page](https://zoom-lfx.platform.linuxfoundation.org/meeting/94551670181?password=6b1f20d7-7b52-4a32-86fe-5a32de2ee879) |
+
+The calendar is the authoritative source for individual meeting dates and any
+schedule changes. Select an occurrence on the calendar and use its meeting
+page to join. No project invitation is required, and participants may join up
+to 10 minutes before the scheduled start.
+
+## Agenda and participation
+
+Before each meeting, maintainers open a public GitHub issue named
+`[Community Meeting] YYYY-MM-DD` for the agenda and meeting record. Anyone may
+propose a topic by commenting on that issue. Agenda issues can be found in the
+[community meeting issue archive](https://github.com/higress-group/higress/issues?q=is%3Aissue+%22%5BCommunity+Meeting%5D%22).
+
+Each agenda issue records:
+
+- the meeting date, time, calendar entry, and joining link;
+- proposed topics, their proposers, and relevant issue or pull-request links;
+- discussion notes, decisions, and action items with owners; and
+- the recording and transcript links after they become available.
+
+Participants who cannot attend may comment on the agenda issue before or after
+the meeting. Significant technical or governance decisions are finalized and
+recorded in the relevant public issue or pull request so that meeting
+attendance is not required to participate in project decisions.
+
+## Recordings and notes
+
+The LFX meeting is configured for recording and transcription. After LFX has
+processed a meeting, the public recording and transcript are linked from the
+calendar event and its agenda issue. The agenda issue remains the durable
+index for notes, decisions, action items, and related project discussions.
+
+All participants must follow the project
+[Code of Conduct](./CODE_OF_CONDUCT.md). Confidential security reports and
+Code of Conduct incidents are not discussed in the public meeting; use the
+private channels documented in [`COMMUNITY.md`](./COMMUNITY.md) instead.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ Join our Discord community! This is where you can connect with developers and ot
 
 [![discord](https://img.shields.io/discord/1364956090566971515?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/tSbww9VDaM)
 
+Join the monthly [Higress Community Meeting](./MEETINGS.md) for public project
+updates, technical discussions, roadmap planning, and community questions.
+
 The complete inventory of public and private communication channels,
 subproject channels, meeting information, and contributor activity is in
 [`COMMUNITY.md`](./COMMUNITY.md).

--- a/docs/cncf/governance-review.md
+++ b/docs/cncf/governance-review.md
@@ -8,10 +8,11 @@ the public review.
 
 - **Review state:** Project self-assessment approved in
   [higress-group/higress#4177](https://github.com/higress-group/higress/pull/4177);
-  public-meeting Must-Fix and CNCF Project Reviews verification pending
+  no project-side Must-Fix items remain; CNCF Project Reviews verification
+  pending
 - **Evidence branch:**
   [`higress-group/higress@main`](https://github.com/higress-group/higress/tree/main)
-- **Template verified:** 2026-08-04 against `cncf/toc` `main`
+- **Template verified:** 2026-08-06 against `cncf/toc` `main`
 - **Intended TOC snapshot:**
   `projects/higress/governance-review/YYYY-MM-DD.md`
 
@@ -22,7 +23,7 @@ snapshot is archived.
 
 ## Summary and Assessment
 
-**Status: Mostly Satisfactory**
+**Status: Satisfactory**
 
 Higress has discoverable governance, maintainer, code-owner, contribution,
 community, security, and Code of Conduct documents. The project defines
@@ -31,16 +32,15 @@ scope, vendor-neutral decisions, maintainer lifecycle, communication channels,
 and security-response roles. The maintainer list includes seven publicly active
 people affiliated with four organizations.
 
-The documentation and public evidence satisfy all Governance Review criteria
-except one Incubation-required item: Higress does not currently publish an
-up-to-date public meeting scheduler or integrate its meetings with the CNCF
-calendar. The project should establish that real public meeting infrastructure
-before asserting that the Governance Review has no remaining Must-Fix item.
+The documentation and public evidence satisfy all Incubation-required
+Governance Review criteria. Higress publishes a recurring community meeting,
+public joining information, agenda and meeting-record process, and an LFX
+public meeting scheduler.
 
 ### Executing the Assessment
 
 The self-assessment reviewed the following repository evidence as it exists on
-2026-08-04:
+2026-08-06:
 
 - [`GOVERNANCE.md`](https://github.com/higress-group/higress/blob/main/GOVERNANCE.md)
 - [`MAINTAINERS.md`](https://github.com/higress-group/higress/blob/main/MAINTAINERS.md)
@@ -48,6 +48,7 @@ The self-assessment reviewed the following repository evidence as it exists on
 - [`CONTRIBUTING_EN.md`](https://github.com/higress-group/higress/blob/main/CONTRIBUTING_EN.md)
 - [`CODE_OF_CONDUCT.md`](https://github.com/higress-group/higress/blob/main/CODE_OF_CONDUCT.md)
 - [`COMMUNITY.md`](https://github.com/higress-group/higress/blob/main/COMMUNITY.md)
+- [`MEETINGS.md`](https://github.com/higress-group/higress/blob/main/MEETINGS.md)
 - [`SECURITY.md`](https://github.com/higress-group/higress/blob/main/SECURITY.md)
 - [`README.md`](https://github.com/higress-group/higress/blob/main/README.md)
 - Git history for the governance, maintainer, and ownership files
@@ -57,11 +58,8 @@ It does not infer private processes or settings that are not publicly recorded.
 
 ### Must-Fix Items
 
-The following issues need to be resolved before the Higress Incubation
-application asserts completion of its Governance Review:
-
-1. Publish an up-to-date public meeting scheduler and/or integrate the project
-   meetings with the CNCF calendar.
+No project-side Must-Fix items remain in this self-assessment. CNCF Project
+Reviews verification and the dated `cncf/toc` snapshot remain pending.
 
 ### Points of Excellence
 
@@ -131,8 +129,8 @@ security documents from its Community section.
 
 Public issue/PR collaboration and lazy consensus are consistent with the
 repository workflow. Code-owner authority, security-team operation, and the
-absence of a current recurring public meeting are documented without claiming
-unobserved processes.
+current recurring public meeting and record process are documented without
+claiming unobserved processes.
 
 **Vendor-neutral direction — Incubating: Suggested — Satisfied.**
 
@@ -251,16 +249,17 @@ GitHub Issues, pull requests, and Discord are publicly documented.
 **All public/private channels documented — Incubating: Required — Satisfied.**
 
 `COMMUNITY.md` is the authoritative inventory for project and subproject GitHub
-channels, Discord, mailing and localized community channels, documentation,
-and narrowly scoped private security and Code of Conduct reporting. It states
-that informal or employer-internal conversations are not project decision
-channels and requires public decision records.
+channels, Discord, localized community channels, public meetings,
+documentation, and narrowly scoped private security and Code of Conduct
+reporting. It states that informal or employer-internal conversations are not
+project decision channels and requires public decision records.
 
-**Public meeting scheduler/CNCF calendar — Incubating: Required — Not
-satisfied.**
+**Public meeting scheduler/CNCF calendar — Incubating: Required — Satisfied.**
 
-No current public meeting scheduler or CNCF calendar integration is linked from
-the reviewed repository documents.
+`COMMUNITY.md` and `MEETINGS.md` publish the monthly schedule, public joining
+information, agenda and meeting-record process, and the
+[LFX public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/higress).
+The recurring series starts on 2026-08-20 and is open without an invitation.
 
 **Contribution documentation — Incubating: Required — Satisfied.**
 

--- a/docs/cncf/incubation-application.md
+++ b/docs/cncf/incubation-application.md
@@ -2,7 +2,7 @@
 
 This working draft follows the CNCF TOC
 [Project Incubation Application v1.6](https://github.com/cncf/toc/blob/main/.github/ISSUE_TEMPLATE/template-incubation-application.md),
-verified on 2026-08-04. It is not ready to file while any item labelled
+verified on 2026-08-06. It is not ready to file while any item labelled
 **BLOCKED** below remains unresolved.
 
 ## Review Project Moving Level Evaluation
@@ -11,8 +11,8 @@ verified on 2026-08-04. It is not ready to file while any item labelled
   criteria are met before opening the issue, and understand that unmet criteria
   will result in closure.
 
-This box remains unchecked because the public meeting, access-control evidence,
-adopter interviews/verification, and remaining vendor-neutral resource work are
+This box remains unchecked because access-control evidence, adopter
+interviews/verification, and remaining vendor-neutral resource work are
 incomplete.
 
 ## Project information
@@ -30,10 +30,11 @@ incomplete.
 - **Related projects:** confirm before submission whether any project point of
   contact operates a technically related project in another foundation
 - **Communication:**
-  [`COMMUNITY.md`](https://github.com/higress-group/higress/blob/main/COMMUNITY.md)
+  [`COMMUNITY.md`](https://github.com/higress-group/higress/blob/main/COMMUNITY.md),
+  including the public meeting process in
+  [`MEETINGS.md`](https://github.com/higress-group/higress/blob/main/MEETINGS.md)
 - **Project points of contact:** Yuanxiao Zhao and Yiquan Dong; **TODO:** confirm
-  direct contact emails before filing (public community contact:
-  [higress@googlegroups.com](mailto:higress@googlegroups.com))
+  direct contact emails before filing
 
 ## Incubation Criteria Summary
 
@@ -73,7 +74,8 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
   Reviews verification and the required dated TOC snapshot remain pending.
 - [ ] Complete a Governance Review. The self-assessment is in
   [`governance-review.md`](https://github.com/higress-group/higress/blob/main/docs/cncf/governance-review.md),
-  but its public-meeting Must-Fix remains open.
+  has no project-side Must-Fix items, and awaits CNCF Project Reviews
+  verification and a dated `cncf/toc` snapshot.
 - [ ] **BLOCKED — All project metadata and resources are vendor-neutral.**
   Governance and the primary README now document vendor-neutral direction and
   no longer promote a single commercial product, but release images remain
@@ -99,9 +101,8 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
 - [ ] Complete the Governance Review with the CNCF Project Reviews subproject;
   external verification is pending.
 - [x] Governance is discoverable and version controlled.
-- [x] Governance documents actual public decision, leadership, role, and
-  security-team processes without claiming a recurring meeting that does not
-  exist.
+- [x] Governance documents actual public decision, leadership, role,
+  security-team, and recurring public meeting processes.
 - [x] Governance documents vendor-neutral project direction and conflicts.
 - [x] Leadership, contribution, CNCF request, governance, goal, and subproject
   decisions use a public process.
@@ -139,10 +140,11 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
 - [x] Public GitHub and Discord communication channels are documented.
 - [x] All official project, subproject, and narrowly scoped non-public channels
   are inventoried in `COMMUNITY.md`.
-- [ ] **BLOCKED — Public meeting scheduler/CNCF calendar.** Higress does not
-  currently publish an up-to-date public meeting scheduler or integrate its
-  meetings with the CNCF calendar. A real schedule or calendar integration must
-  be established rather than represented by documentation alone.
+- [x] The monthly Higress Community Meeting has a public schedule, joining
+  information, agenda and meeting-record process in
+  [`MEETINGS.md`](https://github.com/higress-group/higress/blob/main/MEETINGS.md),
+  and a recurring entry on the
+  [LFX public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/higress).
 - [x] Contribution documentation is maintained.
 - [x] Contributor activity and recruitment are demonstrated through GitHub,
   DevStats, contribution labels, and maintainer activity links.
@@ -218,11 +220,10 @@ include Ant Digital, Kuaishou, Trip.com, Vipshop, and Labring.
 **Do not file yet.** The top-level readiness attestation would be false while
 the following required items remain open:
 
-1. a real public meeting scheduler and/or CNCF calendar integration;
-2. enforced repository access-control evidence;
-3. vendor-neutral resource/website remediation or an accepted migration plan;
-4. 5–7 adopter interview submissions and later TOC verification; and
-5. direct project point-of-contact emails confirmed for the issue.
+1. enforced repository access-control evidence;
+2. vendor-neutral resource/website remediation or an accepted migration plan;
+3. 5–7 adopter interview submissions and later TOC verification; and
+4. direct project point-of-contact emails confirmed for the issue.
 
 OpenSSF Best Practices is no longer a filing blocker. Before final filing, the
 project should also open the CNCF Project Reviews requests and coordinate the

--- a/docs/cncf/security-self-assessment.md
+++ b/docs/cncf/security-self-assessment.md
@@ -190,10 +190,10 @@ count, signed-commit requirement, organization-wide 2FA, or branch-protection
 configuration; those controls require separate repository-settings evidence.
 
 Ordinary project-team communication uses GitHub issues, pull requests,
-discussions, mailing, localized community channels, and Discord. Inbound users
-use the same public channels. Every vulnerability report must be submitted to
-both GitHub Private Security Advisories and the Alibaba Security Response
-Center, as documented in `SECURITY.md`. The Security Response Team correlates
+discussions, localized community channels, and Discord. Inbound users use the
+same public channels. Every vulnerability report must be submitted to both
+GitHub Private Security Advisories and the Alibaba Security Response Center,
+as documented in `SECURITY.md`. The Security Response Team correlates
 the two private records.
 Releases, the project website, and the WeChat Official Account are outbound
 channels. [`COMMUNITY.md`](https://github.com/higress-group/higress/blob/main/COMMUNITY.md)


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

- add a discoverable `MEETINGS.md` with the recurring schedule, public LFX calendar and joining information
- document how community members propose agenda topics and how notes, decisions, action items, recordings, and transcripts are retained
- link the meeting from the README and authoritative community channel inventory
- remove the inactive Higress Google Group from the documented public channels
- update the Governance Review and Incubation working draft to mark the public meeting scheduler requirement as satisfied
- remove the obsolete mailing-list reference from the Security Self-Assessment

## Ⅱ. Does this pull request fix one issue?

N/A.

## Ⅲ. Why don't you add test cases (unit test/integration test)?

This PR only changes Markdown documentation and project review evidence.

## Ⅳ. Describe how to verify it

- `git diff --check`
- confirm the LFX public calendar and meeting page return HTTP 200
- review the repository for obsolete statements that Higress has no recurring public meeting
- verify all new relative Markdown links resolve to repository files

## Ⅴ. Special notes for reviews

The recurring meeting starts on 2026-08-20 and is scheduled for the third Thursday of every month, 20:00–21:00 Asia/Shanghai. CNCF Project Reviews verification and the dated TOC snapshots remain pending; this PR only closes the project-side public-meeting Must-Fix.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Document the newly established public Higress community meeting in the repository, update the CNCF Incubation and Governance Review status consistently, remove obsolete channel information, validate the links, and submit the changes as a focused pull request.

### AI Coding Summary

- Added one canonical meeting document and linked it from existing community entry points.
- Kept the public calendar as the authoritative schedule and GitHub issues as the durable agenda and meeting-record index.
- Updated only the CNCF statements affected by the meeting and inactive mailing list.
- Preserved external CNCF review and remaining Incubation blockers rather than marking the overall application complete.
