### PR TITLE
fix: remove unused insecure TLS transport

### DIFF
--- a/hgctl/pkg/util/http_fetcher.go
+++ b/hgctl/pkg/util/http_fetcher.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,10 +39,6 @@ func NewHTTPFetcher(requestTimeout time.Duration, requestMaxRetry int, bufferSiz
 	if requestTimeout == 0 {
 		requestTimeout = 5 * time.Second
 	}
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	// nolint: gosec
-	// This is only when a user explicitly sets a flag to enable insecure mode
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	return &HTTPFetcher{
 		client: &http.Client{
 			Timeout: requestTimeout,


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Remove an unused cloned HTTP transport that sets `InsecureSkipVerify: true` in the hgctl HTTP fetcher. The transport was never assigned to the returned `http.Client`, so deleting it preserves the existing runtime behavior: downloads continue to use the default transport with normal TLS certificate verification.

This directly removes the source of [CodeQL alert #45](https://github.com/higress-group/higress/security/code-scanning/45).

## Ⅱ. Does this pull request fix one issue?

No GitHub issue. It addresses CodeQL High alert #45 (`go/disabled-certificate-check`).

## Ⅲ. Why do not you add test cases (unit test/integration test)?

The removed transport was local dead code and was never connected to the HTTP client. There is no behavior change or new branch to cover. The existing package test/build check is sufficient for this deletion.

## Ⅳ. Describe how to verify it

- `gofmt -w pkg/util/http_fetcher.go`
- `go test ./pkg/util` from the `hgctl` module using Go 1.24.5
- `git diff --check`
- After merge, the main-branch CodeQL scan should close alert #45 automatically.

## Ⅴ. Special notes for reviews

Please note that assigning the removed transport to `http.Client.Transport` would change behavior and actually disable certificate verification. This PR intentionally deletes it instead; the client continues to use `http.DefaultTransport` securely.

## Ⅵ. AI Coding Tool Usage Checklist (if applicable)

- [x] **For regular updates/changes** (not new plugins):
  - [x] I have provided the prompts/instructions I gave to the AI Coding tool below
  - [x] I have included the AI Coding summary below

### AI Coding Prompts (for regular updates)

Investigate why CodeQL alert #45 reappeared, assess compatibility risk, and create a minimal PR deleting the unused insecure TLS transport.

### AI Coding Summary

- Confirmed #4257 restored complete CodeQL extraction of the separately shipped hgctl binary, causing the historical alert to reappear.
- Verified the cloned transport was never assigned to the HTTP client and had no runtime effect.
- Removed only the unused TLS import and transport setup.
- Kept the current default TLS certificate verification behavior unchanged.