### PR TITLE
fix: correct cache token propagation between Claude and OpenAI formats

### DIFF
--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude.go
@@ -267,7 +267,7 @@ type claudeTextGenContent struct {
 type claudeTextGenUsage struct {
 	InputTokens              int    `json:"input_tokens,omitempty"`
 	OutputTokens             int    `json:"output_tokens,omitempty"`
-	CacheReadInputTokens     int    `json:"cache_read_input_tokens,omitempty"`
+	CacheReadInputTokens     int    `json:"cache_read_input_tokens"`
 	CacheCreationInputTokens int    `json:"cache_creation_input_tokens,omitempty"`
 	ServiceTier              string `json:"service_tier,omitempty"`
 }
@@ -826,10 +826,12 @@ func (c *claudeProvider) responseClaude2OpenAI(ctx wrapper.HttpContext, origResp
 
 	// Include usage information if available
 	if origResponse.Usage.InputTokens > 0 || origResponse.Usage.OutputTokens > 0 {
+		totalPromptTokens := origResponse.Usage.InputTokens + origResponse.Usage.CacheReadInputTokens + origResponse.Usage.CacheCreationInputTokens
 		response.Usage = &usage{
-			PromptTokens:     origResponse.Usage.InputTokens,
+			PromptTokens:     totalPromptTokens,
 			CompletionTokens: origResponse.Usage.OutputTokens,
-			TotalTokens:      origResponse.Usage.InputTokens + origResponse.Usage.OutputTokens,
+			TotalTokens:      totalPromptTokens + origResponse.Usage.OutputTokens,
+			PromptTokensDetails: &promptTokensDetails{CachedTokens: origResponse.Usage.CacheReadInputTokens},
 		}
 	}
 
@@ -860,8 +862,9 @@ func (c *claudeProvider) streamResponseClaude2OpenAI(ctx wrapper.HttpContext, or
 		if origResponse.Message != nil {
 			c.messageId = origResponse.Message.Id
 			c.usage = usage{
-				PromptTokens:     origResponse.Message.Usage.InputTokens,
+				PromptTokens:     origResponse.Message.Usage.InputTokens + origResponse.Message.Usage.CacheReadInputTokens + origResponse.Message.Usage.CacheCreationInputTokens,
 				CompletionTokens: origResponse.Message.Usage.OutputTokens,
+				PromptTokensDetails: &promptTokensDetails{CachedTokens: origResponse.Message.Usage.CacheReadInputTokens},
 			}
 			c.serviceTier = origResponse.Message.Usage.ServiceTier
 		}
@@ -999,9 +1002,10 @@ func (c *claudeProvider) streamResponseClaude2OpenAI(ctx wrapper.HttpContext, or
 			Choices:     []chatCompletionChoice{},
 			ServiceTier: c.serviceTier,
 			Usage: &usage{
-				PromptTokens:     c.usage.PromptTokens,
-				CompletionTokens: c.usage.CompletionTokens,
-				TotalTokens:      c.usage.TotalTokens,
+				PromptTokens:        c.usage.PromptTokens,
+				CompletionTokens:    c.usage.CompletionTokens,
+				TotalTokens:         c.usage.TotalTokens,
+				PromptTokensDetails: c.usage.PromptTokensDetails,
 			},
 		}
 	case "content_block_stop":

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai.go
@@ -353,24 +353,32 @@ func (c *ClaudeToOpenAIConverter) ConvertClaudeRequestToOpenAIWithOptions(body [
 	return result, nil
 }
 
-// computeClaudeInputTokens computes Claude-compatible input_tokens from OpenAI usage.
+// computeClaudeInputTokensAndCachedTokens computes Claude-compatible input_tokens and cache tokens from OpenAI usage.
 //
 // In OpenAI's API, prompt_tokens includes cached_tokens (subset relationship).
 // In Claude's API, input_tokens should NOT include cache tokens.
 // We detect the OpenAI-standard semantics by checking if total_tokens == prompt_tokens + completion_tokens.
 // For providers like Bedrock where prompt_tokens does NOT include cache tokens
 // (total_tokens != prompt_tokens + completion_tokens), we return prompt_tokens as-is.
-func computeClaudeInputTokens(u *usage) int {
+func computeClaudeInputTokensAndCachedTokens(u *usage) (int, int) {
 	if u == nil {
-		return 0
+		return 0, 0
 	}
-	promptTokens := u.PromptTokens
+
+	cachedTokens := 0
 	if u.PromptTokensDetails != nil && u.PromptTokensDetails.CachedTokens > 0 {
-		if u.TotalTokens > 0 && u.TotalTokens == promptTokens+u.CompletionTokens {
-			return promptTokens - u.PromptTokensDetails.CachedTokens
+		cachedTokens = u.PromptTokensDetails.CachedTokens
+	}
+
+	inputTokens := u.PromptTokens
+	if cachedTokens > 0 && u.TotalTokens > 0 && u.TotalTokens == inputTokens+u.CompletionTokens {
+		inputTokens -= cachedTokens
+		if inputTokens < 0 {
+			inputTokens = 0
 		}
 	}
-	return promptTokens
+
+	return inputTokens, cachedTokens
 }
 
 // ConvertOpenAIResponseToClaude converts an OpenAI response back to Claude format
@@ -392,12 +400,11 @@ func (c *ClaudeToOpenAIConverter) ConvertOpenAIResponseToClaude(ctx wrapper.Http
 
 	// Only include usage if it's available
 	if openaiResponse.Usage != nil {
+		inputTokens, cachedTokens := computeClaudeInputTokensAndCachedTokens(openaiResponse.Usage)
 		claudeResponse.Usage = claudeTextGenUsage{
-			InputTokens:  computeClaudeInputTokens(openaiResponse.Usage),
-			OutputTokens: openaiResponse.Usage.CompletionTokens,
-		}
-		if openaiResponse.Usage.PromptTokensDetails != nil {
-			claudeResponse.Usage.CacheReadInputTokens = openaiResponse.Usage.PromptTokensDetails.CachedTokens
+			InputTokens:          inputTokens,
+			OutputTokens:         openaiResponse.Usage.CompletionTokens,
+			CacheReadInputTokens: cachedTokens,
 		}
 	}
 
@@ -601,8 +608,9 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 
 		// Only include usage if it's available
 		if openaiResponse.Usage != nil {
+			inputTokens, _ := computeClaudeInputTokensAndCachedTokens(openaiResponse.Usage)
 			message.Usage = claudeTextGenUsage{
-				InputTokens:  computeClaudeInputTokens(openaiResponse.Usage),
+				InputTokens:  inputTokens,
 				OutputTokens: 0,
 			}
 		}
@@ -847,8 +855,9 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 				Content: []claudeTextGenContent{},
 			}
 			if openaiResponse.Usage != nil {
+				inputTokens, _ := computeClaudeInputTokensAndCachedTokens(openaiResponse.Usage)
 				message.Usage = claudeTextGenUsage{
-					InputTokens:  computeClaudeInputTokens(openaiResponse.Usage),
+					InputTokens:  inputTokens,
 					OutputTokens: 0,
 				}
 			}
@@ -1004,12 +1013,11 @@ func (c *ClaudeToOpenAIConverter) buildClaudeStreamResponse(ctx wrapper.HttpCont
 		log.Debugf("[OpenAI->Claude] Processing usage info - input: %d, output: %d",
 			openaiResponse.Usage.PromptTokens, openaiResponse.Usage.CompletionTokens)
 
+		inputTokens, cachedTokens := computeClaudeInputTokensAndCachedTokens(openaiResponse.Usage)
 		usage := &claudeTextGenUsage{
-			InputTokens:  computeClaudeInputTokens(openaiResponse.Usage),
-			OutputTokens: openaiResponse.Usage.CompletionTokens,
-		}
-		if openaiResponse.Usage.PromptTokensDetails != nil {
-			usage.CacheReadInputTokens = openaiResponse.Usage.PromptTokensDetails.CachedTokens
+			InputTokens:          inputTokens,
+			OutputTokens:         openaiResponse.Usage.CompletionTokens,
+			CacheReadInputTokens: cachedTokens,
 		}
 
 		// Send message_delta with both stop_reason and usage (Claude protocol requirement)

--- a/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/claude_to_openai_test.go
@@ -1409,6 +1409,61 @@ func TestClaudeToOpenAIConverter_ConvertReasoningResponseToClaude(t *testing.T) 
 	}
 }
 
+func TestcomputeClaudeInputTokensAndCachedTokens(t *testing.T) {
+	tests := []struct {
+		name          string
+		usage         *usage
+		expectedInput int
+		expectedCache int
+	}{
+		{
+			name:          "nil usage",
+			expectedInput: 0,
+			expectedCache: 0,
+		},
+		{
+			name: "without cached tokens",
+			usage: &usage{
+				PromptTokens:     100,
+				CompletionTokens: 20,
+				TotalTokens:      120,
+			},
+			expectedInput: 100,
+			expectedCache: 0,
+		},
+		{
+			name: "openai usage with cached tokens",
+			usage: &usage{
+				PromptTokens:        100,
+				CompletionTokens:    20,
+				TotalTokens:         120,
+				PromptTokensDetails: &promptTokensDetails{CachedTokens: 60},
+			},
+			expectedInput: 40,
+			expectedCache: 60,
+		},
+		{
+			name: "provider usage with cached tokens not included in prompt",
+			usage: &usage{
+				PromptTokens:        100,
+				CompletionTokens:    20,
+				TotalTokens:         100,
+				PromptTokensDetails: &promptTokensDetails{CachedTokens: 60},
+			},
+			expectedInput: 100,
+			expectedCache: 60,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputTokens, cachedTokens := computeClaudeInputTokensAndCachedTokens(tt.usage)
+			assert.Equal(t, tt.expectedInput, inputTokens)
+			assert.Equal(t, tt.expectedCache, cachedTokens)
+		})
+	}
+}
+
 func TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_WithCachedTokens(t *testing.T) {
 	converter := &ClaudeToOpenAIConverter{}
 
@@ -1432,7 +1487,7 @@ func TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_BedrockStyl
 
 	// Bedrock-style usage: prompt_tokens does NOT include cached_tokens.
 	// total_tokens (180) != prompt_tokens (100) + completion_tokens (20),
-	// so computeClaudeInputTokens should NOT subtract cached_tokens.
+	// so computeClaudeInputTokensAndCachedTokens should NOT subtract cached_tokens.
 	streamChunk := "data: {\"id\":\"chatcmpl-test\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
 		"data: {\"id\":\"chatcmpl-test\",\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":20,\"total_tokens\":180,\"prompt_tokens_details\":{\"cached_tokens\":60}}}\n\n"
 

--- a/plugins/wasm-go/extensions/ai-proxy/provider/model.go
+++ b/plugins/wasm-go/extensions/ai-proxy/provider/model.go
@@ -194,7 +194,7 @@ type usage struct {
 
 type promptTokensDetails struct {
 	AudioTokens  int `json:"audio_tokens,omitempty"`
-	CachedTokens int `json:"cached_tokens,omitempty"`
+	CachedTokens int `json:"cached_tokens"`
 }
 
 type completionTokensDetails struct {


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contributing guidelines -->

## Ⅰ. Describe what this PR did
Fix cache token propagation between Claude and OpenAI formats in the ai-proxy plugin. The two protocols have different semantics for token counting:

Claude → OpenAI: In Claude's API, input_tokens excludes cache hits (cache_read_input_tokens, cache_creation_input_tokens), but OpenAI's prompt_tokens is expected to include them. Now PromptTokens = InputTokens + CacheReadInputTokens + CacheCreationInputTokens, and CachedTokens is populated in PromptTokensDetails.

OpenAI → Claude: In OpenAI's API, prompt_tokens already includes cached_tokens, but Claude's input_tokens should exclude them. Added computeClaudeInputTokensAndCachedTokens to detect OpenAI-standard vs Bedrock-style usage semantics and subtract cached_tokens accordingly, with negative protection.

Removed omitempty from CacheReadInputTokens and CachedTokens so zero values are always explicit.

## Ⅱ. Does this pull request fix one issue?
fixes #4272


## Ⅲ. Why don't you add test cases (unit test/integration test)? 
Tests are included. Added TestcomputeClaudeInputTokensAndCachedTokens with 4 sub-tests (nil usage, without cached tokens, OpenAI-standard semantics, Bedrock-style semantics). Existing test TestClaudeToOpenAIConverter_ConvertOpenAIStreamResponseToClaude_WithCachedTokens validates the streaming path.


## Ⅳ. Describe how to verify it
Send a chat completion request through ai-proxy with a Claude backend that has prompt caching enabled.
Check the OpenAI-format response: usage.prompt_tokens should equal input_tokens + cache_read_input_tokens + cache_creation_input_tokens from the Claude upstream.
Check usage.prompt_tokens_details.cached_tokens is present and non-null.
For the reverse direction (OpenAI→Claude), check that input_tokens excludes cached_tokens when the OpenAI provider uses standard semantics (total_tokens == prompt_tokens + completion_tokens).

## Ⅴ. Special notes for reviews
The computeClaudeInputTokensAndCachedTokens function uses total_tokens == prompt_tokens + completion_tokens as a heuristic to detect whether the upstream provider includes cached tokens in prompt_tokens (OpenAI standard) or not (Bedrock style). This is necessary because the same field has different meanings across providers.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)
<!-- 
**IMPORTANT**: If you used AI Coding tools (e.g., Cursor, GitHub Copilot, etc.) to generate this PR, please check the following items.
PRs that don't meet these requirements will have **LOWER REVIEW PRIORITY** and we **CANNOT GUARANTEE** timely reviews.

If you did NOT use AI Coding tools, you can skip this section entirely.
-->

**Please check all applicable items:**

- [ ] **For new standalone features** (e.g., new wasm plugin or golang-filter plugin):
  - [ ] I have created a `design/` directory in the plugin folder
  - [ ] I have added the design document to the `design/` directory
  - [ ] I have included the AI Coding summary below

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)
Fix the Claude ↔ OpenAI cache token propagation in the ai-proxy plugin provider layer.

Claude→OpenAI direction (claude.go):
- In both non-streaming (responseClaude2OpenAI) and streaming (streamResponseClaude2OpenAI)
  paths, PromptTokens should be InputTokens + CacheReadInputTokens + CacheCreationInputTokens,
  not just InputTokens.
- Populate PromptTokensDetails.CachedTokens with CacheReadInputTokens from the Claude response.
- The message_stop event in streaming must also carry PromptTokensDetails.
- Remove omitempty from CacheReadInputTokens in claudeTextGenUsage so zero is always explicit.

OpenAI→Claude direction (claude_to_openai.go):
- Replace the existing computeClaudeInputTokens helper with a function that returns both
  inputTokens and cachedTokens, named computeClaudeInputTokensAndCachedTokens.
- The function must detect whether the upstream uses OpenAI-standard semantics
  (prompt_tokens already includes cached_tokens, signaled by total_tokens ==
  prompt_tokens + completion_tokens) or Bedrock-style semantics (prompt_tokens excludes
  cache, signaled by total_tokens != prompt_tokens + completion_tokens).
- If OpenAI-standard, subtract cached_tokens from prompt_tokens with a floor of 0.
- If Bedrock-style, return prompt_tokens as-is.
- Update all 4 call sites: ConvertOpenAIResponseToClaude, and the 3 usage points in
  buildClaudeStreamResponse (two message_start and one message_delta).

model.go:
- Remove omitempty from CachedTokens in promptTokensDetails.

Test file (claude_to_openai_test.go):
- Add a table-driven TestcomputeClaudeInputTokensAndCachedTokens covering nil usage,
  no cached tokens, OpenAI-standard semantics (subtraction), and Bedrock-style
  semantics (no subtraction).
- Update the existing comment in the Bedrock test to reference the new function name.


### AI Coding Summary
- Key decision: Used total_tokens == prompt_tokens + completion_tokens as a heuristic to distinguish OpenAI-standard from Bedrock-style usage semantics. This avoids requiring provider-specific configuration while handling both cases correctly.
- Major changes: 4 files modified, +95 −28 lines total.
 - claude.go: 3 locations updated — non-streaming response, streaming message_start, streaming message_stop. Each adds CacheReadInputTokens + CacheCreationInputTokens to the PromptTokens total and propagates CachedTokens in PromptTokensDetails.
 - claude_to_openai.go: Renamed computeClaudeInputTokens to computeClaudeInputTokensAndCachedTokens, now returning (int, int) with negative protection and semantic detection. Updated all 4 call sites.
 - model.go: Removed omitempty from CachedTokens.
 - claude_to_openai_test.go: Added 4-case unit test for the extracted function; updated comment reference.
- Limitations: The semantic detection heuristic (total_tokens == prompt_tokens + completion_tokens) assumes the upstream either strictly follows OpenAI semantics or Bedrock semantics. A provider that mixes conventions may produce incorrect results. This can be addressed in a future change by adding a provider-level configuration flag.



